### PR TITLE
fix: remove stale privacy-mode write from debounced Settings save

### DIFF
--- a/AIUsageTracker.Tests/UI/AppStartupTests.cs
+++ b/AIUsageTracker.Tests/UI/AppStartupTests.cs
@@ -165,4 +165,16 @@ public class AppStartupTests : IDisposable
         Assert.True(saved);
         Assert.Equal(AppTheme.Midnight, loaded.Theme);
     }
+
+    [Fact]
+    public async Task SavePreferencesAsync_ThenLoadAsync_RoundTripsUpdateChannelAsync()
+    {
+        var preferences = new AppPreferences { UpdateChannel = UpdateChannel.Beta };
+
+        var saved = await this._store.SaveAsync(preferences);
+        var loaded = await this._store.LoadAsync();
+
+        Assert.True(saved);
+        Assert.Equal(UpdateChannel.Beta, loaded.UpdateChannel);
+    }
 }

--- a/AIUsageTracker.UI.Slim/SettingsWindow.xaml.cs
+++ b/AIUsageTracker.UI.Slim/SettingsWindow.xaml.cs
@@ -805,7 +805,6 @@ public partial class SettingsWindow : Window
 
             this._preferences.FontBold = this.FontBoldCheck.IsChecked ?? false;
             this._preferences.FontItalic = this.FontItalicCheck.IsChecked ?? false;
-            this._preferences.IsPrivacyMode = this._isPrivacyMode;
 
             this._preferences.EnableNotifications = this.EnableWindowsNotificationsCheck.IsChecked ?? false;
             if (double.TryParse(this.NotificationThresholdBox.Text, System.Globalization.CultureInfo.InvariantCulture, out var notifyThreshold))


### PR DESCRIPTION
## Summary

- Removes the redundant `this._preferences.IsPrivacyMode = this._isPrivacyMode` line from `PersistAllSettingsAsync` in `SettingsWindow.xaml.cs`
- Adds missing `UpdateChannel` round-trip test to `AppStartupTests`

## Problem

Privacy mode was written by **two separate code paths** in the Settings window:

1. **Immediate**: `PrivacyBtn_Click` → sets `_preferences.IsPrivacyMode` + saves immediately via `SaveUiPreferencesAsync`
2. **Debounced**: `PersistAllSettingsAsync` (fires on any Settings change) → also wrote `_preferences.IsPrivacyMode = this._isPrivacyMode`

Path 2 was a stale-write vector. If `_isPrivacyMode` diverged from the actual stored value between the button click and the next debounce fire (e.g., due to an event delivery race), the debounced save would silently overwrite the correct privacy mode value.

This is the structural weakness that caused the intermittent privacy mode reset reported after beta.30 installation.

## Fix

Remove the redundant assignment from `PersistAllSettingsAsync`. Privacy mode is already correctly maintained on the shared `_preferences` object by:
- `PrivacyBtn_Click` — sets `_preferences.IsPrivacyMode` directly
- `OnPrivacyChanged` — keeps `_preferences.IsPrivacyMode` in sync via the weak event

The debounced save reads from `_preferences` (the shared object) directly via `SaveUiPreferencesAsync`, so it always gets the current value without needing the explicit write-back.

## Test plan

- [x] Full test suite passes (1077/1077)
- [x] `SavePreferencesAsync_ThenLoadAsync_RoundTripsUpdateChannelAsync` added and passes
- [x] Existing `SavePreferencesAsync_ThenLoadAsync_RoundTripsCorrectlyAsync` already covers `IsPrivacyMode` round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)