### PR TITLE
fix: preference reset, MiniMax key visibility, and filter layer elimination

### DIFF
--- a/AIUsageTracker.Core/Models/AuthSource.cs
+++ b/AIUsageTracker.Core/Models/AuthSource.cs
@@ -51,4 +51,62 @@ public static class AuthSource
         return value.Contains(RooPrefix, StringComparison.OrdinalIgnoreCase) ||
                value.Contains(KiloPrefix, StringComparison.OrdinalIgnoreCase);
     }
+
+    public static bool IsConfig(string? value)
+    {
+        return !string.IsNullOrWhiteSpace(value) &&
+               value.StartsWith($"{ConfigPrefix}:", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>Extracts the variable name from "Env: VARIABLE_NAME".</summary>
+    public static bool TryParseEnvironmentVariable(string? authSource, out string varName)
+    {
+        var prefix = $"{EnvironmentPrefix}: ";
+        if (!string.IsNullOrWhiteSpace(authSource) &&
+            authSource.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+        {
+            varName = authSource.Substring(prefix.Length).Trim();
+            return true;
+        }
+
+        varName = string.Empty;
+        return false;
+    }
+
+    /// <summary>
+    /// Extracts all file paths from a "Config: path1, path2" auth source string.
+    /// A config entry may list multiple comma-separated paths when keys were merged
+    /// from several files.
+    /// </summary>
+    public static IReadOnlyList<string> ParseConfigFilePaths(string? authSource)
+    {
+        if (string.IsNullOrWhiteSpace(authSource))
+        {
+            return Array.Empty<string>();
+        }
+
+        var prefix = $"{ConfigPrefix}: ";
+        if (!authSource.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return Array.Empty<string>();
+        }
+
+        var rest = authSource.Substring(prefix.Length);
+        return rest.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    }
+
+    /// <summary>Extracts the file path from "Roo Code: /path/to/file".</summary>
+    public static bool TryParseRooPath(string? authSource, out string filePath)
+    {
+        var prefix = $"{RooPrefix}: ";
+        if (!string.IsNullOrWhiteSpace(authSource) &&
+            authSource.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+        {
+            filePath = authSource.Substring(prefix.Length).Trim();
+            return true;
+        }
+
+        filePath = string.Empty;
+        return false;
+    }
 }

--- a/AIUsageTracker.Core/Models/ProviderConfig.cs
+++ b/AIUsageTracker.Core/Models/ProviderConfig.cs
@@ -36,7 +36,7 @@ public class ProviderConfig
     [JsonPropertyName("enabled_sub_trays")]
     public IReadOnlyList<string> EnabledSubTrays { get; set; } = [];
 
-    [JsonIgnore]
+    [JsonPropertyName("auth_source")]
     [StringLength(100)]
     public string AuthSource { get; set; } = string.Empty;
 

--- a/AIUsageTracker.Core/MonitorClient/AgentGroupedProviderUsage.cs
+++ b/AIUsageTracker.Core/MonitorClient/AgentGroupedProviderUsage.cs
@@ -21,6 +21,8 @@ public sealed class AgentGroupedProviderUsage
 
     public bool IsAvailable { get; set; }
 
+    public ProviderUsageState State { get; set; } = ProviderUsageState.Available;
+
     public PlanType PlanType { get; set; } = PlanType.Usage;
 
     public bool IsQuotaBased { get; set; }

--- a/AIUsageTracker.Infrastructure/Configuration/JsonConfigLoader.cs
+++ b/AIUsageTracker.Infrastructure/Configuration/JsonConfigLoader.cs
@@ -323,11 +323,11 @@ public class JsonConfigLoader : IConfigLoader
     {
         if (string.IsNullOrEmpty(config.AuthSource))
         {
-            config.AuthSource = AuthSource.FromConfigFile(Path.GetFileName(path));
+            config.AuthSource = AuthSource.FromConfigFile(path);
             return;
         }
 
-        config.AuthSource += $", {Path.GetFileName(path)}";
+        config.AuthSource += $", {path}";
     }
 
     private async Task ApplyDiscoveredTokensAsync(List<ProviderConfig> configs)

--- a/AIUsageTracker.Infrastructure/Configuration/JsonConfigLoader.cs
+++ b/AIUsageTracker.Infrastructure/Configuration/JsonConfigLoader.cs
@@ -229,7 +229,6 @@ public class JsonConfigLoader : IConfigLoader
 
         var config = this.GetOrCreateMergedConfig(mergedConfigs, providerId);
         this.ApplyFileConfig(config, entry.Value, providerId, path, isAuthFile);
-        this.AppendConfigSource(config, path);
     }
 
     private ProviderConfig GetOrCreateMergedConfig(Dictionary<string, ProviderConfig> mergedConfigs, string providerId)
@@ -266,6 +265,7 @@ public class JsonConfigLoader : IConfigLoader
                 }
 
                 config.ApiKey = value;
+                config.AuthSource = AuthSource.FromConfigFile(path);
             }
         }
 
@@ -317,17 +317,6 @@ public class JsonConfigLoader : IConfigLoader
             .Select(item => item.GetString())
             .OfType<string>()
             .ToList();
-    }
-
-    private void AppendConfigSource(ProviderConfig config, string path)
-    {
-        if (string.IsNullOrEmpty(config.AuthSource))
-        {
-            config.AuthSource = AuthSource.FromConfigFile(path);
-            return;
-        }
-
-        config.AuthSource += $", {path}";
     }
 
     private async Task ApplyDiscoveredTokensAsync(List<ProviderConfig> configs)

--- a/AIUsageTracker.Infrastructure/Constants/ProviderEndpoints.cs
+++ b/AIUsageTracker.Infrastructure/Constants/ProviderEndpoints.cs
@@ -107,6 +107,7 @@ public static class ProviderEndpoints
         public const string BaseUrl = "https://api.minimax.io";
         public const string UserUsage = "https://api.minimax.io/v1/user/usage";
         public const string ChatUserUsage = "https://api.minimax.chat/v1/user/usage";
+        public const string CodingPlanRemains = "https://api.minimax.io/v1/api/openplatform/coding_plan/remains";
     }
 
     /// <summary>

--- a/AIUsageTracker.Infrastructure/Providers/MinimaxProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/MinimaxProvider.cs
@@ -39,7 +39,7 @@ public class MinimaxProvider : ProviderBase
         {
             [InternationalProviderId] = "MiniMax.io",
             [InternationalLegacyProviderId] = "MiniMax.io",
-            [CodingPlanProviderId] = "MiniMax Coding Plan",
+            [CodingPlanProviderId] = "Minimax.io Coding Plan",
         },
         SettingsAdditionalProviderIds = new[] { InternationalProviderId, CodingPlanProviderId },
         DiscoveryEnvironmentVariables = new[] { "MINIMAX_API_KEY" },

--- a/AIUsageTracker.Infrastructure/Providers/MinimaxProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/MinimaxProvider.cs
@@ -3,11 +3,11 @@
 // </copyright>
 
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using AIUsageTracker.Core.Models;
 using AIUsageTracker.Core.Providers;
+using AIUsageTracker.Infrastructure.Constants;
 using Microsoft.Extensions.Logging;
 
 namespace AIUsageTracker.Infrastructure.Providers;
@@ -17,6 +17,7 @@ public class MinimaxProvider : ProviderBase
     public const string ChinaProviderId = "minimax";
     public const string InternationalProviderId = "minimax-io";
     public const string InternationalLegacyProviderId = "minimax-global";
+    public const string CodingPlanProviderId = "minimax-coding-plan";
 
     private readonly HttpClient _httpClient;
     private readonly ILogger<MinimaxProvider> _logger;
@@ -29,17 +30,18 @@ public class MinimaxProvider : ProviderBase
 
     public static ProviderDefinition StaticDefinition { get; } = new(
         ChinaProviderId,
-        "Minimax (China)",
+        "MiniMax.chat",
         PlanType.Coding,
         isQuotaBased: true)
     {
-        AdditionalHandledProviderIds = new[] { InternationalProviderId, InternationalLegacyProviderId },
+        AdditionalHandledProviderIds = new[] { InternationalProviderId, InternationalLegacyProviderId, CodingPlanProviderId },
         DisplayNameOverrides = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
-            [InternationalProviderId] = "Minimax (International)",
-            [InternationalLegacyProviderId] = "Minimax (International)",
+            [InternationalProviderId] = "MiniMax.io",
+            [InternationalLegacyProviderId] = "MiniMax.io",
+            [CodingPlanProviderId] = "MiniMax Coding Plan",
         },
-        SettingsAdditionalProviderIds = new[] { InternationalProviderId },
+        SettingsAdditionalProviderIds = new[] { InternationalProviderId, CodingPlanProviderId },
         DiscoveryEnvironmentVariables = new[] { "MINIMAX_API_KEY" },
         IconAssetName = "minimax",
         BadgeColorHex = "#00CED1",
@@ -64,21 +66,35 @@ public class MinimaxProvider : ProviderBase
             return new[]
             {
                 new ProviderUsage
-            {
-                ProviderId = config.ProviderId,
-                ProviderName = providerLabel,
-                IsAvailable = false,
-                IsQuotaBased = this.Definition.IsQuotaBased,
-                PlanType = this.Definition.PlanType,
-                Description = "API Key not found.",
-                State = ProviderUsageState.Missing,
-            },
+                {
+                    ProviderId = config.ProviderId,
+                    ProviderName = providerLabel,
+                    IsAvailable = false,
+                    IsQuotaBased = this.Definition.IsQuotaBased,
+                    PlanType = this.Definition.PlanType,
+                    Description = "API Key not found.",
+                    State = ProviderUsageState.Missing,
+                },
             };
         }
 
-        string url;
+        if (string.Equals(config.ProviderId, CodingPlanProviderId, StringComparison.OrdinalIgnoreCase))
+        {
+            return await this.GetCodingPlanUsageAsync(config, providerLabel, cancellationToken).ConfigureAwait(false);
+        }
 
-        // Prioritize BaseUrl if set
+        return await this.GetTokenUsageAsync(config, providerLabel, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static bool IsCodingPlanId(string? providerId) =>
+        string.Equals(providerId, CodingPlanProviderId, StringComparison.OrdinalIgnoreCase);
+
+    private async Task<IEnumerable<ProviderUsage>> GetTokenUsageAsync(
+        ProviderConfig config,
+        string providerLabel,
+        CancellationToken cancellationToken)
+    {
+        string url;
         if (!string.IsNullOrEmpty(config.BaseUrl))
         {
             url = config.BaseUrl;
@@ -89,15 +105,13 @@ public class MinimaxProvider : ProviderBase
         }
         else
         {
-            // Determine endpoint based on ID suffix
             url = string.Equals(config.ProviderId, InternationalProviderId, StringComparison.OrdinalIgnoreCase) ||
                   string.Equals(config.ProviderId, InternationalLegacyProviderId, StringComparison.OrdinalIgnoreCase)
-                ? "https://api.minimax.io/v1/user/usage"
-                : "https://api.minimax.chat/v1/user/usage";
+                ? ProviderEndpoints.Minimax.UserUsage
+                : ProviderEndpoints.Minimax.ChatUserUsage;
         }
 
         var request = CreateBearerRequest(HttpMethod.Get, url, config.ApiKey);
-
         var response = await this._httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
         var httpStatus = (int)response.StatusCode;
 
@@ -107,100 +121,299 @@ public class MinimaxProvider : ProviderBase
             return new[]
             {
                 new ProviderUsage
-            {
-                ProviderId = config.ProviderId,
-                ProviderName = providerLabel,
-                IsAvailable = false,
-                IsQuotaBased = this.Definition.IsQuotaBased,
-                PlanType = this.Definition.PlanType,
-                Description = $"API returned {response.StatusCode} for {url}",
-                RawJson = errorContent,
-                HttpStatus = httpStatus,
-            },
+                {
+                    ProviderId = config.ProviderId,
+                    ProviderName = providerLabel,
+                    IsAvailable = false,
+                    IsQuotaBased = this.Definition.IsQuotaBased,
+                    PlanType = this.Definition.PlanType,
+                    Description = $"API returned {response.StatusCode} for {url}",
+                    RawJson = errorContent,
+                    HttpStatus = httpStatus,
+                },
             };
         }
 
         var responseString = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 
-        double used = 0;
-        double total = 0;
-
         try
         {
-            var minimax = JsonSerializer.Deserialize<MinimaxResponse>(responseString);
-            if (minimax?.Usage != null)
-            {
-                used = minimax.Usage.TokensUsed;
-                total = minimax.Usage.TokensLimit > 0 ? minimax.Usage.TokensLimit : 0;
-            }
-            else
+            var minimax = JsonSerializer.Deserialize<MinimaxTokenResponse>(responseString);
+            if (minimax?.Usage == null)
             {
                 return new[]
                 {
-                     new ProviderUsage
-              {
-                  ProviderId = config.ProviderId,
-                  ProviderName = providerLabel,
-                  IsAvailable = false,
-                  IsQuotaBased = this.Definition.IsQuotaBased,
-                  PlanType = this.Definition.PlanType,
-                  Description = "Invalid Minimax response format",
-                  RawJson = responseString,
-                  HttpStatus = httpStatus,
-              },
+                    new ProviderUsage
+                    {
+                        ProviderId = config.ProviderId,
+                        ProviderName = providerLabel,
+                        IsAvailable = false,
+                        IsQuotaBased = this.Definition.IsQuotaBased,
+                        PlanType = this.Definition.PlanType,
+                        Description = "Invalid Minimax response format",
+                        RawJson = responseString,
+                        HttpStatus = httpStatus,
+                    },
                 };
             }
+
+            var used = minimax.Usage.TokensUsed;
+            var total = minimax.Usage.TokensLimit > 0 ? minimax.Usage.TokensLimit : 0;
+            var utilization = total > 0 ? (used / total) * 100.0 : 0;
+
+            return new[]
+            {
+                new ProviderUsage
+                {
+                    ProviderId = config.ProviderId,
+                    ProviderName = providerLabel,
+                    UsedPercent = Math.Clamp(utilization, 0, 100),
+                    RequestsUsed = used,
+                    RequestsAvailable = total,
+                    PlanType = this.Definition.PlanType,
+                    IsQuotaBased = this.Definition.IsQuotaBased,
+                    Description = $"{used:N0} tokens used" + (total > 0 ? $" / {total:N0} limit" : string.Empty),
+                    RawJson = responseString,
+                    HttpStatus = httpStatus,
+                },
+            };
         }
         catch (JsonException ex)
         {
             return new[]
             {
                 new ProviderUsage
+                {
+                    ProviderId = config.ProviderId,
+                    ProviderName = providerLabel,
+                    IsAvailable = false,
+                    IsQuotaBased = this.Definition.IsQuotaBased,
+                    PlanType = this.Definition.PlanType,
+                    Description = $"Failed to parse Minimax response: {ex.Message}",
+                    RawJson = responseString,
+                    HttpStatus = httpStatus,
+                },
+            };
+        }
+    }
+
+    private async Task<IEnumerable<ProviderUsage>> GetCodingPlanUsageAsync(
+        ProviderConfig config,
+        string providerLabel,
+        CancellationToken cancellationToken)
+    {
+        var url = !string.IsNullOrEmpty(config.BaseUrl)
+            ? (config.BaseUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase) ? config.BaseUrl : "https://" + config.BaseUrl)
+            : ProviderEndpoints.Minimax.CodingPlanRemains;
+
+        var request = CreateBearerRequest(HttpMethod.Get, url, config.ApiKey);
+        var response = await this._httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        var httpStatus = (int)response.StatusCode;
+        var responseString = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            return new[]
             {
-                ProviderId = config.ProviderId,
-                ProviderName = providerLabel,
-                IsAvailable = false,
-                IsQuotaBased = this.Definition.IsQuotaBased,
-                PlanType = this.Definition.PlanType,
-                Description = $"Failed to parse Minimax response: {ex.Message}",
-                RawJson = responseString,
-                HttpStatus = httpStatus,
-            },
+                new ProviderUsage
+                {
+                    ProviderId = config.ProviderId,
+                    ProviderName = providerLabel,
+                    IsAvailable = false,
+                    IsQuotaBased = this.Definition.IsQuotaBased,
+                    PlanType = this.Definition.PlanType,
+                    Description = $"API returned {response.StatusCode}",
+                    RawJson = responseString,
+                    HttpStatus = httpStatus,
+                },
             };
         }
 
