### PR TITLE
fix: privacy toggle broken in Settings and Info dialog (GC bug)

### DIFF
--- a/AIUsageTracker.Tests/UI/Services/PrivacyChangedWeakEventManagerTests.cs
+++ b/AIUsageTracker.Tests/UI/Services/PrivacyChangedWeakEventManagerTests.cs
@@ -2,6 +2,7 @@
 // Copyright (c) AIUsageTracker. All rights reserved.
 // </copyright>
 
+using System.Reflection;
 using AIUsageTracker.UI.Slim;
 using AIUsageTracker.UI.Slim.Services;
 
@@ -77,6 +78,46 @@ public class PrivacyChangedWeakEventManagerTests
             PrivacyChangedWeakEventManager.RemoveHandler(handler);
             App.SetPrivacyMode(originalPrivacyMode);
         }
+    }
+
+    /// <summary>
+    /// Structural regression: every class that registers with PrivacyChangedWeakEventManager
+    /// MUST store the delegate in a field to prevent GC from collecting the weak reference.
+    /// This test scans the UI assembly for any class that has an OnPrivacyChanged method
+    /// and verifies it also declares a _privacyChangedHandler field.
+    /// </summary>
+    [Fact]
+    public void AllPrivacySubscribers_MustStoreHandlerInField_ToPreventGcCollection()
+    {
+        var uiAssembly = typeof(MainWindow).Assembly;
+        var violations = new List<string>();
+
+        foreach (var type in uiAssembly.GetTypes())
+        {
+            var hasOnPrivacyChanged = type.GetMethod(
+                "OnPrivacyChanged",
+                BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public) != null;
+
+            if (!hasOnPrivacyChanged)
+            {
+                continue;
+            }
+
+            var hasHandlerField = type.GetField(
+                "_privacyChangedHandler",
+                BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public) != null;
+
+            if (!hasHandlerField)
+            {
+                violations.Add(type.FullName ?? type.Name);
+            }
+        }
+
+        Assert.True(
+            violations.Count == 0,
+            $"These classes have OnPrivacyChanged but no _privacyChangedHandler field " +
+            $"(delegates passed to PrivacyChangedWeakEventManager.AddHandler will be GC'd): " +
+            string.Join(", ", violations));
     }
 
     [Fact]

--- a/AIUsageTracker.UI.Slim/InfoDialog.xaml.cs
+++ b/AIUsageTracker.UI.Slim/InfoDialog.xaml.cs
@@ -23,6 +23,7 @@ public partial class InfoDialog : Window
 {
     private readonly ILogger<InfoDialog> _logger;
     private readonly IAppPathProvider _pathProvider;
+    private readonly EventHandler<PrivacyChangedEventArgs> _privacyChangedHandler;
     private bool _isPrivacyMode = false;
     private string? _realUserName;
     private string? _realConfigDir;
@@ -36,6 +37,7 @@ public partial class InfoDialog : Window
         this.InitializeComponent();
         this._logger = logger;
         this._pathProvider = pathProvider;
+        this._privacyChangedHandler = this.OnPrivacyChanged;
 
         // In Slim UI, we rely on App.Preferences or direct theme resources
         // No need for complex theme loading or IConfigLoader here
@@ -63,7 +65,7 @@ public partial class InfoDialog : Window
         // Subscribe to global privacy changes using WeakEventManager to prevent memory leaks
         if (Application.Current is App)
         {
-            PrivacyChangedWeakEventManager.AddHandler(this.OnPrivacyChanged);
+            PrivacyChangedWeakEventManager.AddHandler(this._privacyChangedHandler);
 
             // Set initial privacy state
             this._isPrivacyMode = App.IsPrivacyMode;

--- a/AIUsageTracker.UI.Slim/SettingsWindow.xaml.cs
+++ b/AIUsageTracker.UI.Slim/SettingsWindow.xaml.cs
@@ -36,6 +36,7 @@ public partial class SettingsWindow : Window
     private readonly Func<UpdateChannel, GitHubUpdateChecker> _createUpdateChecker;
     private readonly SemaphoreSlim _autoSaveSemaphore = new(1, 1);
     private readonly DispatcherTimer _autoSaveTimer;
+    private readonly EventHandler<PrivacyChangedEventArgs> _privacyChangedHandler;
 
     private List<ProviderConfig> _configs = new();
     private List<ProviderUsage> _usages = new();
@@ -68,7 +69,8 @@ public partial class SettingsWindow : Window
         this._pathProvider = pathProvider;
         this._preferencesStore = preferencesStore;
         this._createUpdateChecker = createUpdateChecker;
-        PrivacyChangedWeakEventManager.AddHandler(this.OnPrivacyChanged);
+        this._privacyChangedHandler = this.OnPrivacyChanged;
+        PrivacyChangedWeakEventManager.AddHandler(this._privacyChangedHandler);
         this.Closing += this.SettingsWindow_Closing;
         this.Closed += this.SettingsWindow_Closed;
         this.Loaded += this.SettingsWindow_Loaded;
@@ -347,7 +349,7 @@ public partial class SettingsWindow : Window
     private void SettingsWindow_Closed(object? sender, EventArgs e)
     {
         this._autoSaveTimer.Stop();
-        PrivacyChangedWeakEventManager.RemoveHandler(this.OnPrivacyChanged);
+        PrivacyChangedWeakEventManager.RemoveHandler(this._privacyChangedHandler);
     }
 
     private async void AutoSaveTimer_Tick(object? sender, EventArgs e)


### PR DESCRIPTION
## Summary

- **Root cause**: `SettingsWindow` and `InfoDialog` were registering privacy-change handlers via `PrivacyChangedWeakEventManager.AddHandler(this.OnPrivacyChanged)`, passing a method-group delegate as a temporary value. The weak event manager holds only a weak reference, so the GC was free to collect the delegate — silently breaking the privacy toggle in both dialogs.
- **Fix**: Store the delegate in a `private readonly EventHandler<PrivacyChangedEventArgs> _privacyChangedHandler` field before registration, so a strong reference is kept alive for the lifetime of the window.
- **Regression guard**: A reflection-based structural test now scans the entire `AIUsageTracker.UI.Slim` assembly and asserts that every class with an `OnPrivacyChanged` method also declares a `_privacyChangedHandler` field, catching any future violations at compile time.

## Files changed

| File | Change |
|---|---|
| `AIUsageTracker.UI.Slim/SettingsWindow.xaml.cs` | Add `_privacyChangedHandler` field; use stored reference for add/remove |
| `AIUsageTracker.UI.Slim/InfoDialog.xaml.cs` | Same pattern fix |
| `AIUsageTracker.Tests/UI/Services/PrivacyChangedWeakEventManagerTests.cs` | Structural regression test via reflection |

## Test plan

- [ ] Existing `PrivacyChangedWeakEventManagerTests` still pass
- [ ] New `AllPrivacySubscribers_MustStoreHandlerInField_ToPreventGcCollection` test passes
- [ ] `dotnet test AIUsageTracker.Tests/AIUsageTracker.Tests.csproj` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)