### PR TITLE
chore: release 2.3.4-beta.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## [Unreleased]
 
+## [2.3.4-beta.30] - 2026-04-12
+
+### Added
+- **MiniMax Coding Plan provider**: new `minimax-coding` provider for the MiniMax API plan tier.
+- **Auth source panel shows exact config file**: each provider card in Settings now displays the exact file path that the key was discovered from (e.g. Roo Code `secrets.json`, OpenCode `auth.json`), with **Open** and **Edit** buttons to open the file or its folder directly. Removal instructions are shown alongside the source path.
+- **Key lifecycle documentation**: user manual section 7 now covers key states, where to rotate keys in upstream sources (env vars, Roo Code, Kilo Code, OpenCode), and the note that removing a key here does not remove it from its upstream source.
+
+### Fixed
+- **Unconfigured StandardApiKey provider cards no longer appear in main window**: root-cause fix across three layers — (1) `ProviderRefreshConfigSelector` never polls a StandardApiKey provider without a key, so no Missing-state rows are written; (2) `GetLatestHistoryAsync` filters history by configured provider IDs at the SQL level; (3) the compensating UI-layer filter has been removed. Session/external auth providers (GitHub Copilot, Codex) are unaffected.
+- **MiniMax International not hidden by unconfigured China sibling**: the old canonical-ID filter incorrectly excluded `minimax-io` (International) when `minimax` (China) had no key. Now filtered at the provider ID level before grouping.
+- **Show Used preference no longer resets on window close**: async-void `Closing` handler race condition and stale toggle reads caused the preference to silently revert on every close.
+- **Privacy toggle works in Settings and Info dialogs**: `SettingsWindow` and `InfoDialog` now store the privacy-change event handler in a field, preventing the GC from collecting the weak-referenced delegate and silently breaking the toggle.
+- **Snapshot cache invalidated on config save**: monitor now immediately invalidates the grouped usage cache after any config save or removal, preventing stale ETag responses to the UI.
+- **Provider key deletion only suppresses after confirmed monitor deletion**: `SuppressedProviderIds` is updated only after the monitor HTTP call succeeds, not speculatively.
+- **Preferences cache invalidated in `RemoveConfigAsync`**: stale in-memory configs no longer linger after key removal.
+
+### Changed
+- **Xiaomi and OpenRouter hidden from Settings when unconfigured**: providers without keys configured are no longer shown as empty slots in the Settings Providers tab.
+- **Minimax display names standardized**: provider card labels updated for consistency across MiniMax variants.
+
 ## [2.3.4-beta.29] - 2026-04-09
 
 ### Fixed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TrackerVersion>2.3.4-beta.29</TrackerVersion>
+    <TrackerVersion>2.3.4-beta.30</TrackerVersion>
     <TrackerAssemblyVersion>2.3.4</TrackerAssemblyVersion>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(MSBuildProjectDirectory)\artifacts\**\*</DefaultItemExcludes>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="AIUsageTracker.Web/wwwroot/favicon.png" width="32" height="32" valign="middle"> AI Usage Tracker
 
-![Version](https://img.shields.io/badge/version-2.3.4--beta.29--beta.28--beta.27--beta.26-orange)
+![Version](https://img.shields.io/badge/version-2.3.4--beta.30-orange)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Platforms](https://img.shields.io/badge/platforms-Windows%20|%20Linux%20-blue)
 ![Language](https://img.shields.io/badge/language-C%23%20|%20.NET-purple)

--- a/scripts/publish-app.ps1
+++ b/scripts/publish-app.ps1
@@ -6,7 +6,7 @@ param(
 )
 
 # AI Usage Tracker - Distribution Packaging Script
-# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.3.4-beta.29 -InstallerCompression balanced
+# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.3.4-beta.30 -InstallerCompression balanced
 
 $isWinPlatform = $Runtime.StartsWith("win-")
 $projectName = if ($isWinPlatform) { "AIUsageTracker" } else { "AIUsageTracker.CLI" }

--- a/scripts/setup.iss
+++ b/scripts/setup.iss
@@ -1,7 +1,7 @@
 ; AI Usage Tracker - Inno Setup Script
 
 #ifndef MyAppVersion
-  #define MyAppVersion "2.3.4-beta.29"
+  #define MyAppVersion "2.3.4-beta.30"
 #endif
 #ifndef SourcePath
   #define SourcePath "..\dist\publish-win-x64"


### PR DESCRIPTION
## Release 2.3.4-beta.30

Version bump and changelog for the `2.3.4-beta.30` release. Covers work merged since `v2.3.4-beta.29` (2026-04-09).

## What's in this release

### Added
- **MiniMax Coding Plan provider** (`minimax-coding`)
- **Auth source panel shows exact config file** with Open/Edit buttons per provider card in Settings
- **Key lifecycle documentation** in user manual (section 7): key states, upstream source rotation, removal notes

### Fixed
- **Unconfigured StandardApiKey cards eliminated at root**: never polled → SQL-filtered → no UI filter needed
- **MiniMax International no longer hidden by unconfigured China sibling**
- **Show Used preference reset on close** (async-void Closing + stale toggle race)
- **Privacy toggle GC bug in Settings and Info dialogs** (handler stored in field)
- **Snapshot cache invalidated on config save**
- **Key deletion suppression only after confirmed monitor deletion**
- **Preferences cache invalidated in RemoveConfigAsync**

### Changed
- Xiaomi and OpenRouter hidden from Settings when unconfigured
- Minimax display names standardized
- README version badge fixed (was accumulating version strings across releases)

## Files changed
- `CHANGELOG.md` — new `[2.3.4-beta.30]` section
- `Directory.Build.props` — `TrackerVersion` bumped to `2.3.4-beta.30`
- `scripts/setup.iss` — `MyAppVersion` bumped
- `scripts/publish-app.ps1` — usage comment version bumped
- `README.md` — badge fixed and bumped to `2.3.4-beta.30`

🤖 Generated with [Claude Code](https://claude.com/claude-code)