-        var utilization = total > 0 ? (used / total) * 100.0 : 0;
+        try
+        {
+            var codingPlan = JsonSerializer.Deserialize<MinimaxCodingPlanResponse>(responseString);
+            if (codingPlan?.BaseResp?.StatusCode != 0 || codingPlan.ModelRemains == null || codingPlan.ModelRemains.Count == 0)
+            {
+                var errMsg = codingPlan?.BaseResp?.StatusMsg ?? "Invalid MiniMax Coding Plan response";
+                return new[]
+                {
+                    new ProviderUsage
+                    {
+                        ProviderId = config.ProviderId,
+                        ProviderName = providerLabel,
+                        IsAvailable = false,
+                        IsQuotaBased = this.Definition.IsQuotaBased,
+                        PlanType = this.Definition.PlanType,
+                        Description = errMsg,
+                        RawJson = responseString,
+                        HttpStatus = httpStatus,
+                    },
+                };
+            }
 
-        return new[]
+            return BuildCodingPlanUsages(config.ProviderId, providerLabel, codingPlan.ModelRemains, responseString, httpStatus);
+        }
+        catch (JsonException ex)
         {
-            new ProviderUsage
-        {
-            ProviderId = config.ProviderId,
-            ProviderName = providerLabel,
-            UsedPercent = Math.Clamp(utilization, 0, 100),
-            RequestsUsed = used,
-            RequestsAvailable = total,
-            PlanType = this.Definition.PlanType,
-            IsQuotaBased = this.Definition.IsQuotaBased,
-            Description = $"{used:N0} tokens used" + (total > 0 ? $" / {total:N0} limit" : string.Empty),
-            RawJson = responseString,
-            HttpStatus = httpStatus,
-        },
-        };
+            this._logger.LogWarning(ex, "Failed to parse MiniMax Coding Plan response");
+            return new[]
+            {
+                new ProviderUsage
+                {
+                    ProviderId = config.ProviderId,
+                    ProviderName = providerLabel,
+                    IsAvailable = false,
+                    IsQuotaBased = this.Definition.IsQuotaBased,
+                    PlanType = this.Definition.PlanType,
+                    Description = $"Failed to parse MiniMax Coding Plan response: {ex.Message}",
+                    RawJson = responseString,
+                    HttpStatus = httpStatus,
+                },
+            };
+        }
     }
 
-    private class MinimaxResponse
+    private static IEnumerable<ProviderUsage> BuildCodingPlanUsages(
+        string providerId,
+        string providerLabel,
+        IReadOnlyList<MinimaxModelRemains> modelRemains,
+        string rawJson,
+        int httpStatus)
+    {
+        var usages = new List<ProviderUsage>();
+
+        // Use only the first model as the primary display; additional models are
+        // included as named cards so they can be shown in grouped view.
+        for (var i = 0; i < modelRemains.Count; i++)
+        {
+            var model = modelRemains[i];
+            var modelName = model.ModelName ?? $"Model {i + 1}";
+            var modelSlug = modelName.ToLowerInvariant().Replace(" ", "-", StringComparison.Ordinal);
+
+            // 5h burst window — note: current_interval_usage_count is REMAINING, not used
+            if (model.IntervalTotal > 0)
+            {
+                var remaining = Math.Max(0, Math.Min(model.IntervalRemaining, model.IntervalTotal));
+                var used = model.IntervalTotal - remaining;
+                var usedPct = Math.Clamp((used / model.IntervalTotal) * 100.0, 0, 100);
+                var resetTime = model.IntervalEndMs > 0
+                    ? DateTimeOffset.FromUnixTimeMilliseconds(model.IntervalEndMs).UtcDateTime
+                    : (DateTime?)null;
+
+                usages.Add(new ProviderUsage
+                {
+                    ProviderId = providerId,
+                    ProviderName = providerLabel,
+                    CardId = i == 0 ? "burst" : $"{modelSlug}.burst",
+                    GroupId = providerId,
+                    Name = i == 0 ? "5h" : $"{modelName} 5h",
+                    WindowKind = WindowKind.Burst,
+                    UsedPercent = usedPct,
+                    RequestsUsed = used,
+                    RequestsAvailable = model.IntervalTotal,
+                    IsQuotaBased = true,
+                    PlanType = PlanType.Coding,
+                    IsAvailable = true,
+                    Description = $"{Math.Clamp(100.0 - usedPct, 0, 100):F0}% remaining ({modelName})",
+                    NextResetTime = resetTime,
+                    PeriodDuration = TimeSpan.FromHours(5),
+                    RawJson = rawJson,
+                    HttpStatus = httpStatus,
+                });
+            }
+
+            // Weekly rolling window — same naming convention, current_weekly_usage_count is REMAINING
+            if (model.WeeklyTotal > 0)
+            {
+                var remaining = Math.Max(0, Math.Min(model.WeeklyRemaining, model.WeeklyTotal));
+                var used = model.WeeklyTotal - remaining;
+                var usedPct = Math.Clamp((used / model.WeeklyTotal) * 100.0, 0, 100);
+                var resetTime = model.WeeklyEndMs > 0
+                    ? DateTimeOffset.FromUnixTimeMilliseconds(model.WeeklyEndMs).UtcDateTime
+                    : (DateTime?)null;
+
+                usages.Add(new ProviderUsage
+                {
+                    ProviderId = providerId,
+                    ProviderName = providerLabel,
+                    CardId = i == 0 ? "weekly" : $"{modelSlug}.weekly",
+                    GroupId = providerId,
+                    Name = i == 0 ? "Weekly" : $"{modelName} Weekly",
+                    WindowKind = WindowKind.Rolling,
+                    UsedPercent = usedPct,
+                    RequestsUsed = used,
+                    RequestsAvailable = model.WeeklyTotal,
+                    IsQuotaBased = true,
+                    PlanType = PlanType.Coding,
+                    IsAvailable = true,
+                    Description = $"{Math.Clamp(100.0 - usedPct, 0, 100):F0}% remaining ({modelName})",
+                    NextResetTime = resetTime,
+                    PeriodDuration = TimeSpan.FromDays(7),
+                    RawJson = rawJson,
+                    HttpStatus = httpStatus,
+                });
+            }
+        }
+
+        return usages;
+    }
+
+    private class MinimaxTokenResponse
     {
         [JsonPropertyName("usage")]
-        public MinimaxUsage? Usage { get; set; }
+        public MinimaxTokenUsage? Usage { get; set; }
     }
 
-    private class MinimaxUsage
+    private class MinimaxTokenUsage
     {
         [JsonPropertyName("tokens_used")]
         public double TokensUsed { get; set; }
 
         [JsonPropertyName("tokens_limit")]
         public double TokensLimit { get; set; }
+    }
+
+    private class MinimaxCodingPlanResponse
+    {
+        [JsonPropertyName("base_resp")]
+        public MinimaxBaseResp? BaseResp { get; set; }
+
+        [JsonPropertyName("model_remains")]
+        public List<MinimaxModelRemains>? ModelRemains { get; set; }
+    }
+
+    private class MinimaxBaseResp
+    {
+        [JsonPropertyName("status_code")]
+        public int StatusCode { get; set; }
+
+        [JsonPropertyName("status_msg")]
+        public string? StatusMsg { get; set; }
+    }
+
+    private class MinimaxModelRemains
+    {
+        [JsonPropertyName("model_name")]
+        public string? ModelName { get; set; }
+
+        [JsonPropertyName("current_interval_total_count")]
+        public double IntervalTotal { get; set; }
+
+        /// <summary>Remaining count for the 5h window (misleadingly named "usage" in the API).</summary>
+        [JsonPropertyName("current_interval_usage_count")]
+        public double IntervalRemaining { get; set; }
+
+        [JsonPropertyName("end_time")]
+        public long IntervalEndMs { get; set; }
+
+        [JsonPropertyName("current_weekly_total_count")]
+        public double WeeklyTotal { get; set; }
+
+        /// <summary>Remaining count for the weekly window (misleadingly named "usage" in the API).</summary>
+        [JsonPropertyName("current_weekly_usage_count")]
+        public double WeeklyRemaining { get; set; }
+
+        [JsonPropertyName("weekly_end_time")]
+        public long WeeklyEndMs { get; set; }
     }
 }

--- a/AIUsageTracker.Infrastructure/Providers/OpenRouterProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/OpenRouterProvider.cs
@@ -33,6 +33,7 @@ public class OpenRouterProvider : ProviderBase
         IconAssetName = "openai",
         BadgeColorHex = "#483D8B",
         BadgeInitial = "OR",
+        ShowInSettings = false,
     };
 
     /// <inheritdoc/>

--- a/AIUsageTracker.Infrastructure/Providers/OpenRouterProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/OpenRouterProvider.cs
@@ -33,7 +33,6 @@ public class OpenRouterProvider : ProviderBase
         IconAssetName = "openai",
         BadgeColorHex = "#483D8B",
         BadgeInitial = "OR",
-        ShowInSettings = false,
     };
 
     /// <inheritdoc/>

--- a/AIUsageTracker.Infrastructure/Providers/XiaomiProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/XiaomiProvider.cs
@@ -32,7 +32,6 @@ public class XiaomiProvider : ProviderBase
         IconAssetName = "xiaomi",
         BadgeColorHex = "#FFA500",
         BadgeInitial = "Xi",
-        ShowInSettings = false,
     };
 
     public override ProviderDefinition Definition => StaticDefinition;

--- a/AIUsageTracker.Infrastructure/Providers/XiaomiProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/XiaomiProvider.cs
@@ -32,6 +32,7 @@ public class XiaomiProvider : ProviderBase
         IconAssetName = "xiaomi",
         BadgeColorHex = "#FFA500",
         BadgeInitial = "Xi",
+        ShowInSettings = false,
     };
 
     public override ProviderDefinition Definition => StaticDefinition;

--- a/AIUsageTracker.Monitor.Tests/ProviderRefreshConfigSelectorTests.cs
+++ b/AIUsageTracker.Monitor.Tests/ProviderRefreshConfigSelectorTests.cs
@@ -59,6 +59,40 @@ public class ProviderRefreshConfigSelectorTests
     }
 
     [Fact]
+    public void SelectActiveConfigs_StandardApiKeyWithNoKey_IsExcludedEvenWhenForceAll()
+    {
+        // forceAll must not bypass the key requirement for StandardApiKey providers.
+        // Polling them without a key can only return "API Key missing", which is useless
+        // to store and causes stale "missing" rows to appear in the main window snapshot.
+        var selector = new ProviderRefreshConfigSelector();
+        var configs = new List<ProviderConfig>
+        {
+            new() { ProviderId = "mistral" },   // StandardApiKey, no key
+            new() { ProviderId = "codex" },     // SessionAuthStatus, no key — still included
+        };
+
+        var selection = selector.SelectActiveConfigs(configs, forceAll: true, includeProviderIds: null);
+
+        Assert.DoesNotContain(selection.ActiveConfigs, c => c.ProviderId == "mistral");
+        Assert.Contains(selection.ActiveConfigs, c => c.ProviderId == "codex");
+    }
+
+    [Fact]
+    public void SelectActiveConfigs_StandardApiKeyWithKey_IsIncludedWhenForceAll()
+    {
+        var selector = new ProviderRefreshConfigSelector();
+        var configs = new List<ProviderConfig>
+        {
+            new() { ProviderId = "mistral", ApiKey = TestApiKey1 },
+        };
+
+        var selection = selector.SelectActiveConfigs(configs, forceAll: true, includeProviderIds: null);
+
+        Assert.Single(selection.ActiveConfigs);
+        Assert.Equal("mistral", selection.ActiveConfigs[0].ProviderId);
+    }
+
+    [Fact]
     public void SelectActiveConfigs_FiltersToIncludedProviderIds()
     {
         var selector = new ProviderRefreshConfigSelector();

--- a/AIUsageTracker.Monitor.Tests/ProviderUsagePersistenceServiceTests.cs
+++ b/AIUsageTracker.Monitor.Tests/ProviderUsagePersistenceServiceTests.cs
@@ -133,7 +133,7 @@ public class ProviderUsagePersistenceServiceTests
     [Fact]
     public async Task PersistUsageAndDynamicProvidersAsync_InvalidatesGroupedUsageCacheAfterHistoryWriteAsync()
     {
-        this._database.SetupSequence(database => database.GetLatestHistoryAsync())
+        this._database.SetupSequence(database => database.GetLatestHistoryAsync(It.IsAny<IReadOnlyCollection<string>?>()))
             .ReturnsAsync(new List<ProviderUsage>
             {
                 new()
@@ -179,7 +179,7 @@ public class ProviderUsagePersistenceServiceTests
         await service.PersistUsageAndDynamicProvidersAsync(usages, activeProviderIds);
         _ = await groupedCache.GetGroupedUsageAsync();
 
-        this._database.Verify(database => database.GetLatestHistoryAsync(), Times.Exactly(2));
+        this._database.Verify(database => database.GetLatestHistoryAsync(It.IsAny<IReadOnlyCollection<string>?>()), Times.Exactly(2));
     }
 
     private ProviderUsagePersistenceService CreateService(CachedGroupedUsageProjectionService? groupedUsageProjectionCache = null)

--- a/AIUsageTracker.Monitor/Endpoints/MonitorConfigEndpoints.cs
+++ b/AIUsageTracker.Monitor/Endpoints/MonitorConfigEndpoints.cs
@@ -29,6 +29,7 @@ internal static class MonitorConfigEndpoints
                 IConfigService configService,
                 ProviderRefreshService refreshService,
                 ProviderRefreshCircuitBreakerService circuitBreakerService,
+                CachedGroupedUsageProjectionService projectionService,
                 ILogger<Program> logger) =>
         {
             if (string.IsNullOrWhiteSpace(config.ProviderId))
@@ -38,6 +39,10 @@ internal static class MonitorConfigEndpoints
 
             logger.LogDebug("POST {Route} ({ProviderId})", MonitorApiRoutes.Config, config.ProviderId);
             await configService.SaveConfigAsync(config).ConfigureAwait(false);
+
+            // Invalidate the snapshot cache so the exclusion filter re-evaluates against the
+            // updated config (e.g. a cleared API key should immediately hide the provider).
+            projectionService.Invalidate();
 
             // Config/auth updates should retry immediately and not wait for a stale backoff window.
             circuitBreakerService.ResetProvider(config.ProviderId, "config update");

--- a/AIUsageTracker.Monitor/Migrations/V14__Add_state_column.sql
+++ b/AIUsageTracker.Monitor/Migrations/V14__Add_state_column.sql
@@ -1,6 +1,0 @@
--- Add state column to provider_history.
--- Stores the ProviderUsageState enum value (Available=0, Missing=1, Error=2,
--- ConsoleCheck=3, Unknown=4, Unavailable=5) so the full state is round-tripped
--- through the database and not lost on read-back.
--- DEFAULT 0 = Available, matching the ProviderUsage model default.
-ALTER TABLE provider_history ADD COLUMN state INTEGER NOT NULL DEFAULT 0;

--- a/AIUsageTracker.Monitor/Migrations/V14__Add_state_column.sql
+++ b/AIUsageTracker.Monitor/Migrations/V14__Add_state_column.sql
@@ -1,0 +1,6 @@
+-- Add state column to provider_history.
+-- Stores the ProviderUsageState enum value (Available=0, Missing=1, Error=2,
+-- ConsoleCheck=3, Unknown=4, Unavailable=5) so the full state is round-tripped
+-- through the database and not lost on read-back.
+-- DEFAULT 0 = Available, matching the ProviderUsage model default.
+ALTER TABLE provider_history ADD COLUMN state INTEGER NOT NULL DEFAULT 0;

--- a/AIUsageTracker.Monitor/Services/CachedGroupedUsageProjectionService.cs
+++ b/AIUsageTracker.Monitor/Services/CachedGroupedUsageProjectionService.cs
@@ -53,9 +53,11 @@ public sealed class CachedGroupedUsageProjectionService
         var activeIds = ProviderMetadataCatalog.ExpandAcceptedUsageProviderIds(
             activeConfigs.Select(c => c.ProviderId));
 
-        // Providers with no API key that are StandardApiKey mode produce only "API Key missing"
-        // records. Exclude their canonical IDs from the snapshot so they don't appear in the
-        // main window. (They remain in Settings where the user can configure a key.)
+        // StandardApiKey providers with no API key configured should not appear in the main
+        // window — they have nothing to show. The config is authoritative here: even if the
+        // database has a stale "API Key missing" history row, the right question is "is this
+        // provider configured?" not "what was its last observed state?".
+        // (They remain in Settings where the user can configure a key.)
         var unconfiguredStandardApiKeyIds = activeConfigs
             .Where(c => string.IsNullOrEmpty(c.ApiKey) &&
                         ProviderMetadataCatalog.Find(c.ProviderId)?.SettingsMode == ProviderSettingsMode.StandardApiKey)

--- a/AIUsageTracker.Monitor/Services/CachedGroupedUsageProjectionService.cs
+++ b/AIUsageTracker.Monitor/Services/CachedGroupedUsageProjectionService.cs
@@ -52,8 +52,20 @@ public sealed class CachedGroupedUsageProjectionService
         var activeConfigs = await this._configService.GetConfigsAsync().ConfigureAwait(false);
         var activeIds = ProviderMetadataCatalog.ExpandAcceptedUsageProviderIds(
             activeConfigs.Select(c => c.ProviderId));
+
+        // Providers with no API key that are StandardApiKey mode produce only "API Key missing"
+        // records. Exclude their canonical IDs from the snapshot so they don't appear in the
+        // main window. (They remain in Settings where the user can configure a key.)
+        var unconfiguredStandardApiKeyIds = activeConfigs
+            .Where(c => string.IsNullOrEmpty(c.ApiKey) &&
+                        ProviderMetadataCatalog.Find(c.ProviderId)?.SettingsMode == ProviderSettingsMode.StandardApiKey)
+            .Select(c => ProviderMetadataCatalog.GetCanonicalProviderId(c.ProviderId))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
         var usage = allUsage
-            .Where(u => activeIds.Contains(u.ProviderId ?? string.Empty))
+            .Where(u => activeIds.Contains(u.ProviderId ?? string.Empty) &&
+                        !unconfiguredStandardApiKeyIds.Contains(
+                            ProviderMetadataCatalog.GetCanonicalProviderId(u.ProviderId ?? string.Empty)))
             .ToList();
         var snapshot = GroupedUsageProjectionService.Build(usage);
         var eTag = CreateUsageETag(usage);

--- a/AIUsageTracker.Monitor/Services/CachedGroupedUsageProjectionService.cs
+++ b/AIUsageTracker.Monitor/Services/CachedGroupedUsageProjectionService.cs
@@ -50,27 +50,21 @@ public sealed class CachedGroupedUsageProjectionService
 
         var allUsage = await this._database.GetLatestHistoryAsync().ConfigureAwait(false);
         var activeConfigs = await this._configService.GetConfigsAsync().ConfigureAwait(false);
-        var activeIds = ProviderMetadataCatalog.ExpandAcceptedUsageProviderIds(
-            activeConfigs.Select(c => c.ProviderId));
 
-        // StandardApiKey providers with no API key configured should not appear in the main
-        // window — they have nothing to show. The config is authoritative here: even if the
-        // database has a stale "API Key missing" history row, the right question is "is this
-        // provider configured?" not "what was its last observed state?".
-        // (They remain in Settings where the user can configure a key.)
-        //
-        // Use the specific ProviderId (not canonical) so that provider families with
-        // multiple independently-keyable sub-providers (e.g. minimax vs minimax-io)
-        // only hide the sub-providers whose key is missing — not the whole family.
-        var unconfiguredStandardApiKeyIds = activeConfigs
-            .Where(c => string.IsNullOrEmpty(c.ApiKey) &&
-                        ProviderMetadataCatalog.Find(c.ProviderId)?.SettingsMode == ProviderSettingsMode.StandardApiKey)
-            .Select(c => c.ProviderId)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        // Build the set of provider IDs that should appear in the snapshot.
+        // StandardApiKey providers require a key to be visible — without one there is nothing
+        // to show (the monitor never polls them, so the only DB rows would be stale zeroes).
+        // Non-StandardApiKey providers (SessionAuth, AutoDetected, ExternalAuth) are always
+        // included because their presence and state are determined by runtime detection, not
+        // by an API key in the config.
+        var visibleIds = ProviderMetadataCatalog.ExpandAcceptedUsageProviderIds(
+            activeConfigs
+                .Where(c => !string.IsNullOrEmpty(c.ApiKey) ||
+                            ProviderMetadataCatalog.Find(c.ProviderId)?.SettingsMode != ProviderSettingsMode.StandardApiKey)
+                .Select(c => c.ProviderId));
 
         var usage = allUsage
-            .Where(u => activeIds.Contains(u.ProviderId ?? string.Empty) &&
-                        !unconfiguredStandardApiKeyIds.Contains(u.ProviderId ?? string.Empty))
+            .Where(u => visibleIds.Contains(u.ProviderId ?? string.Empty))
             .ToList();
         var snapshot = GroupedUsageProjectionService.Build(usage);
         var eTag = CreateUsageETag(usage);

--- a/AIUsageTracker.Monitor/Services/CachedGroupedUsageProjectionService.cs
+++ b/AIUsageTracker.Monitor/Services/CachedGroupedUsageProjectionService.cs
@@ -48,7 +48,6 @@ public sealed class CachedGroupedUsageProjectionService
             }
         }
 
-        var allUsage = await this._database.GetLatestHistoryAsync().ConfigureAwait(false);
         var activeConfigs = await this._configService.GetConfigsAsync().ConfigureAwait(false);
 
         // Build the set of provider IDs that should appear in the snapshot.
@@ -63,9 +62,10 @@ public sealed class CachedGroupedUsageProjectionService
                             ProviderMetadataCatalog.Find(c.ProviderId)?.SettingsMode != ProviderSettingsMode.StandardApiKey)
                 .Select(c => c.ProviderId));
 
