### PR TITLE
fix: key deletion — invalidate monitor preference cache and check delete result

### DIFF
--- a/AIUsageTracker.Monitor/Services/ConfigService.cs
+++ b/AIUsageTracker.Monitor/Services/ConfigService.cs
@@ -128,6 +128,7 @@ public class ConfigService : IConfigService
             configs.RemoveAll(c => c.ProviderId.Equals(providerId, StringComparison.OrdinalIgnoreCase));
             await this._configLoader.SaveConfigAsync(configs).ConfigureAwait(false);
             Volatile.Write(ref this._cachedConfigs, null);
+            Volatile.Write(ref this._cachedPreferences, null); // force ScanForKeysAsync to reload suppressed list from disk
             this._logger.LogInformation("Removed: {ProviderId}", providerId);
         }
         catch (Exception ex)

--- a/AIUsageTracker.UI.Slim/SettingsWindow.xaml.cs
+++ b/AIUsageTracker.UI.Slim/SettingsWindow.xaml.cs
@@ -839,6 +839,13 @@ public partial class SettingsWindow : Window
 
                 if (behavior.InputMode == ProviderInputMode.StandardApiKey && string.IsNullOrWhiteSpace(config.ApiKey))
                 {
+                    var removed = await this._monitorService.RemoveConfigAsync(config.ProviderId).ConfigureAwait(true);
+                    if (!removed)
+                    {
+                        failedConfigs.Add(config.ProviderId);
+                        continue;
+                    }
+
                     // Suppress re-discovery so the scanner won't re-add the key
                     // from external sources (Roo Code, Kilo Code, env vars).
                     if (!this._preferences.SuppressedProviderIds.Contains(config.ProviderId, StringComparer.OrdinalIgnoreCase))
@@ -846,7 +853,6 @@ public partial class SettingsWindow : Window
                         this._preferences.SuppressedProviderIds.Add(config.ProviderId);
                     }
 
-                    await this._monitorService.RemoveConfigAsync(config.ProviderId).ConfigureAwait(true);
                     removedProviderIds.Add(config.ProviderId);
                     continue;
                 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+## [2.3.4-beta.29] - 2026-04-09
+
+### Fixed
+- **Deleted API key no longer reappears after restart**: `SuppressedProviderIds` is now persisted to disk after key deletion. Previously the suppression was written to memory after the preferences file was saved, so removed keys (e.g. Synthetic) would reappear on next startup if originally discovered from an environment variable or Roo/Kilo Code config file.
+- **CLI `set-key` accepts key via stdin**: running `act set-key <provider-id>` without a key argument now prompts securely via stdin instead of requiring the key as a command-line argument (which is visible in process listings and logs). The 3-argument form (`act set-key <provider-id> <key>`) is preserved for scripting.
+- **CORS restricted to required methods and headers**: Monitor's CORS policy now uses `WithMethods("GET", "POST", "DELETE")` and `WithHeaders("Content-Type", "Authorization", "X-Requested-With")` instead of `AllowAnyMethod`/`AllowAnyHeader`.
+- **ConfigService rejects unknown provider IDs**: `SaveConfigAsync` now validates the provider ID against `ProviderMetadataCatalog` and throws `ArgumentException` for unknown IDs, preventing orphan config entries.
+
+### Changed
+- **Fire-and-forget exceptions logged**: unhandled exceptions from `CheckForUpdatesAsync` are now captured via `ContinueWith(OnlyOnFaulted)` and logged via `ILogger`, instead of being silently swallowed.
+
+### Performance
+- **Redundant polling fetch removed**: the 1-second delay + second `GetUsageForDisplayAsync` call in the UI polling tick has been removed. The next normal poll cycle handles the follow-up, eliminating unnecessary latency.
+
 ## [2.3.4-beta.28] - 2026-04-06
 
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TrackerVersion>2.3.4-beta.28</TrackerVersion>
+    <TrackerVersion>2.3.4-beta.29</TrackerVersion>
     <TrackerAssemblyVersion>2.3.4</TrackerAssemblyVersion>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(MSBuildProjectDirectory)\artifacts\**\*</DefaultItemExcludes>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="AIUsageTracker.Web/wwwroot/favicon.png" width="32" height="32" valign="middle"> AI Usage Tracker
 
-![Version](https://img.shields.io/badge/version-2.3.4--beta.28--beta.27--beta.26--beta.21-orange)
+![Version](https://img.shields.io/badge/version-2.3.4--beta.29--beta.28--beta.27--beta.26-orange)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Platforms](https://img.shields.io/badge/platforms-Windows%20|%20Linux%20-blue)
 ![Language](https://img.shields.io/badge/language-C%23%20|%20.NET-purple)

--- a/scripts/publish-app.ps1
+++ b/scripts/publish-app.ps1
@@ -6,7 +6,7 @@ param(
 )
 
 # AI Usage Tracker - Distribution Packaging Script
-# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.3.4-beta.28 -InstallerCompression balanced
+# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.3.4-beta.29 -InstallerCompression balanced
 
 $isWinPlatform = $Runtime.StartsWith("win-")
 $projectName = if ($isWinPlatform) { "AIUsageTracker" } else { "AIUsageTracker.CLI" }

--- a/scripts/setup.iss
+++ b/scripts/setup.iss
@@ -1,7 +1,7 @@
 ; AI Usage Tracker - Inno Setup Script
 
 #ifndef MyAppVersion
-  #define MyAppVersion "2.3.4-beta.28"
+  #define MyAppVersion "2.3.4-beta.29"
 #endif
 #ifndef SourcePath
   #define SourcePath "..\dist\publish-win-x64"


### PR DESCRIPTION
## Summary

Two bugs in the provider key deletion flow that caused deleted keys to reappear:

- **Monitor preferences cache not cleared on deletion**: `ConfigService.RemoveConfigAsync` invalidated `_cachedConfigs` but not `_cachedPreferences`. If the user clicked "Scan for Keys" after deleting a provider, `ScanForKeysAsync` read the stale cache, missed the new `SuppressedProviderIds` entry, and re-discovered the key.
- **Suppression added even when deletion failed**: `MonitorService.RemoveConfigAsync` returns `bool` but the result was discarded. If the monitor was unreachable, the UI still suppressed the provider and hid the card — even though the key was never deleted from `auth.json`. Now fails visibly via the error dialog instead.

## Test plan
- [ ] All existing tests pass
- [ ] Clear synthetic key → click Scan for Keys → synthetic does NOT reappear
- [ ] Clear synthetic key while monitor is offline → error dialog shown, card stays visible