-        var usage = allUsage
-            .Where(u => visibleIds.Contains(u.ProviderId ?? string.Empty))
-            .ToList();
+        // Pass visibleIds directly to the DB so filtering happens in SQL rather than in
+        // application code. Stale history rows for unconfigured providers are excluded at
+        // the query level; the result set is already the snapshot — no further filtering needed.
+        var usage = await this._database.GetLatestHistoryAsync(visibleIds).ConfigureAwait(false);
         var snapshot = GroupedUsageProjectionService.Build(usage);
         var eTag = CreateUsageETag(usage);
 

--- a/AIUsageTracker.Monitor/Services/CachedGroupedUsageProjectionService.cs
+++ b/AIUsageTracker.Monitor/Services/CachedGroupedUsageProjectionService.cs
@@ -58,16 +58,19 @@ public sealed class CachedGroupedUsageProjectionService
         // database has a stale "API Key missing" history row, the right question is "is this
         // provider configured?" not "what was its last observed state?".
         // (They remain in Settings where the user can configure a key.)
+        //
+        // Use the specific ProviderId (not canonical) so that provider families with
+        // multiple independently-keyable sub-providers (e.g. minimax vs minimax-io)
+        // only hide the sub-providers whose key is missing — not the whole family.
         var unconfiguredStandardApiKeyIds = activeConfigs
             .Where(c => string.IsNullOrEmpty(c.ApiKey) &&
                         ProviderMetadataCatalog.Find(c.ProviderId)?.SettingsMode == ProviderSettingsMode.StandardApiKey)
-            .Select(c => ProviderMetadataCatalog.GetCanonicalProviderId(c.ProviderId))
+            .Select(c => c.ProviderId)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
         var usage = allUsage
             .Where(u => activeIds.Contains(u.ProviderId ?? string.Empty) &&
-                        !unconfiguredStandardApiKeyIds.Contains(
-                            ProviderMetadataCatalog.GetCanonicalProviderId(u.ProviderId ?? string.Empty)))
+                        !unconfiguredStandardApiKeyIds.Contains(u.ProviderId ?? string.Empty))
             .ToList();
         var snapshot = GroupedUsageProjectionService.Build(usage);
         var eTag = CreateUsageETag(usage);

--- a/AIUsageTracker.Monitor/Services/GroupedUsageProjectionService.cs
+++ b/AIUsageTracker.Monitor/Services/GroupedUsageProjectionService.cs
@@ -61,6 +61,7 @@ public static class GroupedUsageProjectionService
             ProviderName = displayName,
             AccountName = accountName,
             IsAvailable = group.Any(usage => usage.IsAvailable),
+            State = primary.State,
             PlanType = primary.PlanType,
             IsQuotaBased = primary.IsQuotaBased,
             RequestsUsed = primary.RequestsUsed,

--- a/AIUsageTracker.Monitor/Services/IUsageDatabase.cs
+++ b/AIUsageTracker.Monitor/Services/IUsageDatabase.cs
@@ -24,7 +24,7 @@ public interface IUsageDatabase
 
     Task StoreResetEventAsync(string providerId, string providerName, double? previousUsage, double? newUsage, string resetType);
 
-    Task<IReadOnlyList<ProviderUsage>> GetLatestHistoryAsync();
+    Task<IReadOnlyList<ProviderUsage>> GetLatestHistoryAsync(IReadOnlyCollection<string>? providerIds = null);
 
     Task<IReadOnlyList<ProviderUsage>> GetHistoryAsync(int limit = 100);
 

--- a/AIUsageTracker.Monitor/Services/ProviderRefreshCircuitBreakerService.cs
+++ b/AIUsageTracker.Monitor/Services/ProviderRefreshCircuitBreakerService.cs
@@ -254,13 +254,12 @@ public class ProviderRefreshCircuitBreakerService
             return false;
         }
 
-        // Typed state takes priority
         if (usage.State == ProviderUsageState.Error)
         {
             return false;
         }
 
-        return usage.State != ProviderUsageState.Error;
+        return true;
     }
 
     private static string GetFailureMessage(IReadOnlyCollection<ProviderUsage> providerUsages)

--- a/AIUsageTracker.Monitor/Services/ProviderRefreshConfigSelector.cs
+++ b/AIUsageTracker.Monitor/Services/ProviderRefreshConfigSelector.cs
@@ -16,8 +16,24 @@ public sealed class ProviderRefreshConfigSelector
     {
         var activeConfigs = configs
             .Where(config =>
-                ProviderMetadataCatalog.ShouldPersistProviderId(config.ProviderId) &&
-                (forceAll || !string.IsNullOrEmpty(config.ApiKey)))
+            {
+                if (!ProviderMetadataCatalog.ShouldPersistProviderId(config.ProviderId))
+                {
+                    return false;
+                }
+
+                // StandardApiKey providers always require a key — polling without one can
+                // only return "API Key missing", which is useless to store and poll for.
+                // forceAll does not override this: there is nothing useful to fetch without a key.
+                if (ProviderMetadataCatalog.Find(config.ProviderId)?.SettingsMode == ProviderSettingsMode.StandardApiKey)
+                {
+                    return !string.IsNullOrEmpty(config.ApiKey);
+                }
+
+                // Non-StandardApiKey providers (SessionAuth, AutoDetected, ExternalAuth) respond
+                // to forceAll so that scan operations pick them up even when no key is stored.
+                return forceAll || !string.IsNullOrEmpty(config.ApiKey);
+            })
             .ToList();
 
         if (includeProviderIds != null && includeProviderIds.Count > 0)

--- a/AIUsageTracker.Monitor/Services/UsageDatabase.cs
+++ b/AIUsageTracker.Monitor/Services/UsageDatabase.cs
@@ -318,8 +318,7 @@ public class UsageDatabase : IUsageDatabase
                         u.GroupId,
                         (int)u.WindowKind,
                         u.ModelName,
-                        u.Name,
-                        (int)u.State));
+                        u.Name));
                 }
             }
 
@@ -333,8 +332,7 @@ public class UsageDatabase : IUsageDatabase
                         response_latency_ms, http_status,
                         upstream_response_validity, upstream_response_note,
                         parent_provider_id, card_id, group_id,
-                        window_kind, model_name, name,
-                        state
+                        window_kind, model_name, name
                     ) VALUES (
                         @ProviderId,
                         @RequestsUsed, @RequestsAvailable, @RequestsPercentage,
@@ -342,8 +340,7 @@ public class UsageDatabase : IUsageDatabase
                         @ResponseLatencyMs, @HttpStatus,
                         @UpstreamResponseValidity, @UpstreamResponseNote,
                         @ParentProviderId, @CardId, @GroupId,
-                        @WindowKind, @ModelName, @Name,
-                        @State
+                        @WindowKind, @ModelName, @Name
                     )";
 
                 await connection.ExecuteAsync(insertSql, toInsert).ConfigureAwait(false);
@@ -446,8 +443,7 @@ public class UsageDatabase : IUsageDatabase
         string? GroupId,
         int WindowKind,
         string? ModelName,
-        string? Name,
-        int State);
+        string? Name);
 
     private sealed record HistoryTouchParams(long Id, long FetchedAt);
 
@@ -626,8 +622,7 @@ public class UsageDatabase : IUsageDatabase
                        h.group_id AS GroupId,
                        COALESCE(h.window_kind, 0) AS WindowKind,
                        h.model_name AS ModelName,
-                       h.name AS Name,
-                       COALESCE(h.state, 0) AS State
+                       h.name AS Name
                 FROM provider_history h
                 LEFT JOIN providers p ON h.provider_id = p.provider_id
                 WHERE h.id IN (
@@ -795,8 +790,7 @@ public class UsageDatabase : IUsageDatabase
                        h.response_latency_ms AS ResponseLatencyMs,
                        h.http_status AS HttpStatus,
                        COALESCE(h.upstream_response_validity, 0) AS UpstreamResponseValidity,
-                       COALESCE(h.upstream_response_note, '') AS UpstreamResponseNote,
-                       COALESCE(h.state, 0) AS State
+                       COALESCE(h.upstream_response_note, '') AS UpstreamResponseNote
                 FROM provider_history h
                 JOIN providers p ON h.provider_id = p.provider_id
                 ORDER BY h.fetched_at DESC
@@ -828,8 +822,7 @@ public class UsageDatabase : IUsageDatabase
                        h.response_latency_ms AS ResponseLatencyMs,
                        h.http_status AS HttpStatus,
                        COALESCE(h.upstream_response_validity, 0) AS UpstreamResponseValidity,
-                       COALESCE(h.upstream_response_note, '') AS UpstreamResponseNote,
-                       COALESCE(h.state, 0) AS State
+                       COALESCE(h.upstream_response_note, '') AS UpstreamResponseNote
                 FROM provider_history h
                 JOIN providers p ON h.provider_id = p.provider_id
                 WHERE h.provider_id = @ProviderId
@@ -864,15 +857,13 @@ public class UsageDatabase : IUsageDatabase
                            h.http_status AS HttpStatus,
                            COALESCE(h.upstream_response_validity, 0) AS UpstreamResponseValidity,
                            COALESCE(h.upstream_response_note, '') AS UpstreamResponseNote,
-                           COALESCE(h.state, 0) AS State,
                            ROW_NUMBER() OVER (PARTITION BY h.provider_id ORDER BY h.fetched_at DESC) as pos
                     FROM provider_history h
                     JOIN providers p ON h.provider_id = p.provider_id
                 )
                 SELECT ProviderId, ProviderName, RequestsUsed, RequestsAvailable,
                        UsedPercent, IsAvailable, Description, FetchedAt, NextResetTime,
-                       ResponseLatencyMs, HttpStatus, UpstreamResponseValidity, UpstreamResponseNote,
-                       State
+                       ResponseLatencyMs, HttpStatus, UpstreamResponseValidity, UpstreamResponseNote
                 FROM RankedHistory
                 WHERE pos <= @Count
                 ORDER BY ProviderId, FetchedAt DESC";

--- a/AIUsageTracker.Monitor/Services/UsageDatabase.cs
+++ b/AIUsageTracker.Monitor/Services/UsageDatabase.cs
@@ -318,7 +318,8 @@ public class UsageDatabase : IUsageDatabase
                         u.GroupId,
                         (int)u.WindowKind,
                         u.ModelName,
-                        u.Name));
+                        u.Name,
+                        (int)u.State));
                 }
             }
 
@@ -332,7 +333,8 @@ public class UsageDatabase : IUsageDatabase
                         response_latency_ms, http_status,
                         upstream_response_validity, upstream_response_note,
                         parent_provider_id, card_id, group_id,
-                        window_kind, model_name, name
+                        window_kind, model_name, name,
+                        state
                     ) VALUES (
                         @ProviderId,
                         @RequestsUsed, @RequestsAvailable, @RequestsPercentage,
@@ -340,7 +342,8 @@ public class UsageDatabase : IUsageDatabase
                         @ResponseLatencyMs, @HttpStatus,
                         @UpstreamResponseValidity, @UpstreamResponseNote,
                         @ParentProviderId, @CardId, @GroupId,
-                        @WindowKind, @ModelName, @Name
+                        @WindowKind, @ModelName, @Name,
+                        @State
                     )";
 
                 await connection.ExecuteAsync(insertSql, toInsert).ConfigureAwait(false);
@@ -443,7 +446,8 @@ public class UsageDatabase : IUsageDatabase
         string? GroupId,
         int WindowKind,
         string? ModelName,
-        string? Name);
+        string? Name,
+        int State);
 
     private sealed record HistoryTouchParams(long Id, long FetchedAt);
 
@@ -622,7 +626,8 @@ public class UsageDatabase : IUsageDatabase
                        h.group_id AS GroupId,
                        COALESCE(h.window_kind, 0) AS WindowKind,
                        h.model_name AS ModelName,
-                       h.name AS Name
+                       h.name AS Name,
+                       COALESCE(h.state, 0) AS State
                 FROM provider_history h
                 LEFT JOIN providers p ON h.provider_id = p.provider_id
                 WHERE h.id IN (
@@ -790,7 +795,8 @@ public class UsageDatabase : IUsageDatabase
                        h.response_latency_ms AS ResponseLatencyMs,
                        h.http_status AS HttpStatus,
                        COALESCE(h.upstream_response_validity, 0) AS UpstreamResponseValidity,
-                       COALESCE(h.upstream_response_note, '') AS UpstreamResponseNote
+                       COALESCE(h.upstream_response_note, '') AS UpstreamResponseNote,
+                       COALESCE(h.state, 0) AS State
                 FROM provider_history h
                 JOIN providers p ON h.provider_id = p.provider_id
                 ORDER BY h.fetched_at DESC
@@ -822,7 +828,8 @@ public class UsageDatabase : IUsageDatabase
                        h.response_latency_ms AS ResponseLatencyMs,
                        h.http_status AS HttpStatus,
                        COALESCE(h.upstream_response_validity, 0) AS UpstreamResponseValidity,
-                       COALESCE(h.upstream_response_note, '') AS UpstreamResponseNote
+                       COALESCE(h.upstream_response_note, '') AS UpstreamResponseNote,
+                       COALESCE(h.state, 0) AS State
                 FROM provider_history h
                 JOIN providers p ON h.provider_id = p.provider_id
                 WHERE h.provider_id = @ProviderId
@@ -857,13 +864,15 @@ public class UsageDatabase : IUsageDatabase
                            h.http_status AS HttpStatus,
                            COALESCE(h.upstream_response_validity, 0) AS UpstreamResponseValidity,
                            COALESCE(h.upstream_response_note, '') AS UpstreamResponseNote,
+                           COALESCE(h.state, 0) AS State,
                            ROW_NUMBER() OVER (PARTITION BY h.provider_id ORDER BY h.fetched_at DESC) as pos
                     FROM provider_history h
                     JOIN providers p ON h.provider_id = p.provider_id
                 )
                 SELECT ProviderId, ProviderName, RequestsUsed, RequestsAvailable,
                        UsedPercent, IsAvailable, Description, FetchedAt, NextResetTime,
-                       ResponseLatencyMs, HttpStatus, UpstreamResponseValidity, UpstreamResponseNote
+                       ResponseLatencyMs, HttpStatus, UpstreamResponseValidity, UpstreamResponseNote,
+                       State
                 FROM RankedHistory
                 WHERE pos <= @Count
                 ORDER BY ProviderId, FetchedAt DESC";

--- a/AIUsageTracker.Monitor/Services/UsageDatabase.cs
+++ b/AIUsageTracker.Monitor/Services/UsageDatabase.cs
@@ -600,11 +600,21 @@ public class UsageDatabase : IUsageDatabase
         }
     }
 
-    public async Task<IReadOnlyList<ProviderUsage>> GetLatestHistoryAsync()
+    public async Task<IReadOnlyList<ProviderUsage>> GetLatestHistoryAsync(IReadOnlyCollection<string>? providerIds = null)
     {
+        if (providerIds != null && providerIds.Count == 0)
+        {
+            return Array.Empty<ProviderUsage>();
+        }
+
         using var connection = await this.OpenReadConnectionAsync().ConfigureAwait(false);
 
-        const string sql = @"
+        // When a provider-ID set is supplied, restrict the subquery to those IDs so that
+        // stale history rows for removed/unconfigured providers are excluded at the SQL level
+        // rather than filtered in application code.
+        var providerClause = providerIds != null ? "AND provider_id IN @providerIds" : string.Empty;
+
+        var sql = $@"
                 SELECT h.provider_id AS ProviderId,
                        COALESCE(NULLIF(p.provider_name, ''), h.provider_id) AS ProviderName,
                        h.requests_used AS RequestsUsed, h.requests_available AS RequestsAvailable,
@@ -628,11 +638,13 @@ public class UsageDatabase : IUsageDatabase
                 WHERE h.id IN (
                     SELECT MAX(id) FROM provider_history
                     WHERE fetched_at >= (strftime('%s', 'now') - 86400)
+                    {providerClause}
                     GROUP BY provider_id, card_id
                 )
                 ORDER BY h.provider_id, h.card_id";
 
-        var results = (await connection.QueryAsync<ProviderUsage>(sql).ConfigureAwait(false)).ToList();
+        object? param = providerIds != null ? new { providerIds = providerIds.ToArray() } : null;
+        var results = (await connection.QueryAsync<ProviderUsage>(sql, param).ConfigureAwait(false)).ToList();
 
         await StampUsageRatesAsync(connection, results).ConfigureAwait(false);
 

--- a/AIUsageTracker.Tests/Core/AllProvidersWorkingTests.cs
+++ b/AIUsageTracker.Tests/Core/AllProvidersWorkingTests.cs
@@ -45,7 +45,7 @@ public class AllProvidersWorkingTests
         mockMinimax.Setup(p => p.ProviderId).Returns("minimax");
         mockMinimax.Setup(p => p.Definition).Returns(new ProviderDefinition(
             "minimax",
-            "Minimax (China)",
+            "MiniMax.chat",
             PlanType.Coding,
             isQuotaBased: true)
         {

--- a/AIUsageTracker.Tests/Infrastructure/ProviderMetadataCatalogCanonicalizationTests.cs
+++ b/AIUsageTracker.Tests/Infrastructure/ProviderMetadataCatalogCanonicalizationTests.cs
@@ -67,6 +67,49 @@ public class ProviderMetadataCatalogCanonicalizationTests
     }
 
     [Fact]
+    public void NormalizeCanonicalConfigurations_KeepsMinimaxCodingPlanAsDedicatedProvider()
+    {
+        // minimax-coding-plan must NOT be merged into the minimax (China) config —
+        // it's a separate visible derived provider with its own API key and endpoint.
+        var configs = new List<ProviderConfig>
+        {
+            new()
+            {
+                ProviderId = "minimax-coding-plan",
+                ApiKey = TestApiKey1,
+                AuthSource = "opencode-auth",
+            },
+        };
+
+        ProviderMetadataCatalog.NormalizeCanonicalConfigurations(configs);
+
+        var codingPlan = Assert.Single(configs);
+        Assert.Equal("minimax-coding-plan", codingPlan.ProviderId); // provider-id-guardrail-allow: test assertion
+        Assert.Equal(TestApiKey1, codingPlan.ApiKey);
+        Assert.Equal("opencode-auth", codingPlan.AuthSource);
+    }
+
+    [Fact]
+    public void NormalizeCanonicalConfigurations_KeepsMinimaxIoAsDedicatedProvider()
+    {
+        // minimax-io must NOT be merged into the minimax (China) config.
+        var configs = new List<ProviderConfig>
+        {
+            new()
+            {
+                ProviderId = "minimax-io",
+                ApiKey = TestApiKey2,
+            },
+        };
+
+        ProviderMetadataCatalog.NormalizeCanonicalConfigurations(configs);
+
+        var international = Assert.Single(configs);
+        Assert.Equal("minimax-io", international.ProviderId); // provider-id-guardrail-allow: test assertion
+        Assert.Equal(TestApiKey2, international.ApiKey);
+    }
+
+    [Fact]
     public void NormalizeCanonicalConfigurations_RemovesOpenAiAlias_WhenCodexExists()
     {
         var configs = new List<ProviderConfig>

--- a/AIUsageTracker.Tests/Infrastructure/ProviderMetadataCatalogTests.cs
+++ b/AIUsageTracker.Tests/Infrastructure/ProviderMetadataCatalogTests.cs
@@ -41,8 +41,9 @@ public class ProviderMetadataCatalogTests
     [InlineData("gemini-cli.hourly", "gemini-cli", "Gemini CLI (Hourly)")]
     [InlineData("gemini-cli.daily", "gemini-cli", "Gemini CLI (Daily)")]
     [InlineData("kimi", "kimi-for-coding", "Kimi for Coding")]
-    [InlineData("minimax-io", "minimax", "Minimax (International)")]
-    [InlineData("minimax-global", "minimax", "Minimax (International)")]
+    [InlineData("minimax-io", "minimax", "MiniMax.io")]
+    [InlineData("minimax-global", "minimax", "MiniMax.io")]
+    [InlineData("minimax-coding-plan", "minimax", "MiniMax Coding Plan")]
     [InlineData("opencode-go", "opencode-go", "OpenCode Go")]
     [InlineData("zai", "zai-coding-plan", "Z.AI")]
     public void Find_UsesProviderDefinitionsForAliases(string providerId, string expectedDefinitionId, string expectedDisplayName)
@@ -69,6 +70,10 @@ public class ProviderMetadataCatalogTests
     [Theory]
     [InlineData("codex.spark", "OpenAI (GPT-5.3 Codex Spark)")]
     [InlineData("antigravity.gpt-oss", "Google Antigravity")]
+    [InlineData("minimax", "MiniMax.chat")]
+    [InlineData("minimax-io", "MiniMax.io")]
+    [InlineData("minimax-global", "MiniMax.io")]
+    [InlineData("minimax-coding-plan", "MiniMax Coding Plan")]
     public void GetConfiguredDisplayName_UsesMetadataAuthority(string providerId, string expectedDisplayName)
     {
         Assert.Equal(expectedDisplayName, ProviderMetadataCatalog.GetConfiguredDisplayName(providerId));
@@ -358,6 +363,8 @@ public class ProviderMetadataCatalogTests
     [InlineData("codex", true)]
     [InlineData("openai", false)]
     [InlineData("deepseek", false)]
+    [InlineData("xiaomi", false)]
+    [InlineData("openrouter", false)]
     public void ShouldShowInSettings_UsesProviderDefinitions(string providerId, bool expected)
     {
         Assert.Equal(expected, ProviderMetadataCatalog.Find(providerId)?.ShowInSettings ?? false);

--- a/AIUsageTracker.Tests/Infrastructure/ProviderMetadataCatalogTests.cs
+++ b/AIUsageTracker.Tests/Infrastructure/ProviderMetadataCatalogTests.cs
@@ -43,7 +43,7 @@ public class ProviderMetadataCatalogTests
     [InlineData("kimi", "kimi-for-coding", "Kimi for Coding")]
     [InlineData("minimax-io", "minimax", "MiniMax.io")]
     [InlineData("minimax-global", "minimax", "MiniMax.io")]
-    [InlineData("minimax-coding-plan", "minimax", "MiniMax Coding Plan")]
+    [InlineData("minimax-coding-plan", "minimax", "Minimax.io Coding Plan")]
     [InlineData("opencode-go", "opencode-go", "OpenCode Go")]
     [InlineData("zai", "zai-coding-plan", "Z.AI")]
     public void Find_UsesProviderDefinitionsForAliases(string providerId, string expectedDefinitionId, string expectedDisplayName)
@@ -73,7 +73,7 @@ public class ProviderMetadataCatalogTests
     [InlineData("minimax", "MiniMax.chat")]
     [InlineData("minimax-io", "MiniMax.io")]
     [InlineData("minimax-global", "MiniMax.io")]
-    [InlineData("minimax-coding-plan", "MiniMax Coding Plan")]
+    [InlineData("minimax-coding-plan", "Minimax.io Coding Plan")]
     public void GetConfiguredDisplayName_UsesMetadataAuthority(string providerId, string expectedDisplayName)
     {
         Assert.Equal(expectedDisplayName, ProviderMetadataCatalog.GetConfiguredDisplayName(providerId));

--- a/AIUsageTracker.Tests/Infrastructure/ProviderMetadataCatalogTests.cs
+++ b/AIUsageTracker.Tests/Infrastructure/ProviderMetadataCatalogTests.cs
@@ -363,8 +363,8 @@ public class ProviderMetadataCatalogTests
     [InlineData("codex", true)]
     [InlineData("openai", false)]
     [InlineData("deepseek", false)]
-    [InlineData("xiaomi", false)]
-    [InlineData("openrouter", false)]
+    [InlineData("xiaomi", true)]
+    [InlineData("openrouter", true)]
     public void ShouldShowInSettings_UsesProviderDefinitions(string providerId, bool expected)
     {
         Assert.Equal(expected, ProviderMetadataCatalog.Find(providerId)?.ShowInSettings ?? false);

--- a/AIUsageTracker.Tests/Infrastructure/Providers/MinimaxProviderTests.cs
+++ b/AIUsageTracker.Tests/Infrastructure/Providers/MinimaxProviderTests.cs
@@ -578,7 +578,7 @@ public class MinimaxProviderTests : HttpProviderTestBase<MinimaxProvider>
         Assert.Equal(30, burst.RequestsUsed);
         Assert.Equal(100, burst.RequestsAvailable);
         Assert.Equal("minimax-coding-plan", burst.ProviderId); // provider-id-guardrail-allow: test assertion
-        Assert.Equal("MiniMax Coding Plan", burst.ProviderName);
+        Assert.Equal("Minimax.io Coding Plan", burst.ProviderName);
 
         // Weekly: 100 used / 500 total = 20%
         Assert.Equal(20, weekly.UsedPercent);
@@ -678,7 +678,7 @@ public class MinimaxProviderTests : HttpProviderTestBase<MinimaxProvider>
         var result = await this._provider.GetUsageAsync(this.Config);
 
         // Assert
-        Assert.All(result, u => Assert.Equal("MiniMax Coding Plan", u.ProviderName));
+        Assert.All(result, u => Assert.Equal("Minimax.io Coding Plan", u.ProviderName));
     }
 
     [Fact]
@@ -687,7 +687,7 @@ public class MinimaxProviderTests : HttpProviderTestBase<MinimaxProvider>
         var definition = MinimaxProvider.StaticDefinition;
         Assert.Contains(MinimaxProvider.CodingPlanProviderId, definition.AdditionalHandledProviderIds);
         Assert.Contains(MinimaxProvider.CodingPlanProviderId, definition.SettingsAdditionalProviderIds);
-        Assert.Equal("MiniMax Coding Plan", definition.DisplayNameOverrides[MinimaxProvider.CodingPlanProviderId]);
+        Assert.Equal("Minimax.io Coding Plan", definition.DisplayNameOverrides[MinimaxProvider.CodingPlanProviderId]);
     }
 
     private void SetupResponse(HttpStatusCode statusCode, string content, string? url = null)

--- a/AIUsageTracker.Tests/Infrastructure/Providers/MinimaxProviderTests.cs
+++ b/AIUsageTracker.Tests/Infrastructure/Providers/MinimaxProviderTests.cs
@@ -17,6 +17,7 @@ public class MinimaxProviderTests : HttpProviderTestBase<MinimaxProvider>
 
     private const string ChinaEndpoint = "https://api.minimax.chat/v1/user/usage";
     private const string InternationalEndpoint = "https://api.minimax.io/v1/user/usage";
+    private const string CodingPlanEndpoint = "https://api.minimax.io/v1/api/openplatform/coding_plan/remains";
 
     private readonly MinimaxProvider _provider;
 
@@ -215,7 +216,7 @@ public class MinimaxProviderTests : HttpProviderTestBase<MinimaxProvider>
         var definition = MinimaxProvider.StaticDefinition;
 
         Assert.Equal("minimax", definition.ProviderId); // provider-id-guardrail-allow: test assertion
-        Assert.Equal("Minimax (China)", definition.DisplayName);
+        Assert.Equal("MiniMax.chat", definition.DisplayName);
         Assert.True(definition.IsQuotaBased);
         Assert.Contains("MINIMAX_API_KEY", definition.DiscoveryEnvironmentVariables);
     }
@@ -242,7 +243,7 @@ public class MinimaxProviderTests : HttpProviderTestBase<MinimaxProvider>
         // Assert
         var usage = result.Single();
         Assert.Equal("minimax", usage.ProviderId); // provider-id-guardrail-allow: test assertion
-        Assert.Equal("Minimax (China)", usage.ProviderName);
+        Assert.Equal("MiniMax.chat", usage.ProviderName);
     }
 
     [Fact]
@@ -267,7 +268,7 @@ public class MinimaxProviderTests : HttpProviderTestBase<MinimaxProvider>
         // Assert
         var usage = result.Single();
         Assert.Equal("minimax-io", usage.ProviderId); // provider-id-guardrail-allow: test assertion
-        Assert.Equal("Minimax (International)", usage.ProviderName);
+        Assert.Equal("MiniMax.io", usage.ProviderName);
     }
 
     [Fact]
@@ -292,7 +293,7 @@ public class MinimaxProviderTests : HttpProviderTestBase<MinimaxProvider>
         // Assert
         var usage = result.Single();
         Assert.Equal("minimax-global", usage.ProviderId); // provider-id-guardrail-allow: test assertion
-        Assert.Equal("Minimax (International)", usage.ProviderName);
+        Assert.Equal("MiniMax.io", usage.ProviderName);
     }
 
     [Fact]
@@ -538,6 +539,155 @@ public class MinimaxProviderTests : HttpProviderTestBase<MinimaxProvider>
         // Assert
         var usage = result.Single();
         Assert.Equal(PlanType.Coding, usage.PlanType);
+    }
+
+    [Fact]
+    public async Task GetUsageAsync_WithCodingPlanProviderId_UsesCodingPlanEndpointAsync()
+    {
+        // Arrange
+        this.Config.ProviderId = MinimaxProvider.CodingPlanProviderId;
+        var responseJson = """
+            {
+                "base_resp": { "status_code": 0, "status_msg": "success" },
+                "model_remains": [
+                    {
+                        "model_name": "MiniMax-Text-01",
+                        "current_interval_total_count": 100,
+                        "current_interval_usage_count": 70,
+                        "end_time": 0,
+                        "current_weekly_total_count": 500,
+                        "current_weekly_usage_count": 400,
+                        "weekly_end_time": 0
+                    }
+                ]
+            }
+            """;
+
+        this.SetupResponse(HttpStatusCode.OK, responseJson, CodingPlanEndpoint);
+
+        // Act
+        var result = (await this._provider.GetUsageAsync(this.Config)).ToList();
+
+        // Assert — two cards: burst (5h) and weekly
+        Assert.Equal(2, result.Count);
+        var burst = result.Single(u => u.WindowKind == AIUsageTracker.Core.Models.WindowKind.Burst);
+        var weekly = result.Single(u => u.WindowKind == AIUsageTracker.Core.Models.WindowKind.Rolling);
+
+        // 5h: 30 used / 100 total = 30%
+        Assert.Equal(30, burst.UsedPercent);
+        Assert.Equal(30, burst.RequestsUsed);
+        Assert.Equal(100, burst.RequestsAvailable);
+        Assert.Equal("minimax-coding-plan", burst.ProviderId); // provider-id-guardrail-allow: test assertion
+        Assert.Equal("MiniMax Coding Plan", burst.ProviderName);
+
+        // Weekly: 100 used / 500 total = 20%
+        Assert.Equal(20, weekly.UsedPercent);
+        Assert.Equal(100, weekly.RequestsUsed);
+        Assert.Equal(500, weekly.RequestsAvailable);
+    }
+
+    [Fact]
+    public async Task GetUsageAsync_CodingPlan_ApiError_ReturnsUnavailableAsync()
+    {
+        // Arrange
+        this.Config.ProviderId = MinimaxProvider.CodingPlanProviderId;
+        this.SetupResponse(HttpStatusCode.Unauthorized, """{"error":"invalid_key"}""", CodingPlanEndpoint);
+
+        // Act
+        var result = await this._provider.GetUsageAsync(this.Config);
+
+        // Assert
+        var usage = result.Single();
+        Assert.False(usage.IsAvailable);
+        Assert.Contains("Unauthorized", usage.Description, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetUsageAsync_CodingPlan_NonZeroStatusCode_ReturnsUnavailableAsync()
+    {
+        // Arrange
+        this.Config.ProviderId = MinimaxProvider.CodingPlanProviderId;
+        var responseJson = """{"base_resp": {"status_code": 1004, "status_msg": "invalid api key"}}""";
+        this.SetupResponse(HttpStatusCode.OK, responseJson, CodingPlanEndpoint);
+
+        // Act
+        var result = await this._provider.GetUsageAsync(this.Config);
+
+        // Assert
+        var usage = result.Single();
+        Assert.False(usage.IsAvailable);
+        Assert.Contains("invalid api key", usage.Description, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetUsageAsync_CodingPlan_AtCapacity_Returns100PercentAsync()
+    {
+        // Arrange — remaining = 0, so 100% used
+        this.Config.ProviderId = MinimaxProvider.CodingPlanProviderId;
+        var responseJson = """
+            {
+                "base_resp": { "status_code": 0, "status_msg": "success" },
+                "model_remains": [
+                    {
+                        "model_name": "MiniMax-Text-01",
+                        "current_interval_total_count": 100,
+                        "current_interval_usage_count": 0,
+                        "end_time": 0,
+                        "current_weekly_total_count": 0,
+                        "current_weekly_usage_count": 0,
+                        "weekly_end_time": 0
+                    }
+                ]
+            }
+            """;
+        this.SetupResponse(HttpStatusCode.OK, responseJson, CodingPlanEndpoint);
+
+        // Act
+        var result = (await this._provider.GetUsageAsync(this.Config)).ToList();
+
+        // Assert — only burst card (weekly total = 0 so skipped)
+        var burst = result.Single();
+        Assert.Equal(100, burst.UsedPercent);
+        Assert.Equal(100, burst.RequestsUsed);
+    }
+
+    [Fact]
+    public async Task GetUsageAsync_CodingPlan_DisplayName_IsMiniMaxCodingPlanAsync()
+    {
+        // Arrange
+        this.Config.ProviderId = MinimaxProvider.CodingPlanProviderId;
+        var responseJson = """
+            {
+                "base_resp": { "status_code": 0, "status_msg": "success" },
+                "model_remains": [
+                    {
+                        "model_name": "MiniMax-Text-01",
+                        "current_interval_total_count": 100,
+                        "current_interval_usage_count": 50,
+                        "end_time": 0,
+                        "current_weekly_total_count": 0,
+                        "current_weekly_usage_count": 0,
+                        "weekly_end_time": 0
+                    }
+                ]
+            }
+            """;
+        this.SetupResponse(HttpStatusCode.OK, responseJson, CodingPlanEndpoint);
+
+        // Act
+        var result = await this._provider.GetUsageAsync(this.Config);
+
+        // Assert
+        Assert.All(result, u => Assert.Equal("MiniMax Coding Plan", u.ProviderName));
+    }
+
+    [Fact]
+    public void StaticDefinition_CodingPlan_IsInAdditionalHandledProviderIds()
+    {
+        var definition = MinimaxProvider.StaticDefinition;
+        Assert.Contains(MinimaxProvider.CodingPlanProviderId, definition.AdditionalHandledProviderIds);
+        Assert.Contains(MinimaxProvider.CodingPlanProviderId, definition.SettingsAdditionalProviderIds);
+        Assert.Equal("MiniMax Coding Plan", definition.DisplayNameOverrides[MinimaxProvider.CodingPlanProviderId]);
     }
 
     private void SetupResponse(HttpStatusCode statusCode, string content, string? url = null)

--- a/AIUsageTracker.Tests/Services/CachedGroupedUsageProjectionServiceTests.cs
+++ b/AIUsageTracker.Tests/Services/CachedGroupedUsageProjectionServiceTests.cs
@@ -1,0 +1,82 @@
+// <copyright file="CachedGroupedUsageProjectionServiceTests.cs" company="AIUsageTracker">
+// Copyright (c) AIUsageTracker. All rights reserved.
+// </copyright>
+
+using AIUsageTracker.Core.Models;
+using AIUsageTracker.Monitor.Services;
+using Moq;
+
+namespace AIUsageTracker.Tests.Services;
+
+public sealed class CachedGroupedUsageProjectionServiceTests
+{
+    [Fact]
+    public async Task GetGroupedUsage_ExcludesUnconfiguredStandardApiKeyProviders_FromSnapshot()
+    {
+        // Providers that are StandardApiKey mode with no API key (e.g. OpenRouter, Xiaomi when
+        // unconfigured) must not appear in the main-window snapshot even if they have stale
+        // history rows in the database, because the database never persists State and those
+        // rows always deserialise with State=Available.
+        var dbUsages = new List<ProviderUsage>
+        {
+            // openrouter row with no state info (as it comes from the DB)
+            new() { ProviderId = "openrouter", ProviderName = "OpenRouter", IsAvailable = false, Description = "API Key missing." },
+            // A configured provider that should appear
+            new() { ProviderId = "mistral", ProviderName = "Mistral", IsAvailable = true, UsedPercent = 20 },
+        };
+
+        var configs = new List<ProviderConfig>
+        {
+            // openrouter has no API key → unconfigured StandardApiKey provider
+            new() { ProviderId = "openrouter", ApiKey = string.Empty },
+            // mistral has a key → should appear
+            new() { ProviderId = "mistral", ApiKey = "sk-test-key" },
+        };
+
+        var mockDb = new Mock<IUsageDatabase>();
+        mockDb.Setup(d => d.GetLatestHistoryAsync()).ReturnsAsync(dbUsages);
+
+        var mockConfig = new Mock<IConfigService>();
+        mockConfig.Setup(c => c.GetConfigsAsync()).ReturnsAsync(configs);
+
+        var service = new CachedGroupedUsageProjectionService(mockDb.Object, mockConfig.Object);
+
+        var snapshot = await service.GetGroupedUsageAsync().ConfigureAwait(false);
+
+        // OpenRouter must not be in the snapshot
+        Assert.DoesNotContain(snapshot.Providers, p =>
+            string.Equals(p.ProviderId, "openrouter", StringComparison.OrdinalIgnoreCase));
+
+        // Mistral must still be present
+        Assert.Contains(snapshot.Providers, p =>
+            string.Equals(p.ProviderId, "mistral", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task GetGroupedUsage_IncludesStandardApiKeyProviders_WhenApiKeyIsConfigured()
+    {
+        // A StandardApiKey provider WITH a key should appear in the snapshot normally.
+        var dbUsages = new List<ProviderUsage>
+        {
+            new() { ProviderId = "openrouter", ProviderName = "OpenRouter", IsAvailable = true, UsedPercent = 50 },
+        };
+
+        var configs = new List<ProviderConfig>
+        {
+            new() { ProviderId = "openrouter", ApiKey = "sk-or-real-key" },
+        };
+
+        var mockDb = new Mock<IUsageDatabase>();
+        mockDb.Setup(d => d.GetLatestHistoryAsync()).ReturnsAsync(dbUsages);
+
+        var mockConfig = new Mock<IConfigService>();
+        mockConfig.Setup(c => c.GetConfigsAsync()).ReturnsAsync(configs);
+
+        var service = new CachedGroupedUsageProjectionService(mockDb.Object, mockConfig.Object);
+
+        var snapshot = await service.GetGroupedUsageAsync().ConfigureAwait(false);
+
+        Assert.Contains(snapshot.Providers, p =>
+            string.Equals(p.ProviderId, "openrouter", StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/AIUsageTracker.Tests/Services/CachedGroupedUsageProjectionServiceTests.cs
+++ b/AIUsageTracker.Tests/Services/CachedGroupedUsageProjectionServiceTests.cs
@@ -34,7 +34,11 @@ public sealed class CachedGroupedUsageProjectionServiceTests
         };
 
         var mockDb = new Mock<IUsageDatabase>();
-        mockDb.Setup(d => d.GetLatestHistoryAsync()).ReturnsAsync(dbUsages);
+        mockDb.Setup(d => d.GetLatestHistoryAsync(It.IsAny<IReadOnlyCollection<string>?>()))
+            .Returns((IReadOnlyCollection<string>? ids) => Task.FromResult<IReadOnlyList<ProviderUsage>>(
+                ids == null ? dbUsages : dbUsages
+                    .Where(u => ids.Contains(u.ProviderId ?? string.Empty, StringComparer.OrdinalIgnoreCase))
+                    .ToList()));
 
         var mockConfig = new Mock<IConfigService>();
         mockConfig.Setup(c => c.GetConfigsAsync()).ReturnsAsync(configs);
@@ -67,7 +71,11 @@ public sealed class CachedGroupedUsageProjectionServiceTests
         };
 
         var mockDb = new Mock<IUsageDatabase>();
-        mockDb.Setup(d => d.GetLatestHistoryAsync()).ReturnsAsync(dbUsages);
+        mockDb.Setup(d => d.GetLatestHistoryAsync(It.IsAny<IReadOnlyCollection<string>?>()))
+            .Returns((IReadOnlyCollection<string>? ids) => Task.FromResult<IReadOnlyList<ProviderUsage>>(
+                ids == null ? dbUsages : dbUsages
+                    .Where(u => ids.Contains(u.ProviderId ?? string.Empty, StringComparer.OrdinalIgnoreCase))
+                    .ToList()));
 
         var mockConfig = new Mock<IConfigService>();
         mockConfig.Setup(c => c.GetConfigsAsync()).ReturnsAsync(configs);
@@ -108,7 +116,11 @@ public sealed class CachedGroupedUsageProjectionServiceTests
         };
 
         var mockDb = new Mock<IUsageDatabase>();
-        mockDb.Setup(d => d.GetLatestHistoryAsync()).ReturnsAsync(dbUsages);
+        mockDb.Setup(d => d.GetLatestHistoryAsync(It.IsAny<IReadOnlyCollection<string>?>()))
+            .Returns((IReadOnlyCollection<string>? ids) => Task.FromResult<IReadOnlyList<ProviderUsage>>(
+                ids == null ? dbUsages : dbUsages
+                    .Where(u => ids.Contains(u.ProviderId ?? string.Empty, StringComparer.OrdinalIgnoreCase))
+                    .ToList()));
 
         var mockConfig = new Mock<IConfigService>();
         mockConfig.Setup(c => c.GetConfigsAsync()).ReturnsAsync(configs);

--- a/AIUsageTracker.Tests/Services/CachedGroupedUsageProjectionServiceTests.cs
+++ b/AIUsageTracker.Tests/Services/CachedGroupedUsageProjectionServiceTests.cs
@@ -79,4 +79,53 @@ public sealed class CachedGroupedUsageProjectionServiceTests
         Assert.Contains(snapshot.Providers, p =>
             string.Equals(p.ProviderId, "openrouter", StringComparison.OrdinalIgnoreCase));
     }
+
+    [Fact]
+    public async Task GetGroupedUsage_SubProvider_WithKey_IsNotHiddenByUnconfiguredSibling()
+    {
+        // Regression: the canonical-ID filter incorrectly hid all sub-providers of a
+        // family when any sibling had an empty key. E.g. minimax (China, no key) and
+        // minimax-io (International, has key) share canonical ID "minimax". The old code
+        // put "minimax" in the exclusion set and then checked GetCanonicalProviderId on
+        // each usage row — so minimax-io usage (also canonical "minimax") was filtered out
+        // even though the user had a key configured for it.
+        //
+        // Note: GroupedUsageProjectionService.Build groups by canonical ID, so the output
+        // snapshot has ProviderId = "minimax" (the canonical) whether the data came from
+        // minimax or minimax-io. The key assertion is that the MiniMax family appears and
+        // reflects the configured (minimax-io) data — i.e. IsAvailable = true — not the
+        // "API Key not found" data from the unconfigured minimax entry.
+        var dbUsages = new List<ProviderUsage>
+        {
+            new() { ProviderId = "minimax", ProviderName = "MiniMax.chat", IsAvailable = false, Description = "API Key not found." },
+            new() { ProviderId = "minimax-io", ProviderName = "MiniMax.io", IsAvailable = true, UsedPercent = 30 },
+        };
+
+        var configs = new List<ProviderConfig>
+        {
+            new() { ProviderId = "minimax", ApiKey = string.Empty },         // no key — usage row must be excluded
+            new() { ProviderId = "minimax-io", ApiKey = "sk-minimax-key" },  // has key — usage row must survive
+        };
+
+        var mockDb = new Mock<IUsageDatabase>();
+        mockDb.Setup(d => d.GetLatestHistoryAsync()).ReturnsAsync(dbUsages);
+
+        var mockConfig = new Mock<IConfigService>();
+        mockConfig.Setup(c => c.GetConfigsAsync()).ReturnsAsync(configs);
+
+        var service = new CachedGroupedUsageProjectionService(mockDb.Object, mockConfig.Object);
+
+        var snapshot = await service.GetGroupedUsageAsync().ConfigureAwait(false);
+
+        // The MiniMax family (canonical "minimax") must appear — minimax-io has a key.
+        var minimaxGroup = snapshot.Providers
+            .FirstOrDefault(p => string.Equals(p.ProviderId, "minimax", StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(minimaxGroup);
+
+        // The group must reflect the minimax-io data (available, 30% used),
+        // not the "API Key not found" data from the unconfigured minimax entry.
+        Assert.True(minimaxGroup.IsAvailable,
+            "MiniMax group should be available because minimax-io has a key; " +
+            "the unconfigured minimax entry must have been excluded before Build.");
+    }
 }

--- a/AIUsageTracker.Tests/Services/UsageDatabaseReadTests.cs
+++ b/AIUsageTracker.Tests/Services/UsageDatabaseReadTests.cs
@@ -63,6 +63,53 @@ public sealed class UsageDatabaseReadTests : IDisposable
     }
 
     [Fact]
+    public async Task GetLatestHistoryAsync_WithProviderIds_ReturnsOnlyRequestedProvidersAsync()
+    {
+        var db = await this.CreateDatabaseAsync();
+        var now = DateTime.UtcNow.AddMinutes(-1);
+
+        await db.StoreHistoryAsync([
+            MakeUsage("codex", fetchedAt: now),
+            MakeUsage("mistral", fetchedAt: now),
+            MakeUsage("antigravity", fetchedAt: now),
+        ]);
+
+        var results = await db.GetLatestHistoryAsync(new[] { "codex", "antigravity" });
+
+        Assert.Contains(results, u => string.Equals(u.ProviderId, "codex", StringComparison.Ordinal));
+        Assert.Contains(results, u => string.Equals(u.ProviderId, "antigravity", StringComparison.Ordinal));
+        Assert.DoesNotContain(results, u => string.Equals(u.ProviderId, "mistral", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task GetLatestHistoryAsync_WithEmptyProviderIds_ReturnsEmptyAsync()
+    {
+        var db = await this.CreateDatabaseAsync();
+        await db.StoreHistoryAsync([MakeUsage("codex", fetchedAt: DateTime.UtcNow.AddMinutes(-1))]);
+
+        var results = await db.GetLatestHistoryAsync(Array.Empty<string>());
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public async Task GetLatestHistoryAsync_WithNullProviderIds_ReturnsAllProvidersAsync()
+    {
+        var db = await this.CreateDatabaseAsync();
+        var now = DateTime.UtcNow.AddMinutes(-1);
+
+        await db.StoreHistoryAsync([
+            MakeUsage("codex", fetchedAt: now),
+            MakeUsage("mistral", fetchedAt: now),
+        ]);
+
+        var results = await db.GetLatestHistoryAsync(null);
+
+        Assert.Contains(results, u => string.Equals(u.ProviderId, "codex", StringComparison.Ordinal));
+        Assert.Contains(results, u => string.Equals(u.ProviderId, "mistral", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task GetLatestHistoryAsync_RowOlderThan24h_IsExcludedFromResultsAsync()
     {
         // Rows older than 24 h are excluded at the SQL level — the provider must not appear at all.

--- a/AIUsageTracker.Tests/UI/GroupedUsageDisplayAdapterTests.cs
+++ b/AIUsageTracker.Tests/UI/GroupedUsageDisplayAdapterTests.cs
@@ -707,4 +707,33 @@ public class GroupedUsageDisplayAdapterTests
         Assert.Equal(TimeSpan.FromDays(7), sonnet.PeriodDuration);
         Assert.Equal(TimeSpan.FromDays(7), allModels.PeriodDuration);
     }
+
+    [Fact]
+    public void Expand_LegacyPath_PropagatesStateFromSnapshot()
+    {
+        // Verifies that State=Missing survives the AgentGroupedProviderUsage → ProviderUsage
+        // conversion, so PrepareForMainWindow can filter unconfigured StandardApiKey providers.
+        var snapshot = new AgentGroupedUsageSnapshot
+        {
+            Providers = new[]
+            {
+                new AgentGroupedProviderUsage
+                {
+                    ProviderId = "openrouter",
+                    IsAvailable = false,
+                    State = ProviderUsageState.Missing,
+                    IsQuotaBased = true,
+                    PlanType = PlanType.Usage,
+                    Description = "API Key missing",
+                    Models = Array.Empty<AgentGroupedModelUsage>(),
+                },
+            },
+        };
+
+        var usages = GroupedUsageDisplayAdapter.Expand(snapshot);
+
+        var card = Assert.Single(usages);
+        Assert.Equal("openrouter", card.ProviderId);
+        Assert.Equal(ProviderUsageState.Missing, card.State);
+    }
 }

--- a/AIUsageTracker.Tests/UI/ProviderCardSlotRenderingTests.cs
+++ b/AIUsageTracker.Tests/UI/ProviderCardSlotRenderingTests.cs
@@ -146,4 +146,35 @@ public sealed class ProviderCardSlotRenderingTests
         var deserialized = AppPreferences.Deserialize(json);
         Assert.Equal(CardSlotContent.ProjectedPercent, deserialized.CardPrimaryBadge);
     }
+
+    /// <summary>
+    /// Verifies that <see cref="AppPreferences.ShowUsedPercentages"/> is the canonical source
+    /// of truth for the display mode, not any UI toggle's visual state.
+    ///
+    /// Prior bug: MainWindow.AddProviderCard read ShowUsedToggle.IsChecked directly. When
+    /// Settings closed quickly (within the 600ms debounce window), the async void Closing
+    /// handler suspended at the first await, ShowDialog() returned null, and the main window
+    /// skipped ApplyPreferencesFromSettings() — leaving ShowUsedToggle out of sync with the
+    /// updated preference. Rendering then used the stale toggle state instead of the preference.
+    /// </summary>
+    [Fact]
+    public void PercentageDisplayMode_IsTruthForShowUsed_RoundTripsCorrectly()
+    {
+        var prefs = new AppPreferences { ShowUsedPercentages = false };
+        Assert.Equal(PercentageDisplayMode.Remaining, prefs.PercentageDisplayMode);
+        Assert.False(prefs.ShowUsedPercentages);
+
+        prefs.ShowUsedPercentages = true;
+        Assert.Equal(PercentageDisplayMode.Used, prefs.PercentageDisplayMode);
+        Assert.True(prefs.ShowUsedPercentages);
+
+        // Round-trip: serialized as PercentageDisplayMode (ShowUsedPercentages is [JsonIgnore])
+        var json = System.Text.Json.JsonSerializer.Serialize(prefs);
+        Assert.Contains("\"Used\"", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("ShowUsedPercentages", json, StringComparison.Ordinal);
+
+        var reloaded = AppPreferences.Deserialize(json);
+        Assert.True(reloaded.ShowUsedPercentages);
+        Assert.Equal(PercentageDisplayMode.Used, reloaded.PercentageDisplayMode);
+    }
 }

--- a/AIUsageTracker.Tests/UI/ProviderKeyDeletionEndToEndTests.cs
+++ b/AIUsageTracker.Tests/UI/ProviderKeyDeletionEndToEndTests.cs
@@ -11,8 +11,9 @@ namespace AIUsageTracker.Tests.UI;
 /// <summary>
 /// End-to-end tests for provider key deletion behavior.
 /// Settings always shows all provider cards (they are configuration slots).
-/// The main window hides Missing-state cards for StandardApiKey providers
-/// so deleted/unconfigured providers don't clutter the UI.
+/// The monitor snapshot (CachedGroupedUsageProjectionService) excludes unconfigured
+/// StandardApiKey providers so they never reach the main window; see
+/// CachedGroupedUsageProjectionServiceTests for those assertions.
 /// </summary>
 public sealed class ProviderKeyDeletionEndToEndTests
 {
@@ -68,28 +69,15 @@ public sealed class ProviderKeyDeletionEndToEndTests
     }
 
     // ───────────────────────────────────────────────────────────
-    //  Main window: Missing-state StandardApiKey cards are hidden
+    //  Main window: state does not affect visibility (filtering
+    //  of unconfigured providers happens upstream in the monitor)
     // ───────────────────────────────────────────────────────────
-
-    [Fact]
-    public void MainWindow_HidesMissingState_ForStandardApiKeyProviders()
-    {
-        var usages = new List<ProviderUsage>
-        {
-            CreateUsage("synthetic", isAvailable: false, state: ProviderUsageState.Missing, description: "API Key missing"),
-            CreateUsage("codex", isAvailable: true, description: "OK"),
-        };
-
-        var items = MainWindowRuntimeLogic.PrepareForMainWindow(usages);
-
-        Assert.DoesNotContain(items, item => item.ProviderId == "synthetic");
-        Assert.Contains(items, item => item.ProviderId == "codex");
-    }
 
     [Fact]
     public void MainWindow_ShowsMissingState_ForSessionAuthProviders()
     {
-        // GitHub Copilot uses ExternalAuthStatus — "Not authenticated" is useful info
+        // GitHub Copilot uses ExternalAuthStatus — "Not authenticated" is useful info.
+        // PrepareForMainWindow imposes no state filter; it renders whatever the monitor snapshot contains.
         var usages = new List<ProviderUsage>
         {
             CreateUsage("github-copilot", isAvailable: false, state: ProviderUsageState.Missing, description: "Not authenticated"),
@@ -138,38 +126,6 @@ public sealed class ProviderKeyDeletionEndToEndTests
         var items = MainWindowRuntimeLogic.PrepareForMainWindow(usages, new[] { "synthetic" });
 
         Assert.DoesNotContain(items, item => item.ProviderId == "synthetic");
-    }
-
-    [Fact]
-    public void MainWindow_MultipleProviders_OnlyStandardApiKeyMissingHidden()
-    {
-        var usages = new List<ProviderUsage>
-        {
-            CreateUsage("synthetic", isAvailable: false, state: ProviderUsageState.Missing),
-            CreateUsage("mistral", isAvailable: false, state: ProviderUsageState.Missing),
-            CreateUsage("github-copilot", isAvailable: false, state: ProviderUsageState.Missing),
-            CreateUsage("codex", isAvailable: true),
-        };
-
-        var items = MainWindowRuntimeLogic.PrepareForMainWindow(usages);
-
-        Assert.DoesNotContain(items, item => item.ProviderId == "synthetic");
-        Assert.DoesNotContain(items, item => item.ProviderId == "mistral");
-        Assert.Contains(items, item => item.ProviderId == "github-copilot");
-        Assert.Contains(items, item => item.ProviderId == "codex");
-    }
-
-    [Fact]
-    public void MainWindow_RenderPlan_MissingStandardApiKey_ZeroRendered()
-    {
-        var usages = new List<ProviderUsage>
-        {
-            CreateUsage("synthetic", isAvailable: false, state: ProviderUsageState.Missing),
-        };
-
-        var plan = MainWindowRuntimeLogic.BuildProviderRenderPlan(usages, null);
-
-        Assert.Equal(0, plan.RenderedCount);
     }
 
     [Fact]
@@ -251,22 +207,18 @@ public sealed class ProviderKeyDeletionEndToEndTests
     }
 
     [Fact]
-    public void MainWindow_HidesMissing_ButShowsExpired_ForSameProvider()
+    public void MainWindow_ShowsExpired_WhenSubscriptionLapsed()
     {
-        // Missing = key deleted → hidden. Expired = key present, sub lapsed → visible.
-        var missingUsages = new List<ProviderUsage>
-        {
-            CreateUsage("synthetic", isAvailable: false, state: ProviderUsageState.Missing, description: "API Key missing"),
-        };
+        // Expired = key present but subscription lapsed → card must remain visible so the
+        // user can see their quota is exhausted. Filtering of Missing (no key) happens
+        // upstream in CachedGroupedUsageProjectionService, not here.
         var expiredUsages = new List<ProviderUsage>
         {
             CreateUsage("synthetic", isAvailable: false, state: ProviderUsageState.Expired, description: "No active subscription"),
         };
 
-        var missingItems = MainWindowRuntimeLogic.PrepareForMainWindow(missingUsages);
         var expiredItems = MainWindowRuntimeLogic.PrepareForMainWindow(expiredUsages);
 
-        Assert.DoesNotContain(missingItems, item => item.ProviderId == "synthetic");
         Assert.Contains(expiredItems, item => item.ProviderId == "synthetic");
     }
 

--- a/AIUsageTracker.Tests/UI/ProviderSettingsDisplayCatalogTests.cs
+++ b/AIUsageTracker.Tests/UI/ProviderSettingsDisplayCatalogTests.cs
@@ -52,7 +52,7 @@ public sealed class ProviderSettingsDisplayCatalogTests
     {
         var configs = new List<ProviderConfig>
         {
-            new() { ProviderId = "xiaomi" },
+            new() { ProviderId = "minimax" },
             new() { ProviderId = "codex" },
             new() { ProviderId = "opencode-zen" },
         };
@@ -60,8 +60,8 @@ public sealed class ProviderSettingsDisplayCatalogTests
         var items = SettingsWindow.CreateProviderDisplayItems(configs, Array.Empty<ProviderUsage>());
 
         Assert.Equal(
-            new[] { "codex", "opencode-zen", "xiaomi" },
-            items.Where(item => new[] { "codex", "opencode-zen", "xiaomi" }.Contains(item.Config.ProviderId, StringComparer.Ordinal))
+            new[] { "minimax", "codex", "opencode-zen" },
+            items.Where(item => new[] { "codex", "minimax", "opencode-zen" }.Contains(item.Config.ProviderId, StringComparer.Ordinal))
                 .Select(item => item.Config.ProviderId)
                 .ToArray());
     }

--- a/AIUsageTracker.Tests/UI/ProviderUsageDisplayCatalogTests.cs
+++ b/AIUsageTracker.Tests/UI/ProviderUsageDisplayCatalogTests.cs
@@ -210,6 +210,24 @@ public sealed class ProviderUsageDisplayCatalogTests
         // The preferred entry has NextResetTime set
         Assert.NotNull(gemini.NextResetTime);
     }
+
+    [Fact]
+    public void PrepareForMainWindow_HidesStandardApiKeyProviders_WhenStateIsMissing()
+    {
+        // openrouter and xiaomi are StandardApiKey providers.
+        // When State=Missing (no API key configured), they must not appear in the main window.
+        var usages = new List<ProviderUsage>
+        {
+            new() { ProviderId = "synthetic", IsAvailable = true, State = ProviderUsageState.Available },
+            new() { ProviderId = "openrouter", IsAvailable = false, State = ProviderUsageState.Missing },
+            new() { ProviderId = "xiaomi", IsAvailable = false, State = ProviderUsageState.Missing },
+        };
+
+        var preparation = MainWindowRuntimeLogic.PrepareForMainWindow(usages);
+
+        var syntheticItem = Assert.Single(preparation);
+        Assert.Equal("synthetic", syntheticItem.ProviderId);
+    }
 }
 
 

--- a/AIUsageTracker.Tests/UI/ProviderUsageDisplayCatalogTests.cs
+++ b/AIUsageTracker.Tests/UI/ProviderUsageDisplayCatalogTests.cs
@@ -211,23 +211,6 @@ public sealed class ProviderUsageDisplayCatalogTests
         Assert.NotNull(gemini.NextResetTime);
     }
 
-    [Fact]
-    public void PrepareForMainWindow_HidesStandardApiKeyProviders_WhenStateIsMissing()
-    {
-        // openrouter and xiaomi are StandardApiKey providers.
-        // When State=Missing (no API key configured), they must not appear in the main window.
-        var usages = new List<ProviderUsage>
-        {
-            new() { ProviderId = "synthetic", IsAvailable = true, State = ProviderUsageState.Available },
-            new() { ProviderId = "openrouter", IsAvailable = false, State = ProviderUsageState.Missing },
-            new() { ProviderId = "xiaomi", IsAvailable = false, State = ProviderUsageState.Missing },
-        };
-
-        var preparation = MainWindowRuntimeLogic.PrepareForMainWindow(usages);
-
-        var syntheticItem = Assert.Single(preparation);
-        Assert.Equal("synthetic", syntheticItem.ProviderId);
-    }
 }
 
 

--- a/AIUsageTracker.UI.Slim/LegacyParentCardBuilder.cs
+++ b/AIUsageTracker.UI.Slim/LegacyParentCardBuilder.cs
@@ -22,6 +22,7 @@ internal static class LegacyParentCardBuilder
             ProviderName = ProviderMetadataCatalog.GetConfiguredDisplayName(provider.ProviderId),
             AccountName = provider.AccountName,
             IsAvailable = provider.IsAvailable,
+            State = provider.State,
             PlanType = provider.PlanType,
             IsQuotaBased = provider.IsQuotaBased,
             RequestsUsed = provider.RequestsUsed,

--- a/AIUsageTracker.UI.Slim/MainWindow.Rendering.cs
+++ b/AIUsageTracker.UI.Slim/MainWindow.Rendering.cs
@@ -300,7 +300,10 @@ public partial class MainWindow : Window
 
     private void AddProviderCard(ProviderUsage usage, StackPanel container, ProviderCardRenderer cardRenderer, bool isChild = false)
     {
-        var showUsed = this.ShowUsedToggle?.IsChecked ?? false;
+        // Read from preferences (the authoritative source) rather than the toggle's
+        // visual state, which can lag behind when Settings closes without the main window
+        // applying the updated preferences (e.g. quick close within the debounce window).
+        var showUsed = this._preferences.ShowUsedPercentages;
         var definition = ProviderMetadataCatalog.Find(usage.ProviderId ?? string.Empty);
         var card = cardRenderer.CreateProviderCard(usage, showUsed, isChild, definition);
 

--- a/AIUsageTracker.UI.Slim/MainWindowRuntimeLogic.cs
+++ b/AIUsageTracker.UI.Slim/MainWindowRuntimeLogic.cs
@@ -149,14 +149,6 @@ internal static partial class MainWindowRuntimeLogic
                     return false;
                 }
 
-                // Hide Missing-state cards for StandardApiKey providers.
-                // These show "API Key missing" which is not actionable in the main window.
-                if (usage.State == ProviderUsageState.Missing &&
-                    definition.SettingsMode == ProviderSettingsMode.StandardApiKey)
-                {
-                    return false;
-                }
-
                 return true;
             })
             .GroupBy(usage => $"{usage.ProviderId ?? string.Empty}::{usage.CardId ?? string.Empty}", StringComparer.OrdinalIgnoreCase)

--- a/AIUsageTracker.UI.Slim/SettingsWindow.Providers.cs
+++ b/AIUsageTracker.UI.Slim/SettingsWindow.Providers.cs
@@ -2,6 +2,8 @@
 // Copyright (c) AIUsageTracker. All rights reserved.
 // </copyright>
 
+using System.Diagnostics;
+using System.IO;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -639,9 +641,13 @@ public partial class SettingsWindow
         sourceLine.Inlines.Add(new System.Windows.Documents.Run(sourceLabel));
         panel.Children.Add(sourceLine);
 
-        // File path lines (one per path, selectable for copy)
+        // File path lines (one per path, selectable for copy + open button)
         foreach (var path in paths)
         {
+            var row = new Grid { Margin = new Thickness(0, 0, 0, 1) };
+            row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+            row.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
             var pathBox = new TextBox
             {
                 Text = path,
@@ -650,13 +656,30 @@ public partial class SettingsWindow
                 BorderThickness = new Thickness(0),
                 Background = System.Windows.Media.Brushes.Transparent,
                 Padding = new Thickness(0),
-                Margin = new Thickness(0, 0, 0, 1),
+                Margin = new Thickness(0, 0, 4, 0),
                 TextWrapping = TextWrapping.NoWrap,
                 HorizontalScrollBarVisibility = ScrollBarVisibility.Hidden,
                 ToolTip = path,
+                VerticalAlignment = VerticalAlignment.Center,
             };
             pathBox.SetResourceReference(TextBox.ForegroundProperty, "TertiaryText");
-            panel.Children.Add(pathBox);
+            Grid.SetColumn(pathBox, 0);
+            row.Children.Add(pathBox);
+
+            var openButton = new Button
+            {
+                Content = "Open",
+                FontSize = 8,
+                Padding = new Thickness(4, 1, 4, 1),
+                VerticalAlignment = VerticalAlignment.Center,
+                ToolTip = File.Exists(path) ? $"Open {path}" : $"Open folder containing {path}",
+            };
+            var capturedPath = path;
+            openButton.Click += (_, _) => OpenPathInExplorer(capturedPath);
+            Grid.SetColumn(openButton, 1);
+            row.Children.Add(openButton);
+
+            panel.Children.Add(row);
         }
 
         // Removal hint
@@ -675,6 +698,39 @@ public partial class SettingsWindow
         }
 
         return panel;
+    }
+
+    private static void OpenPathInExplorer(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = "explorer.exe",
+                    Arguments = $"/select,\"{path}\"",
+                    UseShellExecute = true,
+                });
+            }
+            else
+            {
+                var dir = Path.GetDirectoryName(path);
+                if (!string.IsNullOrEmpty(dir))
+                {
+                    Process.Start(new ProcessStartInfo
+                    {
+                        FileName = "explorer.exe",
+                        Arguments = $"\"{dir}\"",
+                        UseShellExecute = true,
+                    });
+                }
+            }
+        }
+        catch (Exception ex) when (ex is System.IO.IOException or InvalidOperationException or System.ComponentModel.Win32Exception)
+        {
+            // If shell open fails, silently ignore — the path is still selectable for manual navigation.
+        }
     }
 
     private static (string? SourceLabel, string? RemovalHint, IReadOnlyList<string> Paths) ResolveAuthSourceDisplay(string? authSource)

--- a/AIUsageTracker.UI.Slim/SettingsWindow.Providers.cs
+++ b/AIUsageTracker.UI.Slim/SettingsWindow.Providers.cs
@@ -605,41 +605,150 @@ public partial class SettingsWindow
             };
         }
 
-        var authSourceLabel = BuildAuthSourceLabel(config.AuthSource);
-        if (authSourceLabel == null)
+        var authSourcePanel = BuildAuthSourcePanel(config.AuthSource);
+        if (authSourcePanel == null)
         {
             return keyBox;
         }
 
         var panel = new StackPanel();
         panel.Children.Add(keyBox);
-        panel.Children.Add(authSourceLabel);
+        panel.Children.Add(authSourcePanel);
         return panel;
     }
 
-    private static TextBlock? BuildAuthSourceLabel(string? authSource)
+    private static FrameworkElement? BuildAuthSourcePanel(string? authSource)
     {
-        if (string.IsNullOrWhiteSpace(authSource))
+        var (sourceLabel, removalHint, paths) = ResolveAuthSourceDisplay(authSource);
+        if (sourceLabel == null)
         {
             return null;
         }
 
-        // Only show for external sources where the user needs to know the origin.
-        if (!AuthSource.IsRooOrKilo(authSource) && !AuthSource.IsEnvironment(authSource))
-        {
-            return null;
-        }
+        var panel = new StackPanel { Margin = new Thickness(0, 4, 0, 0) };
 
-        var label = new TextBlock
+        // Source line
+        var sourceLine = new TextBlock
         {
-            Text = $"Source: {authSource}",
             FontSize = 9,
-            FontStyle = FontStyles.Italic,
-            Margin = new Thickness(0, 2, 0, 0),
+            Margin = new Thickness(0, 0, 0, 1),
             TextTrimming = TextTrimming.CharacterEllipsis,
         };
-        label.SetResourceReference(TextBlock.ForegroundProperty, "TertiaryText");
-        return label;
+        sourceLine.SetResourceReference(TextBlock.ForegroundProperty, "TertiaryText");
+        sourceLine.Inlines.Add(new System.Windows.Documents.Run("Source: ") { FontWeight = FontWeights.SemiBold });
+        sourceLine.Inlines.Add(new System.Windows.Documents.Run(sourceLabel));
+        panel.Children.Add(sourceLine);
+
+        // File path lines (one per path, selectable for copy)
+        foreach (var path in paths)
+        {
+            var pathBox = new TextBox
+            {
+                Text = path,
+                FontSize = 8,
+                IsReadOnly = true,
+                BorderThickness = new Thickness(0),
+                Background = System.Windows.Media.Brushes.Transparent,
+                Padding = new Thickness(0),
+                Margin = new Thickness(0, 0, 0, 1),
+                TextWrapping = TextWrapping.NoWrap,
+                HorizontalScrollBarVisibility = ScrollBarVisibility.Hidden,
+                ToolTip = path,
+            };
+            pathBox.SetResourceReference(TextBox.ForegroundProperty, "TertiaryText");
+            panel.Children.Add(pathBox);
+        }
+
+        // Removal hint
+        if (!string.IsNullOrEmpty(removalHint))
+        {
+            var hintLine = new TextBlock
+            {
+                Text = $"To remove: {removalHint}",
+                FontSize = 9,
+                FontStyle = FontStyles.Italic,
+                Margin = new Thickness(0, 2, 0, 0),
+                TextWrapping = TextWrapping.Wrap,
+            };
+            hintLine.SetResourceReference(TextBlock.ForegroundProperty, "TertiaryText");
+            panel.Children.Add(hintLine);
+        }
+
+        return panel;
+    }
+
+    private static (string? SourceLabel, string? RemovalHint, IReadOnlyList<string> Paths) ResolveAuthSourceDisplay(string? authSource)
+    {
+        if (string.IsNullOrWhiteSpace(authSource) ||
+            string.Equals(authSource, AuthSource.None, StringComparison.OrdinalIgnoreCase))
+        {
+            return (null, null, Array.Empty<string>());
+        }
+
+        // Environment variable
+        if (AuthSource.TryParseEnvironmentVariable(authSource, out var varName))
+        {
+            return (
+                $"Environment variable {varName}",
+                $"Delete the {varName} environment variable from System Properties → Environment Variables, then restart.",
+                Array.Empty<string>());
+        }
+
+        // Roo Code
+        if (AuthSource.TryParseRooPath(authSource, out var rooPath))
+        {
+            return (
+                "Roo Code",
+                "Edit or delete the file below to remove the key from Roo Code.",
+                new[] { rooPath });
+        }
+
+        // Kilo Code
+        if (AuthSource.IsRooOrKilo(authSource))
+        {
+            return (
+                "Kilo Code",
+                "Remove the key from Kilo Code settings.",
+                Array.Empty<string>());
+        }
+
+        // Config file(s) — show full paths
+        var configPaths = AuthSource.ParseConfigFilePaths(authSource);
+        if (configPaths.Count > 0)
+        {
+            // Determine human-readable source application from paths
+            var appName = ResolveConfigSourceAppName(configPaths);
+            return (
+                appName,
+                "Edit or delete the file(s) below, or clear the key field above and save.",
+                configPaths);
+        }
+
+        // Fallback for other known constants (OpenCode Session, Codex Native, etc.)
+        return (authSource, null, Array.Empty<string>());
+    }
+
+    private static string ResolveConfigSourceAppName(IReadOnlyList<string> paths)
+    {
+        foreach (var path in paths)
+        {
+            if (path.Contains("opencode", StringComparison.OrdinalIgnoreCase))
+            {
+                return "OpenCode";
+            }
+
+            if (path.Contains("roo", StringComparison.OrdinalIgnoreCase))
+            {
+                return "Roo Code";
+            }
+
+            if (path.Contains("kilo", StringComparison.OrdinalIgnoreCase))
+            {
+                return "Kilo Code";
+            }
+        }
+
+        return "Config file";
     }
 
     private static string GetDisplayApiKey(string? apiKey, bool isPrivacyMode)

--- a/AIUsageTracker.UI.Slim/SettingsWindow.Providers.cs
+++ b/AIUsageTracker.UI.Slim/SettingsWindow.Providers.cs
@@ -636,16 +636,22 @@ public partial class SettingsWindow
             Margin = new Thickness(0, 0, 0, 1),
             TextTrimming = TextTrimming.CharacterEllipsis,
         };
-        sourceLine.SetResourceReference(TextBlock.ForegroundProperty, "TertiaryText");
+        sourceLine.SetResourceReference(TextBlock.ForegroundProperty, "SecondaryText");
         sourceLine.Inlines.Add(new System.Windows.Documents.Run("Source: ") { FontWeight = FontWeights.SemiBold });
         sourceLine.Inlines.Add(new System.Windows.Documents.Run(sourceLabel));
+        if (!string.IsNullOrEmpty(removalHint))
+        {
+            sourceLine.ToolTip = $"To remove: {removalHint}";
+        }
+
         panel.Children.Add(sourceLine);
 
-        // File path lines (one per path, selectable for copy + open button)
+        // File path lines (one per path, selectable for copy + edit/folder buttons)
         foreach (var path in paths)
         {
-            var row = new Grid { Margin = new Thickness(0, 0, 0, 1) };
+            var row = new Grid { Margin = new Thickness(0, 2, 0, 0) };
             row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+            row.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
             row.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
 
             var pathBox = new TextBox
@@ -656,48 +662,67 @@ public partial class SettingsWindow
                 BorderThickness = new Thickness(0),
                 Background = System.Windows.Media.Brushes.Transparent,
                 Padding = new Thickness(0),
-                Margin = new Thickness(0, 0, 4, 0),
+                Margin = new Thickness(0, 0, 6, 0),
                 TextWrapping = TextWrapping.NoWrap,
                 HorizontalScrollBarVisibility = ScrollBarVisibility.Hidden,
                 ToolTip = path,
                 VerticalAlignment = VerticalAlignment.Center,
             };
-            pathBox.SetResourceReference(TextBox.ForegroundProperty, "TertiaryText");
+            pathBox.SetResourceReference(TextBox.ForegroundProperty, "SecondaryText");
             Grid.SetColumn(pathBox, 0);
             row.Children.Add(pathBox);
 
-            var openButton = new Button
-            {
-                Content = "Open",
-                FontSize = 8,
-                Padding = new Thickness(4, 1, 4, 1),
-                VerticalAlignment = VerticalAlignment.Center,
-                ToolTip = File.Exists(path) ? $"Open {path}" : $"Open folder containing {path}",
-            };
             var capturedPath = path;
-            openButton.Click += (_, _) => OpenPathInExplorer(capturedPath);
-            Grid.SetColumn(openButton, 1);
-            row.Children.Add(openButton);
+            var fileExists = File.Exists(path);
+
+            var editButton = new Button
+            {
+                Content = "Edit",
+                FontSize = 9,
+                Padding = new Thickness(8, 3, 8, 3),
+                Margin = new Thickness(0, 0, 4, 0),
+                VerticalAlignment = VerticalAlignment.Center,
+                ToolTip = fileExists ? $"Open in Notepad: {path}" : "File does not exist yet",
+                IsEnabled = fileExists,
+            };
+            editButton.SetResourceReference(Button.BackgroundProperty, "AccentColor");
+            editButton.SetResourceReference(Button.ForegroundProperty, "AccentForeground");
+            editButton.Click += (_, _) => OpenInNotepad(capturedPath);
+            Grid.SetColumn(editButton, 1);
+            row.Children.Add(editButton);
+
+            var folderButton = new Button
+            {
+                Content = "Folder",
+                FontSize = 9,
+                Padding = new Thickness(8, 3, 8, 3),
+                VerticalAlignment = VerticalAlignment.Center,
+                ToolTip = $"Show in Explorer: {Path.GetDirectoryName(path)}",
+            };
+            folderButton.Click += (_, _) => OpenPathInExplorer(capturedPath);
+            Grid.SetColumn(folderButton, 2);
+            row.Children.Add(folderButton);
 
             panel.Children.Add(row);
         }
 
-        // Removal hint
-        if (!string.IsNullOrEmpty(removalHint))
-        {
-            var hintLine = new TextBlock
-            {
-                Text = $"To remove: {removalHint}",
-                FontSize = 9,
-                FontStyle = FontStyles.Italic,
-                Margin = new Thickness(0, 2, 0, 0),
-                TextWrapping = TextWrapping.Wrap,
-            };
-            hintLine.SetResourceReference(TextBlock.ForegroundProperty, "TertiaryText");
-            panel.Children.Add(hintLine);
-        }
-
         return panel;
+    }
+
+    private static void OpenInNotepad(string path)
+    {
+        try
+        {
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = "notepad.exe",
+                Arguments = $"\"{path}\"",
+                UseShellExecute = true,
+            });
+        }
+        catch (Exception ex) when (ex is System.IO.IOException or InvalidOperationException or System.ComponentModel.Win32Exception)
+        {
+        }
     }
 
     private static void OpenPathInExplorer(string path)
@@ -801,6 +826,11 @@ public partial class SettingsWindow
             if (path.Contains("kilo", StringComparison.OrdinalIgnoreCase))
             {
                 return "Kilo Code";
+            }
+
+            if (path.Contains("AIUsageTracker", StringComparison.OrdinalIgnoreCase))
+            {
+                return "AI Usage Tracker";
             }
         }
 

--- a/AIUsageTracker.UI.Slim/SettingsWindow.xaml.cs
+++ b/AIUsageTracker.UI.Slim/SettingsWindow.xaml.cs
@@ -44,6 +44,7 @@ public partial class SettingsWindow : Window
     private bool _isDeterministicScreenshotMode;
     private bool _isLoadingSettings;
     private bool _hasPendingAutoSave;
+    private bool _closingStarted;
     private UpdateInfo? _pendingUpdate;
     private GitHubUpdateChecker? _pendingUpdateChecker;
 
@@ -319,13 +320,31 @@ public partial class SettingsWindow : Window
 
     private async void SettingsWindow_Closing(object? sender, System.ComponentModel.CancelEventArgs e)
     {
-        // Flush any pending auto-save so preferences are persisted to disk
-        // regardless of how the window closes (X button, Alt+F4, etc.).
-        this._autoSaveTimer.Stop();
-        if (this._hasPendingAutoSave)
+        // If there is a pending auto-save and the close has not been initiated yet,
+        // cancel the close, flush preferences, then re-close via DialogResult = true.
+        // Without this, ShowDialog() returns null: the async void suspends at the first
+        // await, WPF closes the window before DialogResult is set, and the main window
+        // skips ApplyPreferencesFromSettings() — leaving the display out of sync.
+        if (!this._closingStarted && this._hasPendingAutoSave)
         {
-            await this.PersistAllSettingsAsync(showErrorDialog: false).ConfigureAwait(true);
+            e.Cancel = true;
+            this._closingStarted = true;
+            this._autoSaveTimer.Stop();
+            try
+            {
+                await this.PersistAllSettingsAsync(showErrorDialog: false).ConfigureAwait(true);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                this._logger.LogError(ex, "SettingsWindow_Closing flush failed");
+            }
+
+            // Setting DialogResult fires Closing again; _closingStarted prevents re-entrancy.
+            this.DialogResult = true;
+            return;
         }
+
+        this._autoSaveTimer.Stop();
 
         // Ensure the main window reloads preferences regardless of how the dialog closes
         // (Close button, X button, or Alt+F4). DialogResult can only be set before the

--- a/AIUsageTracker.Web.Tests/ViewTests.cs
+++ b/AIUsageTracker.Web.Tests/ViewTests.cs
@@ -19,6 +19,45 @@ public class ViewTests : WebTestBase
     private static readonly Regex BrokenRazorFormatString =
         new(@"@\w[\w.]*:[A-Z]\d", RegexOptions.Compiled, RegexTimeout);
 
+    // Matches unprocessed Razor expressions that leaked into the output, e.g. "@Model.Foo".
+    private static readonly Regex UnprocessedRazorExpression =
+        new(@"@[A-Z]\w*\.", RegexOptions.Compiled, RegexTimeout);
+
+    [TestMethod]
+    [DataRow("/")]
+    [DataRow("/providers")]
+    [DataRow("/charts")]
+    [DataRow("/history")]
+    [DataRow("/reliability")]
+    [DataRow("/provider/openai")]
+    [DataRow("/error")]
+    public async Task Page_IsProperlyRenderedAsync(string path)
+    {
+        using var client = CreateClient();
+        using var response = await client.GetAsync(path);
+        var html = await ReadBodyAsync(response);
+
+        // Must be a complete HTML document.
+        Assert.IsTrue(html.Contains("<html", StringComparison.OrdinalIgnoreCase), $"'{path}': missing <html>");
+        Assert.IsTrue(html.Contains("</html>", StringComparison.OrdinalIgnoreCase), $"'{path}': missing </html>");
+        Assert.IsTrue(html.Contains("<body", StringComparison.OrdinalIgnoreCase), $"'{path}': missing <body>");
+        Assert.IsTrue(html.Contains("</body>", StringComparison.OrdinalIgnoreCase), $"'{path}': missing </body>");
+        Assert.IsTrue(html.Contains("<title>", StringComparison.OrdinalIgnoreCase), $"'{path}': missing <title>");
+
+        // Must not contain a server-side exception dump.
+        Assert.IsFalse(html.Contains("System.Exception", StringComparison.Ordinal), $"'{path}': contains exception dump");
+        Assert.IsFalse(html.Contains("System.NullReferenceException", StringComparison.Ordinal), $"'{path}': contains NullReferenceException");
+        Assert.IsFalse(html.Contains("An unhandled exception occurred", StringComparison.OrdinalIgnoreCase), $"'{path}': contains unhandled exception message");
+
+        // Must not contain unprocessed Razor expressions (Razor failed to evaluate them).
+        var razorLeak = UnprocessedRazorExpression.Match(html);
+        Assert.IsFalse(razorLeak.Success, $"'{path}': unprocessed Razor expression '{razorLeak.Value}' leaked into output");
+
+        // Broken colon-format strings (e.g. @val:F1%) render literally instead of formatting.
+        var brokenFormat = BrokenRazorFormatString.Match(html);
+        Assert.IsFalse(brokenFormat.Success, $"'{path}': broken Razor format string '{brokenFormat.Value}'");
+    }
+
     [TestMethod]
     [DataRow("/")]
     [DataRow("/providers")]

--- a/AIUsageTracker.Web.Tests/ViewTests.cs
+++ b/AIUsageTracker.Web.Tests/ViewTests.cs
@@ -14,6 +14,29 @@ public class ViewTests : WebTestBase
 {
     private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(1);
 
+    // Matches broken Razor format strings like @variable:F1 that render literally in HTML.
+    // Correct syntax in text content is @variable.ToString("F1").
+    private static readonly Regex BrokenRazorFormatString =
+        new(@"@\w[\w.]*:[A-Z]\d", RegexOptions.Compiled, RegexTimeout);
+
+    [TestMethod]
+    [DataRow("/")]
+    [DataRow("/providers")]
+    [DataRow("/charts")]
+    [DataRow("/history")]
+    [DataRow("/reliability")]
+    public async Task Page_ContainsNoBrokenRazorFormatStringsAsync(string path)
+    {
+        using var client = CreateClient();
+        using var response = await client.GetAsync(path);
+        var html = await ReadBodyAsync(response);
+        var match = BrokenRazorFormatString.Match(html);
+        Assert.IsFalse(
+            match.Success,
+            $"Page '{path}' contains a broken Razor format string '{match.Value}'. " +
+            "Use .ToString(\"F1\") instead of :F1 in text content.");
+    }
+
     [TestMethod]
     [DataRow("/")]
     [DataRow("/providers")]

--- a/AIUsageTracker.Web/Pages/Index.cshtml
+++ b/AIUsageTracker.Web/Pages/Index.cshtml
@@ -68,7 +68,7 @@
                             <div class="reliability-metric">
                                 <div class="reliability-row">
                                     <span>Success Rate</span>
-                                    <span>@successRate:F1%</span>
+                                    <span>@successRate.ToString("F1")%</span>
                                 </div>
                                 <div class="reliability-progress">
                                     <div class="reliability-progress-bar success" style="width: @successRate%"></div>
@@ -77,7 +77,7 @@
                             <div class="reliability-metric">
                                 <div class="reliability-row">
                                     <span>Failure Rate</span>
-                                    <span>@snapshot.FailureRatePercent:F1%</span>
+                                    <span>@snapshot.FailureRatePercent.ToString("F1")%</span>
                                 </div>
                                 <div class="reliability-progress">
                                     <div class="reliability-progress-bar @failureClass" style="width: @snapshot.FailureRatePercent%"></div>

--- a/docs/adr/005-hide-missing-state-cards-from-main-window.md
+++ b/docs/adr/005-hide-missing-state-cards-from-main-window.md
@@ -1,7 +1,9 @@
 # ADR-005: Hide Missing-State Cards from Main Window for StandardApiKey Providers
 
 ## Status
-Accepted — 2026-04-05
+Superseded by refactor on 2026-04-12 — see **Superseding approach** below.
+
+Originally accepted — 2026-04-05.
 
 ## Context
 
@@ -15,29 +17,54 @@ The card was not actionable in the main window — the user could not fix "API K
 
 Meanwhile, session-based providers (GitHub Copilot, Codex) also use `Missing` state to communicate "Not authenticated," which IS useful information in the main window — it tells the user to log in.
 
-## Decision
+## Original Decision (superseded)
 
 ### 1. Filter Missing-state cards by provider settings mode
 
-`MainWindowRuntimeLogic.PrepareForMainWindow` now hides usage entries where:
+`MainWindowRuntimeLogic.PrepareForMainWindow` hid usage entries where:
 - `usage.State == ProviderUsageState.Missing`, AND
 - `definition.SettingsMode == ProviderSettingsMode.StandardApiKey`
 
-Providers with other settings modes (SessionAuthStatus, ExternalAuthStatus, AutoDetectedStatus) continue to show their Missing-state cards, since "Not authenticated" or "Not detected" is actionable context.
-
-Error-state cards (`ProviderUsageState.Error`) are always shown regardless of settings mode, since they indicate a runtime problem worth surfacing.
-
 ### 2. Invalidate ETag cache after config changes
 
-`IMonitorService.InvalidateGroupedUsageCache()` was added to clear the cached ETag and snapshot. It is called in `PersistAllSettingsAsync` after saving or removing configs, so the next `GetGroupedUsageAsync()` call fetches fresh data instead of returning a stale 304.
+`IMonitorService.InvalidateGroupedUsageCache()` was added to clear the cached ETag and snapshot after saves/removals.
 
 ### 3. Settings dialog always shows all provider cards
 
-The Settings dialog is a configuration surface. All providers with `ShowInSettings=true` are always displayed as configuration slots — even if the key is empty. The user can see the Inactive badge and type a new key at any time. No cards are removed from Settings on key deletion.
+The Settings dialog is a configuration surface. All providers with `ShowInSettings=true` are always displayed as configuration slots — even if the key is empty.
+
+## Problem with the original approach
+
+The `PrepareForMainWindow` filter was a compensating workaround for two upstream defects:
+
+1. `ProviderRefreshConfigSelector` used `forceAll=true` to bypass key checks for all provider types, so StandardApiKey providers without keys were polled and wrote `State=Missing` rows to the history DB.
+2. `CachedGroupedUsageProjectionService` used a two-step canonical-ID filter that incorrectly hid entire provider families (e.g. `minimax-io` was hidden because `minimax`, its canonical sibling, had no key).
+
+These produced two redundant filter layers with overlapping logic and subtle bugs.
+
+## Superseding approach
+
+The root cause is fixed at each responsible layer; no compensating filter is needed in the UI:
+
+### 1. `ProviderRefreshConfigSelector` — never poll without a key
+
+StandardApiKey providers are excluded from polling if their key is empty, regardless of `forceAll`. There is nothing useful to fetch without a key, so no `State=Missing` rows are ever written to the DB.
+
+### 2. `IUsageDatabase.GetLatestHistoryAsync(providerIds)` — filter at the SQL level
+
+`CachedGroupedUsageProjectionService` computes a `visibleIds` set (StandardApiKey providers require a key; non-StandardApiKey providers are always included) and passes it directly to the DB. The SQL query adds `AND provider_id IN (...)` to the 24-hour subquery so only relevant rows are fetched. No application-level `Where` clause follows.
+
+### 3. `PrepareForMainWindow` — no state filter
+
+The `State == Missing && StandardApiKey` check has been removed. The UI renders whatever the monitor snapshot contains; filtering is the monitor's responsibility.
+
+### 4. Settings dialog — unchanged
+
+All providers with `ShowInSettings=true` remain visible as configuration slots regardless of key state.
 
 ## Consequences
 
-- Deleting a StandardApiKey provider's key immediately removes its card from the main window and tray.
+- Deleting a StandardApiKey provider's key immediately removes its card from the main window (next refresh cycle).
 - Session/external auth providers still show their authentication status in the main window.
 - The Settings dialog is unaffected — all provider slots remain visible for reconfiguration.
-- The ETag cache invalidation adds negligible overhead (one lock + two null assignments per save cycle).
+- Historical usage data is preserved on key removal; only live monitoring stops.

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -242,9 +242,24 @@ A provider card's appearance reflects the current state of its API key:
 | **Error** | Red, API error message | Key is present but the provider returned an error (e.g. 429 rate limit, 500 server error). |
 | **Not configured** | Card absent from dashboard | No key is set for this provider. Configure one in Settings to show the card. |
 
-### Replacing an expired key
+### Where to update a key — upstream source first
 
-When your subscription renews or you purchase a new plan, update the key:
+**This tracker does not own your API keys.** It reads them from wherever you originally stored them: environment variables, Roo Code, OpenCode, Kilo Code, or other tools (see [section 6](#6-api-key-discovery)). The Settings UI key field only holds a local copy for keys that have no external source.
+
+If your key came from an external source, **always update it there first**, then re-scan:
+
+| Original source | Where to rotate the key | Then |
+|:---|:---|:---|
+| Environment variable (e.g. `OPENROUTER_API_KEY`) | Update the variable in your system or shell profile | Re-open terminal / restart service, then `act scan` |
+| Roo Code / Kilo Code config | Update the key inside that tool's settings | Run `act scan` or click **Scan for Keys** |
+| OpenCode `auth.json` | Update via `opencode auth` or edit the file directly | Run `act scan` or click **Scan for Keys** |
+| GitHub Copilot | Re-authenticate inside Settings (click **Log in**) | Automatic |
+
+Updating the key only in the tracker's Settings field will be overwritten on the next scan — the tracker will re-read the old key from the upstream source.
+
+### Replacing an expired key (no external source)
+
+If the key lives only in this tracker (you entered it manually and it is not discovered from any external source), update it here:
 
 **Via Settings UI:**
 1. Open Settings (⚙️) → **Providers** tab.
@@ -258,6 +273,8 @@ act set-key <provider-id> <new-api-key>
 # Example:
 act set-key synthetic sk-syn-...
 ```
+
+> **Check the auth source first.** The Settings card shows the source of the current key (e.g. "Env: OPENROUTER_API_KEY" or "Roo Code: …"). If a source is shown, update it there instead of overwriting the field here.
 
 ### Removing a key you no longer need
 
@@ -275,7 +292,9 @@ act remove-key <provider-id>
 act remove-key openrouter
 ```
 
-> **Note:** Removing a key does not delete historical usage data. Past records are preserved and visible in the **History** tab and via `act history`.
+> **Note:** Removing a key here does not remove it from the upstream source. If the key still exists in an environment variable or external tool config, a future **Scan for Keys** will rediscover it. To fully stop tracking a provider, also remove or unset the key in the upstream source.
+>
+> Removing a key does not delete historical usage data. Past records are preserved and visible in the **History** tab and via `act history`.
 
 ---
 

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -229,7 +229,57 @@ Click **"Scan for Keys"** in Settings or run `act scan` to trigger discovery fro
 
 ---
 
-## 7. Troubleshooting
+## 7. Managing API Keys
+
+### Key states
+
+A provider card's appearance reflects the current state of its API key:
+
+| State | Card appearance | What it means |
+|:---|:---|:---|
+| **Active** | Green/yellow/red progress bar | Key is present and working. |
+| **Expired** | Amber warning, "No active subscription" | Key is valid but your subscription or credits are exhausted. The card remains visible so you can see the state. |
+| **Error** | Red, API error message | Key is present but the provider returned an error (e.g. 429 rate limit, 500 server error). |
+| **Not configured** | Card absent from dashboard | No key is set for this provider. Configure one in Settings to show the card. |
+
+### Replacing an expired key
+
+When your subscription renews or you purchase a new plan, update the key:
+
+**Via Settings UI:**
+1. Open Settings (⚙️) → **Providers** tab.
+2. Find the provider — its card shows the **Inactive** badge.
+3. Paste the new key into the key field.
+4. The card reappears on the dashboard within one refresh cycle.
+
+**Via CLI:**
+```bash
+act set-key <provider-id> <new-api-key>
+# Example:
+act set-key synthetic sk-syn-...
+```
+
+### Removing a key you no longer need
+
+If you want to stop tracking a provider entirely, remove its key. The card disappears from the main dashboard immediately; the configuration slot remains in Settings so you can re-add a key later.
+
+**Via Settings UI:**
+1. Open Settings (⚙️) → **Providers** tab.
+2. Clear the key field for the provider (select all, delete).
+3. Close Settings — the card is removed from the dashboard on the next refresh.
+
+**Via CLI:**
+```bash
+act remove-key <provider-id>
+# Example:
+act remove-key openrouter
+```
+
+> **Note:** Removing a key does not delete historical usage data. Past records are preserved and visible in the **History** tab and via `act history`.
+
+---
+
+## 8. Troubleshooting
 
 - **Monitor not running**: The CLI will attempt to auto-start the monitor. If it fails, run `act monitor start` or start the UI application.
 - **Missing Keys**: Use `act check` to see which providers are failing due to missing or invalid keys.
@@ -237,4 +287,4 @@ Click **"Scan for Keys"** in Settings or run `act scan` to trigger discovery fro
 
 ---
 
-*Version: 2.3.2 beta series | Author: Alexander Brandt*
+*Version: 2.3.2 beta series | Author: Alexander Brandt | Updated: 2026-04-12*


### PR DESCRIPTION
## Summary

- **Fix: \"Show Used\" preference randomly resets** — `SettingsWindow_Closing` was `async void`; WPF does not await it, so `ShowDialog()` returned `null` before `DialogResult` was set. Fixed with cancel-and-refire pattern. Rendering also now reads from `_preferences` directly instead of the toggle's visual state.
- **Fix: MiniMax not showing despite having a key** — The unconfigured-key filter used `GetCanonicalProviderId()`, which mapped both `minimax` (no key) and `minimax-io` (has key) to `"minimax"`, hiding both. Fixed to use the specific `ProviderId` so only keyless sub-providers are excluded.
- **Refactor: eliminate all filter layers** — Three-part root cause fix:
  1. `ProviderRefreshConfigSelector` — StandardApiKey providers without a key are never polled regardless of `forceAll`, so no "API Key missing" rows are ever written to the DB.
  2. `IUsageDatabase.GetLatestHistoryAsync` — new optional `providerIds` parameter pushes filtering into SQL (`WHERE provider_id IN (...)`); stale history rows for removed providers are excluded at the query level.
  3. `CachedGroupedUsageProjectionService` and `MainWindowRuntimeLogic` — removed all application-level filtering; the snapshot service passes `visibleIds` directly to the DB and returns the result unmodified; `PrepareForMainWindow` no longer has any state-based filter.

## Test plan

- [x] `ProviderCardSlotRenderingTests.PercentageDisplayMode_IsTruthForShowUsed_RoundTripsCorrectly` — preference serialisation round-trip
- [x] `CachedGroupedUsageProjectionServiceTests` (3 tests) — unconfigured providers excluded, configured included, MiniMax sibling regression
- [x] `ProviderRefreshConfigSelectorTests` (2 new) — StandardApiKey with no key excluded even when `forceAll=true`; with key included
- [x] `UsageDatabaseReadTests` (3 new) — `GetLatestHistoryAsync` with provider ID set, empty set, and null
- [x] Full suite: 1161 tests, 2 pre-existing failures (`ConfigLoaderTests` env-dependent, `DialogOpenBehaviorTests` STA-flaky) — zero regressions introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)