### PR TITLE
feat: power state resilience for Monitor process

### DIFF
--- a/AIUsageTracker.Monitor.Tests/MonitorJobSchedulerTests.cs
+++ b/AIUsageTracker.Monitor.Tests/MonitorJobSchedulerTests.cs
@@ -332,6 +332,107 @@ public class MonitorJobSchedulerTests
         }
     }
 
+    [Fact]
+    public async Task Pause_BlocksNewJobDispatchWhileInFlightCompletesAsync()
+    {
+        var logger = new Mock<ILogger<MonitorJobScheduler>>();
+        var scheduler = new MonitorJobScheduler(logger.Object);
+        var firstJobStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstJobCanFinish = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondJobExecuted = false;
+
+        await scheduler.StartAsync(CancellationToken.None);
+        try
+        {
+            // Enqueue a long-running first job that signals when started
+            _ = scheduler.Enqueue(
+                "in-flight-job",
+                async _ =>
+                {
+                    firstJobStarted.TrySetResult(true);
+                    await firstJobCanFinish.Task.ConfigureAwait(false);
+                },
+                MonitorJobPriority.Normal);
+
+            // Wait for first job to start
+            var started = await Task.WhenAny(firstJobStarted.Task, Task.Delay(TimeSpan.FromSeconds(5))) == firstJobStarted.Task;
+            Assert.True(started, "First job did not start within timeout.");
+
+            // Pause while first job is in-flight
+            scheduler.Pause();
+
+            // Verify snapshot reports paused
+            Assert.True(scheduler.GetSnapshot().IsPaused);
+
+            // Enqueue a second job - it should not execute while paused
+            _ = scheduler.Enqueue(
+                "blocked-job",
+                _ =>
+                {
+                    secondJobExecuted = true;
+                    return Task.CompletedTask;
+                },
+                MonitorJobPriority.Normal);
+
+            // Let the first in-flight job finish
+            firstJobCanFinish.TrySetResult(true);
+
+            // Wait a moment — second job should NOT run while paused
+            await Task.Delay(200);
+
+            Assert.False(secondJobExecuted, "Second job should not execute while scheduler is paused.");
+            Assert.True(scheduler.GetSnapshot().IsPaused);
+        }
+        finally
+        {
+            scheduler.Resume();
+            await scheduler.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [Fact]
+    public async Task Resume_RestoresDispatchAfterPauseAsync()
+    {
+        var logger = new Mock<ILogger<MonitorJobScheduler>>();
+        var scheduler = new MonitorJobScheduler(logger.Object);
+        var jobExecuted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await scheduler.StartAsync(CancellationToken.None);
+        try
+        {
+            // Pause before enqueuing
+            scheduler.Pause();
+            Assert.True(scheduler.GetSnapshot().IsPaused);
+
+            // Enqueue a job while paused — it should not run yet
+            _ = scheduler.Enqueue(
+                "held-job",
+                _ =>
+                {
+                    jobExecuted.TrySetResult(true);
+                    return Task.CompletedTask;
+                },
+                MonitorJobPriority.Normal);
+
+            // Verify job does not run within a short wait
+            var ranBeforeResume = await Task.WhenAny(jobExecuted.Task, Task.Delay(200)) == jobExecuted.Task;
+            Assert.False(ranBeforeResume, "Job should not run while paused.");
+
+            // Resume
+            scheduler.Resume();
+            Assert.False(scheduler.GetSnapshot().IsPaused);
+
+            // Job should now run
+            var ranAfterResume = await Task.WhenAny(jobExecuted.Task, Task.Delay(TimeSpan.FromSeconds(5))) == jobExecuted.Task;
+            Assert.True(ranAfterResume, "Job did not run after resume within timeout.");
+            Assert.False(scheduler.GetSnapshot().IsPaused);
+        }
+        finally
+        {
+            await scheduler.StopAsync(CancellationToken.None);
+        }
+    }
+
     private static async Task<MonitorJobSchedulerSnapshot> WaitForCoalescedCompletionAsync(
         MonitorJobScheduler scheduler,
         int expectedCompletedJobs)

--- a/AIUsageTracker.Monitor.Tests/PowerStateListenerTests.cs
+++ b/AIUsageTracker.Monitor.Tests/PowerStateListenerTests.cs
@@ -1,0 +1,59 @@
+// <copyright file="PowerStateListenerTests.cs" company="AIUsageTracker">
+// Copyright (c) AIUsageTracker. All rights reserved.
+// </copyright>
+
+using AIUsageTracker.Monitor.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace AIUsageTracker.Monitor.Tests;
+
+public class PowerStateListenerTests
+{
+    [Fact]
+    public void OnSuspend_PausesScheduler()
+    {
+        var schedulerLogger = new Mock<ILogger<MonitorJobScheduler>>();
+        var listenerLogger = new Mock<ILogger<PowerStateListener>>();
+        var pathProvider = new Mock<AIUsageTracker.Core.Interfaces.IAppPathProvider>();
+        pathProvider.Setup(p => p.GetMonitorInfoFilePath()).Returns(Path.Combine(Path.GetTempPath(), $"power-test-{Guid.NewGuid()}", "monitor-info.json"));
+
+        var scheduler = new MonitorJobScheduler(schedulerLogger.Object);
+
+        var listener = new PowerStateListener(
+            listenerLogger.Object,
+            scheduler,
+            pathProvider.Object,
+            onSuspend: () => scheduler.Pause(),
+            onResume: () => scheduler.Resume());
+
+        listener.SimulateSuspend();
+
+        Assert.True(scheduler.GetSnapshot().IsPaused);
+    }
+
+    [Fact]
+    public void OnResume_ResumesScheduler()
+    {
+        var schedulerLogger = new Mock<ILogger<MonitorJobScheduler>>();
+        var listenerLogger = new Mock<ILogger<PowerStateListener>>();
+        var pathProvider = new Mock<AIUsageTracker.Core.Interfaces.IAppPathProvider>();
+        pathProvider.Setup(p => p.GetMonitorInfoFilePath()).Returns(Path.Combine(Path.GetTempPath(), $"power-test-{Guid.NewGuid()}", "monitor-info.json"));
+
+        var scheduler = new MonitorJobScheduler(schedulerLogger.Object);
+
+        var listener = new PowerStateListener(
+            listenerLogger.Object,
+            scheduler,
+            pathProvider.Object,
+            onSuspend: () => scheduler.Pause(),
+            onResume: () => scheduler.Resume());
+
+        listener.SimulateSuspend();
+        Assert.True(scheduler.GetSnapshot().IsPaused);
+
+        listener.SimulateResume();
+        Assert.False(scheduler.GetSnapshot().IsPaused);
+    }
+}

--- a/AIUsageTracker.Monitor.Tests/ProviderRefreshServiceTests.cs
+++ b/AIUsageTracker.Monitor.Tests/ProviderRefreshServiceTests.cs
@@ -759,6 +759,12 @@ public class ProviderRefreshServiceTests
         return lifecycle.CurrentMaxConcurrency;
     }
 
+    [Fact]
+    public void CancelActiveRefresh_WhenNoRefreshActive_DoesNotThrow()
+    {
+        this._service.CancelActiveRefresh();
+    }
+
     private sealed record PipelineTestFiles(string Root, string AuthPath, string ProvidersPath, string PreferencesPath);
 
     private sealed record PipelinePrivacyScenario(

--- a/AIUsageTracker.Monitor/Program.cs
+++ b/AIUsageTracker.Monitor/Program.cs
@@ -229,6 +229,27 @@ public class Program
             builder.Services.AddSingleton<ProviderRefreshService>();
             builder.Services.AddHostedService(sp => sp.GetRequiredService<ProviderRefreshService>());
 
+            if (OperatingSystem.IsWindows())
+            {
+                builder.Services.AddSingleton<PowerStateListener>(sp =>
+                    new PowerStateListener(
+                        sp.GetRequiredService<ILogger<PowerStateListener>>(),
+                        sp.GetRequiredService<MonitorJobScheduler>(),
+                        sp.GetRequiredService<IAppPathProvider>(),
+                        onSuspend: () =>
+                        {
+                            sp.GetRequiredService<MonitorJobScheduler>().Pause();
+                            sp.GetRequiredService<ProviderRefreshService>().CancelActiveRefresh();
+                        },
+                        onResume: () =>
+                        {
+                            var scheduler = sp.GetRequiredService<MonitorJobScheduler>();
+                            scheduler.Resume();
+                            sp.GetRequiredService<ProviderRefreshService>().QueueManualRefresh(forceAll: true);
+                        }));
+                builder.Services.AddHostedService(sp => sp.GetRequiredService<PowerStateListener>());
+            }
+
             // Configure HTTP clients
             builder.Services.AddHttpClient();
             builder.Services.AddConfiguredHttpClients();

--- a/AIUsageTracker.Monitor/Services/IMonitorJobScheduler.cs
+++ b/AIUsageTracker.Monitor/Services/IMonitorJobScheduler.cs
@@ -20,5 +20,9 @@ public interface IMonitorJobScheduler
         TimeSpan? initialDelay = null,
         string? coalesceKey = null);
 
+    void Pause();
+
+    void Resume();
+
     MonitorJobSchedulerSnapshot GetSnapshot();
 }

--- a/AIUsageTracker.Monitor/Services/MonitorJobScheduler.cs
+++ b/AIUsageTracker.Monitor/Services/MonitorJobScheduler.cs
@@ -27,6 +27,8 @@ public sealed class MonitorJobScheduler : BackgroundService, IMonitorJobSchedule
     private readonly ConcurrentQueue<ScheduledJob> _lowPriorityQueue = new();
     private readonly ConcurrentDictionary<string, byte> _coalescedKeys = new(StringComparer.OrdinalIgnoreCase);
     private readonly SemaphoreSlim _queuedItemsSignal = new(0);
+    private readonly SemaphoreSlim _pauseGate = new(1, 1);
+    private volatile bool _paused;
     private readonly object _recurringLock = new();
     private readonly List<RecurringJobRegistration> _recurringRegistrations = new();
     private readonly List<Task> _recurringTasks = new();
@@ -88,6 +90,30 @@ public sealed class MonitorJobScheduler : BackgroundService, IMonitorJobSchedule
         return true;
     }
 
+    public void Pause()
+    {
+        if (this._paused)
+        {
+            return;
+        }
+
+        this._paused = true;
+        this._pauseGate.Wait(); // architecture-allow-sync-wait: called from synchronous SystemEvents.PowerModeChanged handler
+        this._logger.LogInformation("Monitor job scheduler paused");
+    }
+
+    public void Resume()
+    {
+        if (!this._paused)
+        {
+            return;
+        }
+
+        this._paused = false;
+        this._pauseGate.Release();
+        this._logger.LogInformation("Monitor job scheduler resumed");
+    }
+
     public void RegisterRecurringJob(
         string jobName,
         TimeSpan interval,
@@ -144,6 +170,7 @@ public sealed class MonitorJobScheduler : BackgroundService, IMonitorJobSchedule
 
         return new MonitorJobSchedulerSnapshot
         {
+            IsPaused = this._paused,
             HighPriorityQueuedJobs = high,
             NormalPriorityQueuedJobs = normal,
             LowPriorityQueuedJobs = low,
@@ -187,6 +214,8 @@ public sealed class MonitorJobScheduler : BackgroundService, IMonitorJobSchedule
             while (!stoppingToken.IsCancellationRequested)
             {
                 await this._queuedItemsSignal.WaitAsync(stoppingToken).ConfigureAwait(false);
+                await this._pauseGate.WaitAsync(stoppingToken).ConfigureAwait(false);
+                this._pauseGate.Release();
                 if (!this.TryDequeueNext(out var job))
                 {
                     Interlocked.Increment(ref this._dispatchNoopSignals);

--- a/AIUsageTracker.Monitor/Services/MonitorJobSchedulerSnapshot.cs
+++ b/AIUsageTracker.Monitor/Services/MonitorJobSchedulerSnapshot.cs
@@ -6,6 +6,8 @@ namespace AIUsageTracker.Monitor.Services;
 
 public sealed class MonitorJobSchedulerSnapshot
 {
+    public bool IsPaused { get; init; }
+
     public int HighPriorityQueuedJobs { get; init; }
 
     public int NormalPriorityQueuedJobs { get; init; }

--- a/AIUsageTracker.Monitor/Services/PowerStateListener.cs
+++ b/AIUsageTracker.Monitor/Services/PowerStateListener.cs
@@ -1,0 +1,129 @@
+// <copyright file="PowerStateListener.cs" company="AIUsageTracker">
+// Copyright (c) AIUsageTracker. All rights reserved.
+// </copyright>
+
+using AIUsageTracker.Core.Interfaces;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace AIUsageTracker.Monitor.Services;
+
+public sealed class PowerStateListener : IHostedService, IDisposable
+{
+    private readonly ILogger<PowerStateListener> _logger;
+    private readonly IAppPathProvider _pathProvider;
+    private readonly Action _onSuspend;
+    private readonly Action _onResume;
+    private bool _subscribedToPowerEvents;
+    private bool _disposed;
+
+    public PowerStateListener(
+        ILogger<PowerStateListener> logger,
+        MonitorJobScheduler scheduler,
+        IAppPathProvider pathProvider,
+        Action? onSuspend = null,
+        Action? onResume = null)
+    {
+        this._logger = logger;
+        this._pathProvider = pathProvider;
+
+        this._onSuspend = onSuspend ?? (() =>
+        {
+            scheduler.Pause();
+        });
+
+        this._onResume = onResume ?? (() =>
+        {
+            scheduler.Resume();
+            scheduler.Enqueue("post-resume-refresh", _ => Task.CompletedTask, MonitorJobPriority.High);
+        });
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            this.SubscribePowerEvents();
+        }
+
+        this._logger.LogInformation("Power state listener started");
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (OperatingSystem.IsWindows() && this._subscribedToPowerEvents)
+        {
+            this.UnsubscribePowerEvents();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public void SimulateSuspend()
+    {
+        this.HandleSuspend();
+    }
+
+    public void SimulateResume()
+    {
+        this.HandleResume();
+    }
+
+    public void Dispose()
+    {
+        if (this._disposed)
+        {
+            return;
+        }
+
+        this._disposed = true;
+
+        if (OperatingSystem.IsWindows() && this._subscribedToPowerEvents)
+        {
+            this.UnsubscribePowerEvents();
+        }
+    }
+
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    private void SubscribePowerEvents()
+    {
+        Microsoft.Win32.SystemEvents.PowerModeChanged += this.OnPowerModeChanged;
+        this._subscribedToPowerEvents = true;
+    }
+
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    private void UnsubscribePowerEvents()
+    {
+        Microsoft.Win32.SystemEvents.PowerModeChanged -= this.OnPowerModeChanged;
+        this._subscribedToPowerEvents = false;
+    }
+
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    private void OnPowerModeChanged(object sender, Microsoft.Win32.PowerModeChangedEventArgs e)
+    {
+        switch (e.Mode)
+        {
+            case Microsoft.Win32.PowerModes.Suspend:
+                this.HandleSuspend();
+                break;
+            case Microsoft.Win32.PowerModes.Resume:
+                this.HandleResume();
+                break;
+        }
+    }
+
+    private void HandleSuspend()
+    {
+        this._logger.LogInformation("System suspend detected — pausing scheduler");
+        this._onSuspend();
+        MonitorInfoPersistence.SaveMonitorInfo(0, false, this._logger, this._pathProvider, startupStatus: "suspended");
+    }
+
+    private void HandleResume()
+    {
+        this._logger.LogInformation("System resume detected — resuming scheduler");
+        this._onResume();
+        MonitorInfoPersistence.SaveMonitorInfo(0, false, this._logger, this._pathProvider, startupStatus: "running");
+    }
+}

--- a/AIUsageTracker.Monitor/Services/ProviderRefreshService.cs
+++ b/AIUsageTracker.Monitor/Services/ProviderRefreshService.cs
@@ -33,6 +33,7 @@ public class ProviderRefreshService : BackgroundService
     private readonly StartupSequenceService _startupSequenceService;
     private readonly IProviderUsageProcessingPipeline _usageProcessingPipeline;
     private readonly SemaphoreSlim _refreshSemaphore = new(1, 1);
+    private volatile CancellationTokenSource? _activeRefreshCts;
     private readonly TimeSpan _refreshInterval = TimeSpan.FromMinutes(5);
 
     public static void SetDebugMode(bool debug)
@@ -91,6 +92,16 @@ public class ProviderRefreshService : BackgroundService
             forceAll: forceAll,
             includeProviderIds: includeProviderIds,
             bypassCircuitBreaker: true);
+    }
+
+    public void CancelActiveRefresh()
+    {
+        var cts = this._activeRefreshCts;
+        if (cts != null && !cts.IsCancellationRequested)
+        {
+            this._logger.LogInformation("Cancelling active refresh cycle (power state transition)");
+            cts.Cancel();
+        }
     }
 
     internal static string? BuildManualRefreshCoalesceKey(
@@ -164,6 +175,8 @@ public class ProviderRefreshService : BackgroundService
         bool bypassCircuitBreaker = false,
         CancellationToken cancellationToken = default)
     {
+        using var refreshCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        this._activeRefreshCts = refreshCts;
         using var refreshActivity = ActivitySource.StartActivity("monitor.provider_refresh", ActivityKind.Internal);
         refreshActivity?.SetTag("refresh.force_all", forceAll);
         refreshActivity?.SetTag("refresh.bypass_circuit_breaker", bypassCircuitBreaker);
@@ -176,10 +189,11 @@ public class ProviderRefreshService : BackgroundService
 
         if (this.TryGetProviderManagerForRefresh(refreshStopwatch, refreshActivity) == null)
         {
+            this._activeRefreshCts = null;
             return;
         }
 
-        await this._refreshSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        await this._refreshSemaphore.WaitAsync(refreshCts.Token).ConfigureAwait(false);
         try
         {
             await this.EnsureProviderManagerConcurrencyAsync().ConfigureAwait(false);
@@ -226,7 +240,7 @@ public class ProviderRefreshService : BackgroundService
                         configs,
                         refreshableConfigs,
                         circuitSkippedConfigs,
-                        cancellationToken)
+                        refreshCts.Token)
                     .ConfigureAwait(false);
             }
             else
@@ -258,6 +272,7 @@ public class ProviderRefreshService : BackgroundService
             this._refreshTelemetryManager.RecordRefreshTelemetry(refreshStopwatch.Elapsed, refreshSucceeded, refreshError);
             refreshActivity?.SetTag("refresh.duration_ms", refreshStopwatch.Elapsed.TotalMilliseconds);
             this._refreshSemaphore.Release();
+            this._activeRefreshCts = null;
         }
     }
 

--- a/AIUsageTracker.Tests/Core/MonitorStartupOrchestratorWatchdogTests.cs
+++ b/AIUsageTracker.Tests/Core/MonitorStartupOrchestratorWatchdogTests.cs
@@ -1,0 +1,126 @@
+// <copyright file="MonitorStartupOrchestratorWatchdogTests.cs" company="AIUsageTracker">
+// Copyright (c) AIUsageTracker. All rights reserved.
+// </copyright>
+
+using AIUsageTracker.Core.Interfaces;
+using AIUsageTracker.Core.MonitorClient;
+using AIUsageTracker.UI.Slim.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace AIUsageTracker.Tests.Core;
+
+public sealed class MonitorStartupOrchestratorWatchdogTests
+{
+    private static readonly TimeSpan BaseInterval = TimeSpan.FromSeconds(60);
+
+    private readonly Mock<IMonitorService> _mockMonitorService;
+    private readonly Mock<IMonitorLauncher> _mockLauncher;
+    private readonly MonitorLifecycleService _lifecycleService;
+    private readonly MonitorStartupOrchestrator _orchestrator;
+
+    public MonitorStartupOrchestratorWatchdogTests()
+    {
+        this._mockMonitorService = new Mock<IMonitorService>();
+        this._mockLauncher = new Mock<IMonitorLauncher>();
+        this._lifecycleService = new MonitorLifecycleService(this._mockLauncher.Object);
+        this._orchestrator = new MonitorStartupOrchestrator(
+            this._mockMonitorService.Object,
+            this._lifecycleService,
+            NullLogger<MonitorStartupOrchestrator>.Instance);
+    }
+
+    [Fact]
+    public async Task Watchdog_WhenHealthCheckFails_CallsEnsureAgentRunning()
+    {
+        this._mockMonitorService
+            .Setup(m => m.CheckHealthAsync(It.IsAny<TimeSpan>()))
+            .ReturnsAsync(false);
+        this._mockMonitorService
+            .Setup(m => m.RefreshPortAsync())
+            .Returns(Task.CompletedTask);
+        this._mockLauncher
+            .Setup(l => l.EnsureAgentRunningAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        await this._orchestrator.RunWatchdogTickAsync();
+
+        this._mockLauncher.Verify(l => l.EnsureAgentRunningAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Watchdog_WhenHealthCheckSucceeds_DoesNotRelaunch()
+    {
+        this._mockMonitorService
+            .Setup(m => m.CheckHealthAsync(It.IsAny<TimeSpan>()))
+            .ReturnsAsync(true);
+
+        await this._orchestrator.RunWatchdogTickAsync();
+
+        this._mockLauncher.Verify(l => l.EnsureAgentRunningAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Watchdog_AfterRepeatedFailures_IncreasesInterval()
+    {
+        this._mockMonitorService
+            .Setup(m => m.CheckHealthAsync(It.IsAny<TimeSpan>()))
+            .ReturnsAsync(false);
+        this._mockMonitorService
+            .Setup(m => m.RefreshPortAsync())
+            .Returns(Task.CompletedTask);
+        this._mockLauncher
+            .Setup(l => l.EnsureAgentRunningAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        await this._orchestrator.RunWatchdogTickAsync();
+        var firstInterval = this._orchestrator.CurrentWatchdogInterval;
+
+        await this._orchestrator.RunWatchdogTickAsync();
+        var secondInterval = this._orchestrator.CurrentWatchdogInterval;
+
+        Assert.True(secondInterval > firstInterval, $"Expected second interval ({secondInterval}) > first ({firstInterval})");
+    }
+
+    [Fact]
+    public async Task Watchdog_AfterRecovery_ResetsInterval()
+    {
+        this._mockMonitorService
+            .Setup(m => m.CheckHealthAsync(It.IsAny<TimeSpan>()))
+            .ReturnsAsync(false);
+        this._mockMonitorService
+            .Setup(m => m.RefreshPortAsync())
+            .Returns(Task.CompletedTask);
+        this._mockLauncher
+            .Setup(l => l.EnsureAgentRunningAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        // Tick twice to grow the interval
+        await this._orchestrator.RunWatchdogTickAsync();
+        await this._orchestrator.RunWatchdogTickAsync();
+        Assert.True(this._orchestrator.CurrentWatchdogInterval > BaseInterval);
+
+        // Now health check succeeds — recovery
+        this._mockMonitorService
+            .Setup(m => m.CheckHealthAsync(It.IsAny<TimeSpan>()))
+            .ReturnsAsync(true);
+
+        await this._orchestrator.RunWatchdogTickAsync();
+
+        Assert.Equal(BaseInterval, this._orchestrator.CurrentWatchdogInterval);
+    }
+
+    [Fact]
+    public async Task NotifyResumed_TriggersImmediateCheck()
+    {
+        this._mockMonitorService
+            .Setup(m => m.CheckHealthAsync(It.IsAny<TimeSpan>()))
+            .ReturnsAsync(true);
+
+        this._orchestrator.NotifyResumed();
+        await this._orchestrator.RunWatchdogTickAsync();
+
+        this._mockMonitorService.Verify(m => m.CheckHealthAsync(It.IsAny<TimeSpan>()), Times.Once);
+    }
+}

--- a/AIUsageTracker.UI.Slim/MainWindow.xaml.cs
+++ b/AIUsageTracker.UI.Slim/MainWindow.xaml.cs
@@ -71,6 +71,7 @@ public partial class MainWindow : Window
     private bool _isSettingsDialogOpen;
     private bool _isChangelogOpen;
     private bool _isTooltipOpen;
+    private readonly CancellationTokenSource _watchdogCts = new();
 
     public MainWindow(
         MainViewModel viewModel,
@@ -176,10 +177,22 @@ public partial class MainWindow : Window
         this._alwaysOnTopTimer.Start();
 
         this.SourceInitialized += this.OnSourceInitialized;
+        if (OperatingSystem.IsWindows())
+        {
+            SystemEvents.PowerModeChanged += this.OnPowerModeChanged;
+        }
+
         PrivacyChangedWeakEventManager.AddHandler(this._privacyChangedHandler);
         this.Closed += (s, e) =>
         {
             PrivacyChangedWeakEventManager.RemoveHandler(this._privacyChangedHandler);
+            this._watchdogCts.Cancel();
+            this._watchdogCts.Dispose();
+            if (OperatingSystem.IsWindows())
+            {
+                SystemEvents.PowerModeChanged -= this.OnPowerModeChanged;
+            }
+
             this._updateCheckTimer.Stop();
             this._alwaysOnTopTimer.Stop();
             this.SourceInitialized -= this.OnSourceInitialized;
@@ -419,6 +432,7 @@ public partial class MainWindow : Window
                 var handshakeResult = await this._monitorService.CheckApiContractAsync().ConfigureAwait(false); // ui-thread-guardrail-allow: Task.Run thread pool
                 await this.Dispatcher.InvokeAsync(() => this.ApplyMonitorContractStatus(handshakeResult)).Task.ConfigureAwait(true);
             });
+            _ = Task.Run(() => this._monitorStartupOrchestrator.RunWatchdogLoopAsync(this._watchdogCts.Token));
 
             this.ShowStatus("Connected", StatusType.Success);
         }
@@ -557,6 +571,16 @@ public partial class MainWindow : Window
         if (hasUsages)
         {
             this.RenderProviders();
+        }
+    }
+
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    private void OnPowerModeChanged(object sender, PowerModeChangedEventArgs e)
+    {
+        if (e.Mode == PowerModes.Resume)
+        {
+            this._logger.LogInformation("System resumed — triggering immediate watchdog check");
+            this._monitorStartupOrchestrator.NotifyResumed();
         }
     }
 

--- a/AIUsageTracker.UI.Slim/Services/MonitorStartupOrchestrator.cs
+++ b/AIUsageTracker.UI.Slim/Services/MonitorStartupOrchestrator.cs
@@ -11,9 +11,16 @@ namespace AIUsageTracker.UI.Slim.Services;
 
 public sealed class MonitorStartupOrchestrator
 {
+    private static readonly TimeSpan BaseInterval = TimeSpan.FromSeconds(60);
+    private static readonly TimeSpan MaxInterval = TimeSpan.FromSeconds(300);
+    private static readonly TimeSpan HealthCheckTimeout = TimeSpan.FromMilliseconds(2000);
+
     private readonly IMonitorService _monitorService;
     private readonly MonitorLifecycleService _monitorLifecycleService;
     private readonly ILogger<MonitorStartupOrchestrator> _logger;
+
+    private TaskCompletionSource<bool>? _activeResumeSignal;
+    private int _consecutiveFailures;
 
     public MonitorStartupOrchestrator(
         IMonitorService monitorService,
@@ -23,7 +30,10 @@ public sealed class MonitorStartupOrchestrator
         this._monitorService = monitorService;
         this._monitorLifecycleService = monitorLifecycleService;
         this._logger = logger;
+        this.CurrentWatchdogInterval = BaseInterval;
     }
+
+    public TimeSpan CurrentWatchdogInterval { get; private set; }
 
     public async Task<MonitorStartupOrchestrationResult> EnsureMonitorReadyAsync(
         Func<string, StatusType, Task> reportStatusAsync,
@@ -67,6 +77,98 @@ public sealed class MonitorStartupOrchestrator
             this._logger.LogError(ex, "Startup orchestration failed");
             return new MonitorStartupOrchestrationResult(IsSuccess: false, IsLaunchFailure: false);
         }
+    }
+
+    public async Task RunWatchdogLoopAsync(CancellationToken cancellationToken)
+    {
+        this._logger.LogInformation("Watchdog loop starting");
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                this._activeResumeSignal = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                await Task.WhenAny(
+                    Task.Delay(this.CurrentWatchdogInterval, cancellationToken),
+                    this._activeResumeSignal.Task).ConfigureAwait(false);
+
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
+
+                await this.RunWatchdogTickAsync().ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Clean shutdown
+        }
+
+        this._logger.LogInformation("Watchdog loop stopped");
+    }
+
+    public async Task RunWatchdogTickAsync()
+    {
+        try
+        {
+            var isHealthy = await this._monitorService.CheckHealthAsync(HealthCheckTimeout).ConfigureAwait(false);
+            if (isHealthy)
+            {
+                if (this._consecutiveFailures > 0)
+                {
+                    this._logger.LogInformation(
+                        "Monitor recovered after {Failures} consecutive failure(s)",
+                        this._consecutiveFailures);
+                }
+
+                this._consecutiveFailures = 0;
+                this.CurrentWatchdogInterval = BaseInterval;
+                return;
+            }
+
+            this._consecutiveFailures++;
+            this._logger.LogWarning(
+                "Watchdog health check failed (consecutive failures: {Failures})",
+                this._consecutiveFailures);
+
+            await this._monitorService.RefreshPortAsync().ConfigureAwait(false);
+            var restarted = await this._monitorLifecycleService.EnsureAgentRunningAsync().ConfigureAwait(false);
+
+            if (restarted)
+            {
+                this._logger.LogInformation("Monitor restarted successfully by watchdog");
+                await this._monitorService.RefreshPortAsync().ConfigureAwait(false);
+                this._consecutiveFailures = 0;
+                this.CurrentWatchdogInterval = BaseInterval;
+            }
+            else
+            {
+                var backoffSeconds = Math.Min(
+                    BaseInterval.TotalSeconds * Math.Pow(2, this._consecutiveFailures - 1),
+                    MaxInterval.TotalSeconds);
+                this.CurrentWatchdogInterval = TimeSpan.FromSeconds(backoffSeconds);
+                this._logger.LogWarning(
+                    "Watchdog restart failed; next check in {Seconds:F0}s",
+                    backoffSeconds);
+            }
+        }
+        catch (Exception ex)
+        {
+            this._consecutiveFailures++;
+            var backoffSeconds = Math.Min(
+                BaseInterval.TotalSeconds * Math.Pow(2, this._consecutiveFailures - 1),
+                MaxInterval.TotalSeconds);
+            this.CurrentWatchdogInterval = TimeSpan.FromSeconds(backoffSeconds);
+            this._logger.LogError(
+                ex,
+                "Watchdog tick failed; next check in {Seconds:F0}s",
+                backoffSeconds);
+        }
+    }
+
+    public void NotifyResumed()
+    {
+        this._activeResumeSignal?.TrySetResult(true);
     }
 
     private async Task<bool> TryRestartMonitorForVersionMismatchAsync(Func<string, StatusType, Task> reportStatusAsync)

--- a/docs/superpowers/plans/2026-04-13-power-state-resilience.md
+++ b/docs/superpowers/plans/2026-04-13-power-state-resilience.md
@@ -1,0 +1,1095 @@
+# Power State Resilience Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Monitor process survive Windows sleep/wake transitions and add a watchdog to the UI Slim that relaunches the Monitor when it dies.
+
+**Architecture:** Two layers — (1) a `PowerStateListener` hosted service in the Monitor that pauses jobs on suspend and resumes on wake, and (2) an adaptive watchdog loop in `MonitorStartupOrchestrator` that periodically health-checks the Monitor and relaunches it on failure, with immediate wake-triggered checks.
+
+**Tech Stack:** .NET 8, ASP.NET Core hosted services, `Microsoft.Win32.SystemEvents.PowerModeChanged`, xUnit + Moq
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `AIUsageTracker.Monitor/Services/PowerStateListener.cs` | Hosted service subscribing to Windows power events, pausing/resuming scheduler and refresh |
+| Create | `AIUsageTracker.Monitor.Tests/PowerStateListenerTests.cs` | Tests for power state listener |
+| Modify | `AIUsageTracker.Monitor/Services/IMonitorJobScheduler.cs` | Add `PauseAsync()` / `ResumeAsync()` to interface |
+| Modify | `AIUsageTracker.Monitor/Services/MonitorJobScheduler.cs` | Implement pause/resume: block dispatch, stop/restart recurring timers |
+| Modify | `AIUsageTracker.Monitor/Services/MonitorJobSchedulerSnapshot.cs` | Add `IsPaused` property |
+| Modify | `AIUsageTracker.Monitor/Program.cs:202-230` | Register `PowerStateListener` (Windows-only) |
+| Modify | `AIUsageTracker.Monitor.Tests/MonitorJobSchedulerTests.cs` | Add pause/resume tests |
+| Modify | `AIUsageTracker.UI.Slim/Services/MonitorStartupOrchestrator.cs` | Add watchdog loop with power-aware fast path |
+| Modify | `AIUsageTracker.Tests/Core/MonitorStartupOrchestratorTests.cs` or create new test file | Add watchdog tests |
+
+---
+
+### Task 1: Add PauseAsync/ResumeAsync to MonitorJobScheduler
+
+**Files:**
+- Modify: `AIUsageTracker.Monitor/Services/IMonitorJobScheduler.cs`
+- Modify: `AIUsageTracker.Monitor/Services/MonitorJobScheduler.cs:29-48` (fields), `171-276` (ExecuteAsync), `285-324` (StartRecurringLoopAsync)
+- Modify: `AIUsageTracker.Monitor/Services/MonitorJobSchedulerSnapshot.cs`
+- Modify: `AIUsageTracker.Monitor.Tests/MonitorJobSchedulerTests.cs`
+
+- [ ] **Step 1: Write the failing test — PauseAsync blocks new job dispatch**
+
+Add to `AIUsageTracker.Monitor.Tests/MonitorJobSchedulerTests.cs`:
+
+```csharp
+[Fact]
+public async Task PauseAsync_BlocksNewJobDispatchWhileInFlightCompletesAsync()
+{
+    var logger = new Mock<ILogger<MonitorJobScheduler>>();
+    var scheduler = new MonitorJobScheduler(logger.Object);
+    var inFlightStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+    var inFlightGate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+    var blockedJobExecuted = false;
+
+    await scheduler.StartAsync(CancellationToken.None);
+    try
+    {
+        // Enqueue a job that will be in-flight when we pause
+        _ = scheduler.Enqueue(
+            "in-flight-job",
+            async _ =>
+            {
+                inFlightStarted.TrySetResult(true);
+                await inFlightGate.Task;
+            },
+            MonitorJobPriority.High);
+
+        // Wait for the in-flight job to start executing
+        Assert.True(await inFlightStarted.Task.WaitAsync(TimeSpan.FromSeconds(2)));
+
+        // Pause while a job is in-flight
+        scheduler.PauseAsync();
+
+        // Enqueue a job that should be blocked
+        _ = scheduler.Enqueue(
+            "blocked-job",
+            _ =>
+            {
+                blockedJobExecuted = true;
+                return Task.CompletedTask;
+            },
+            MonitorJobPriority.High);
+
+        // Let the in-flight job complete
+        inFlightGate.TrySetResult(true);
+        await Task.Delay(200);
+
+        // The blocked job should NOT have executed while paused
+        Assert.False(blockedJobExecuted);
+
+        var snapshot = scheduler.GetSnapshot();
+        Assert.True(snapshot.IsPaused);
+    }
+    finally
+    {
+        scheduler.ResumeAsync();
+        await scheduler.StopAsync(CancellationToken.None);
+    }
+}
+```
+
+- [ ] **Step 2: Write the failing test — ResumeAsync restores dispatch**
+
+Add to `AIUsageTracker.Monitor.Tests/MonitorJobSchedulerTests.cs`:
+
+```csharp
+[Fact]
+public async Task ResumeAsync_RestoresDispatchAfterPauseAsync()
+{
+    var logger = new Mock<ILogger<MonitorJobScheduler>>();
+    var scheduler = new MonitorJobScheduler(logger.Object);
+    var jobCompleted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    await scheduler.StartAsync(CancellationToken.None);
+    try
+    {
+        scheduler.PauseAsync();
+
+        _ = scheduler.Enqueue(
+            "queued-while-paused",
+            _ =>
+            {
+                jobCompleted.TrySetResult(true);
+                return Task.CompletedTask;
+            },
+            MonitorJobPriority.High);
+
+        // Job should not run while paused
+        await Task.Delay(200);
+        Assert.False(jobCompleted.Task.IsCompleted);
+
+        // Resume should allow the queued job to run
+        scheduler.ResumeAsync();
+        Assert.True(await jobCompleted.Task.WaitAsync(TimeSpan.FromSeconds(2)));
+
+        var snapshot = scheduler.GetSnapshot();
+        Assert.False(snapshot.IsPaused);
+    }
+    finally
+    {
+        await scheduler.StopAsync(CancellationToken.None);
+    }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `dotnet test AIUsageTracker.Monitor.Tests --filter "PauseAsync_BlocksNewJobDispatchWhileInFlightCompletesAsync|ResumeAsync_RestoresDispatchAfterPauseAsync" --no-restore -v minimal`
+Expected: Compile error — `PauseAsync`, `ResumeAsync`, `IsPaused` do not exist yet.
+
+- [ ] **Step 4: Add PauseAsync/ResumeAsync to IMonitorJobScheduler**
+
+In `AIUsageTracker.Monitor/Services/IMonitorJobScheduler.cs`, add after the `GetSnapshot()` method:
+
+```csharp
+void PauseAsync();
+
+void ResumeAsync();
+```
+
+- [ ] **Step 5: Add IsPaused to MonitorJobSchedulerSnapshot**
+
+In `AIUsageTracker.Monitor/Services/MonitorJobSchedulerSnapshot.cs`, add:
+
+```csharp
+public bool IsPaused { get; init; }
+```
+
+- [ ] **Step 6: Implement PauseAsync/ResumeAsync in MonitorJobScheduler**
+
+In `AIUsageTracker.Monitor/Services/MonitorJobScheduler.cs`:
+
+Add new fields after line 48 (`private CancellationToken _schedulerToken`):
+
+```csharp
+private volatile bool _paused;
+private readonly SemaphoreSlim _pauseGate = new(1, 1);
+```
+
+Add the two methods after `GetSnapshot()` (after line 169):
+
+```csharp
+public void PauseAsync()
+{
+    if (this._paused)
+    {
+        return;
+    }
+
+    this._paused = true;
+    this._pauseGate.Wait();
+    this._logger.LogInformation("Job scheduler paused");
+}
+
+public void ResumeAsync()
+{
+    if (!this._paused)
+    {
+        return;
+    }
+
+    this._paused = false;
+    this._pauseGate.Release();
+    this._logger.LogInformation("Job scheduler resumed");
+}
+```
+
+Modify `ExecuteAsync` — in the dispatch loop, after the `WaitAsync` on `_queuedItemsSignal` (line 189) and before `TryDequeueNext` (line 190), add a pause gate check:
+
+```csharp
+// Wait for pause gate — blocks dispatch when paused
+await this._pauseGate.WaitAsync(stoppingToken).ConfigureAwait(false);
+this._pauseGate.Release();
+```
+
+Add `IsPaused` to the `GetSnapshot()` method return:
+
+```csharp
+IsPaused = this._paused,
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `dotnet test AIUsageTracker.Monitor.Tests --filter "PauseAsync_BlocksNewJobDispatchWhileInFlightCompletesAsync|ResumeAsync_RestoresDispatchAfterPauseAsync" --no-restore -v minimal`
+Expected: Both PASS.
+
+- [ ] **Step 8: Run all existing scheduler tests to verify no regressions**
+
+Run: `dotnet test AIUsageTracker.Monitor.Tests --filter "MonitorJobSchedulerTests" --no-restore -v minimal`
+Expected: All existing tests still pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add AIUsageTracker.Monitor/Services/IMonitorJobScheduler.cs AIUsageTracker.Monitor/Services/MonitorJobScheduler.cs AIUsageTracker.Monitor/Services/MonitorJobSchedulerSnapshot.cs AIUsageTracker.Monitor.Tests/MonitorJobSchedulerTests.cs
+git commit -m "feat: add PauseAsync/ResumeAsync to MonitorJobScheduler for power state resilience"
+```
+
+---
+
+### Task 2: Add CancelActiveRefresh to ProviderRefreshService
+
+**Files:**
+- Modify: `AIUsageTracker.Monitor/Services/ProviderRefreshService.cs:34` (fields), `160-261` (TriggerRefreshAsync)
+- Modify: `AIUsageTracker.Monitor.Tests/ProviderRefreshServiceTests.cs`
+
+- [ ] **Step 1: Write the failing test — CancelActiveRefresh cancels current cycle**
+
+Add to `AIUsageTracker.Monitor.Tests/ProviderRefreshServiceTests.cs`:
+
+```csharp
+[Fact]
+public void CancelActiveRefresh_WhenNoRefreshActive_DoesNotThrow()
+{
+    this._service.CancelActiveRefresh();
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test AIUsageTracker.Monitor.Tests --filter "CancelActiveRefresh_WhenNoRefreshActive_DoesNotThrow" --no-restore -v minimal`
+Expected: Compile error — `CancelActiveRefresh` does not exist.
+
+- [ ] **Step 3: Implement CancelActiveRefresh**
+
+In `AIUsageTracker.Monitor/Services/ProviderRefreshService.cs`:
+
+Add a new field after line 34 (`private readonly SemaphoreSlim _refreshSemaphore`):
+
+```csharp
+private CancellationTokenSource? _activeRefreshCts;
+```
+
+Add the public method after `QueueForceRefresh` (after line 93):
+
+```csharp
+public void CancelActiveRefresh()
+{
+    var cts = this._activeRefreshCts;
+    if (cts != null && !cts.IsCancellationRequested)
+    {
+        this._logger.LogInformation("Cancelling active refresh cycle (power state transition)");
+        cts.Cancel();
+    }
+}
+```
+
+In `TriggerRefreshAsync` (line 160), after the method signature and before `using var refreshActivity`, add CTS management:
+
+```csharp
+using var refreshCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+this._activeRefreshCts = refreshCts;
+var effectiveToken = refreshCts.Token;
+```
+
+Replace all uses of `cancellationToken` inside `TriggerRefreshAsync` and `RefreshAndStoreProviderDataAsync` with `effectiveToken` — specifically:
+- Line 181: `await this._refreshSemaphore.WaitAsync(cancellationToken)` → `await this._refreshSemaphore.WaitAsync(effectiveToken)`
+
+In the `finally` block of `TriggerRefreshAsync` (after line 259), add:
+
+```csharp
+this._activeRefreshCts = null;
+```
+
+Also pass `effectiveToken` through to `RefreshAndStoreProviderDataAsync` on line 223-229.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test AIUsageTracker.Monitor.Tests --filter "CancelActiveRefresh_WhenNoRefreshActive_DoesNotThrow" --no-restore -v minimal`
+Expected: PASS.
+
+- [ ] **Step 5: Run all existing refresh service tests**
+
+Run: `dotnet test AIUsageTracker.Monitor.Tests --filter "ProviderRefreshServiceTests" --no-restore -v minimal`
+Expected: All existing tests still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add AIUsageTracker.Monitor/Services/ProviderRefreshService.cs AIUsageTracker.Monitor.Tests/ProviderRefreshServiceTests.cs
+git commit -m "feat: add CancelActiveRefresh to ProviderRefreshService for power state transitions"
+```
+
+---
+
+### Task 3: Create PowerStateListener hosted service
+
+**Files:**
+- Create: `AIUsageTracker.Monitor/Services/PowerStateListener.cs`
+- Create: `AIUsageTracker.Monitor.Tests/PowerStateListenerTests.cs`
+- Modify: `AIUsageTracker.Monitor/Program.cs:218-220` (service registration)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `AIUsageTracker.Monitor.Tests/PowerStateListenerTests.cs`:
+
+```csharp
+// <copyright file="PowerStateListenerTests.cs" company="AIUsageTracker">
+// Copyright (c) AIUsageTracker. All rights reserved.
+// </copyright>
+
+using AIUsageTracker.Core.Interfaces;
+using AIUsageTracker.Monitor.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace AIUsageTracker.Monitor.Tests;
+
+public class PowerStateListenerTests
+{
+    private readonly Mock<ILogger<PowerStateListener>> _mockLogger;
+    private readonly Mock<MonitorJobScheduler> _mockScheduler;
+    private readonly Mock<ProviderRefreshService> _mockRefreshService;
+    private readonly Mock<IAppPathProvider> _mockPathProvider;
+
+    public PowerStateListenerTests()
+    {
+        this._mockLogger = new Mock<ILogger<PowerStateListener>>();
+        this._mockScheduler = new Mock<MonitorJobScheduler>(new Mock<ILogger<MonitorJobScheduler>>().Object) { CallBase = false };
+        this._mockRefreshService = new Mock<ProviderRefreshService>() { CallBase = false };
+        this._mockPathProvider = new Mock<IAppPathProvider>();
+    }
+
+    [Fact]
+    public void OnSuspend_PausesSchedulerAndCancelsRefresh()
+    {
+        var scheduler = new MonitorJobScheduler(new Mock<ILogger<MonitorJobScheduler>>().Object);
+        var listener = new PowerStateListener(
+            this._mockLogger.Object,
+            scheduler,
+            this._mockPathProvider.Object,
+            onSuspend: () =>
+            {
+                scheduler.PauseAsync();
+            },
+            onResume: () =>
+            {
+                scheduler.ResumeAsync();
+            });
+
+        listener.SimulateSuspend();
+
+        var snapshot = scheduler.GetSnapshot();
+        Assert.True(snapshot.IsPaused);
+    }
+
+    [Fact]
+    public void OnResume_ResumesScheduler()
+    {
+        var scheduler = new MonitorJobScheduler(new Mock<ILogger<MonitorJobScheduler>>().Object);
+        var listener = new PowerStateListener(
+            this._mockLogger.Object,
+            scheduler,
+            this._mockPathProvider.Object,
+            onSuspend: () =>
+            {
+                scheduler.PauseAsync();
+            },
+            onResume: () =>
+            {
+                scheduler.ResumeAsync();
+            });
+
+        listener.SimulateSuspend();
+        Assert.True(scheduler.GetSnapshot().IsPaused);
+
+        listener.SimulateResume();
+        Assert.False(scheduler.GetSnapshot().IsPaused);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test AIUsageTracker.Monitor.Tests --filter "PowerStateListenerTests" --no-restore -v minimal`
+Expected: Compile error — `PowerStateListener` does not exist.
+
+- [ ] **Step 3: Create PowerStateListener**
+
+Create `AIUsageTracker.Monitor/Services/PowerStateListener.cs`:
+
+```csharp
+// <copyright file="PowerStateListener.cs" company="AIUsageTracker">
+// Copyright (c) AIUsageTracker. All rights reserved.
+// </copyright>
+
+using AIUsageTracker.Core.Interfaces;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace AIUsageTracker.Monitor.Services;
+
+public sealed class PowerStateListener : IHostedService, IDisposable
+{
+    private readonly ILogger<PowerStateListener> _logger;
+    private readonly IAppPathProvider _pathProvider;
+    private readonly Action _onSuspend;
+    private readonly Action _onResume;
+    private bool _subscribed;
+
+    public PowerStateListener(
+        ILogger<PowerStateListener> logger,
+        MonitorJobScheduler scheduler,
+        IAppPathProvider pathProvider,
+        Action? onSuspend = null,
+        Action? onResume = null)
+    {
+        this._logger = logger;
+        this._pathProvider = pathProvider;
+
+        this._onSuspend = onSuspend ?? (() =>
+        {
+            scheduler.PauseAsync();
+        });
+
+        this._onResume = onResume ?? (() =>
+        {
+            scheduler.ResumeAsync();
+            scheduler.Enqueue(
+                "post-resume-refresh",
+                _ => Task.CompletedTask,
+                MonitorJobPriority.High);
+        });
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            this._logger.LogDebug("Power state listener skipped — not running on Windows");
+            return Task.CompletedTask;
+        }
+
+        SubscribePowerEvents();
+        this._logger.LogInformation("Power state listener started");
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (this._subscribed)
+        {
+            UnsubscribePowerEvents();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public void SimulateSuspend()
+    {
+        this.HandleSuspend();
+    }
+
+    public void SimulateResume()
+    {
+        this.HandleResume();
+    }
+
+    public void Dispose()
+    {
+        if (this._subscribed)
+        {
+            UnsubscribePowerEvents();
+        }
+    }
+
+    private void HandleSuspend()
+    {
+        this._logger.LogInformation("System entering suspend — pausing scheduled jobs");
+        try
+        {
+            this._onSuspend();
+            MonitorInfoPersistence.SaveMonitorInfo(0, false, this._logger, this._pathProvider, startupStatus: "suspended");
+        }
+        catch (Exception ex)
+        {
+            this._logger.LogError(ex, "Error handling suspend event");
+        }
+    }
+
+    private void HandleResume()
+    {
+        this._logger.LogInformation("System resuming — restarting scheduled jobs");
+        try
+        {
+            this._onResume();
+            MonitorInfoPersistence.SaveMonitorInfo(0, false, this._logger, this._pathProvider, startupStatus: "running");
+        }
+        catch (Exception ex)
+        {
+            this._logger.LogError(ex, "Error handling resume event");
+        }
+    }
+
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    private void SubscribePowerEvents()
+    {
+        Microsoft.Win32.SystemEvents.PowerModeChanged += this.OnPowerModeChanged;
+        this._subscribed = true;
+    }
+
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    private void UnsubscribePowerEvents()
+    {
+        Microsoft.Win32.SystemEvents.PowerModeChanged -= this.OnPowerModeChanged;
+        this._subscribed = false;
+    }
+
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    private void OnPowerModeChanged(object sender, Microsoft.Win32.PowerModeChangedEventArgs e)
+    {
+        switch (e.Mode)
+        {
+            case Microsoft.Win32.PowerModes.Suspend:
+                this.HandleSuspend();
+                break;
+            case Microsoft.Win32.PowerModes.Resume:
+                this.HandleResume();
+                break;
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test AIUsageTracker.Monitor.Tests --filter "PowerStateListenerTests" --no-restore -v minimal`
+Expected: Both tests PASS.
+
+- [ ] **Step 5: Register PowerStateListener in Program.cs**
+
+In `AIUsageTracker.Monitor/Program.cs`, after the line `builder.Services.AddHostedService(sp => sp.GetRequiredService<ProviderRefreshService>());` (line 230), add:
+
+```csharp
+if (OperatingSystem.IsWindows())
+{
+    builder.Services.AddSingleton<PowerStateListener>(sp =>
+        new PowerStateListener(
+            sp.GetRequiredService<ILogger<PowerStateListener>>(),
+            sp.GetRequiredService<MonitorJobScheduler>(),
+            sp.GetRequiredService<IAppPathProvider>(),
+            onSuspend: () =>
+            {
+                sp.GetRequiredService<MonitorJobScheduler>().PauseAsync();
+                sp.GetRequiredService<ProviderRefreshService>().CancelActiveRefresh();
+            },
+            onResume: () =>
+            {
+                var scheduler = sp.GetRequiredService<MonitorJobScheduler>();
+                scheduler.ResumeAsync();
+                sp.GetRequiredService<ProviderRefreshService>().QueueManualRefresh(forceAll: true);
+            }));
+    builder.Services.AddHostedService(sp => sp.GetRequiredService<PowerStateListener>());
+}
+```
+
+- [ ] **Step 6: Run all Monitor tests**
+
+Run: `dotnet test AIUsageTracker.Monitor.Tests --no-restore -v minimal`
+Expected: All tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add AIUsageTracker.Monitor/Services/PowerStateListener.cs AIUsageTracker.Monitor.Tests/PowerStateListenerTests.cs AIUsageTracker.Monitor/Program.cs
+git commit -m "feat: add PowerStateListener to pause/resume Monitor on sleep/wake"
+```
+
+---
+
+### Task 4: Add adaptive watchdog to MonitorStartupOrchestrator
+
+**Files:**
+- Modify: `AIUsageTracker.UI.Slim/Services/MonitorStartupOrchestrator.cs`
+- Create: `AIUsageTracker.Tests/Core/MonitorStartupOrchestratorWatchdogTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `AIUsageTracker.Tests/Core/MonitorStartupOrchestratorWatchdogTests.cs`:
+
+```csharp
+// <copyright file="MonitorStartupOrchestratorWatchdogTests.cs" company="AIUsageTracker">
+// Copyright (c) AIUsageTracker. All rights reserved.
+// </copyright>
+
+using AIUsageTracker.Core.Interfaces;
+using AIUsageTracker.Core.MonitorClient;
+using AIUsageTracker.Infrastructure.Services;
+using AIUsageTracker.UI.Slim.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace AIUsageTracker.Tests.Core;
+
+public class MonitorStartupOrchestratorWatchdogTests
+{
+    private readonly Mock<IMonitorService> _mockMonitorService;
+    private readonly Mock<MonitorLifecycleService> _mockLifecycle;
+    private readonly Mock<ILogger<MonitorStartupOrchestrator>> _mockLogger;
+
+    public MonitorStartupOrchestratorWatchdogTests()
+    {
+        this._mockMonitorService = new Mock<IMonitorService>();
+        var launcherLogger = new Mock<ILogger<MonitorLauncher>>();
+        var launcher = new MonitorLauncher(launcherLogger.Object);
+        this._mockLifecycle = new Mock<MonitorLifecycleService>(launcher) { CallBase = false };
+        this._mockLogger = new Mock<ILogger<MonitorStartupOrchestrator>>();
+    }
+
+    [Fact]
+    public async Task Watchdog_WhenHealthCheckFails_CallsEnsureAgentRunningAsync()
+    {
+        this._mockMonitorService.Setup(m => m.CheckHealthAsync(It.IsAny<TimeSpan>())).ReturnsAsync(false);
+        this._mockLifecycle.Setup(m => m.EnsureAgentRunningAsync()).ReturnsAsync(true);
+        this._mockMonitorService.Setup(m => m.RefreshPortAsync()).Returns(Task.CompletedTask);
+
+        var orchestrator = new MonitorStartupOrchestrator(
+            this._mockMonitorService.Object,
+            this._mockLifecycle.Object,
+            this._mockLogger.Object);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+        // Trigger a single watchdog tick
+        await orchestrator.RunWatchdogTickAsync();
+
+        this._mockLifecycle.Verify(m => m.EnsureAgentRunningAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task Watchdog_WhenHealthCheckSucceeds_DoesNotRelaunch()
+    {
+        this._mockMonitorService.Setup(m => m.CheckHealthAsync(It.IsAny<TimeSpan>())).ReturnsAsync(true);
+
+        var orchestrator = new MonitorStartupOrchestrator(
+            this._mockMonitorService.Object,
+            this._mockLifecycle.Object,
+            this._mockLogger.Object);
+
+        await orchestrator.RunWatchdogTickAsync();
+
+        this._mockLifecycle.Verify(m => m.EnsureAgentRunningAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task Watchdog_AfterRepeatedFailures_IncreasesInterval()
+    {
+        this._mockMonitorService.Setup(m => m.CheckHealthAsync(It.IsAny<TimeSpan>())).ReturnsAsync(false);
+        this._mockLifecycle.Setup(m => m.EnsureAgentRunningAsync()).ReturnsAsync(false);
+
+        var orchestrator = new MonitorStartupOrchestrator(
+            this._mockMonitorService.Object,
+            this._mockLifecycle.Object,
+            this._mockLogger.Object);
+
+        // First failure: interval should increase from 60s
+        await orchestrator.RunWatchdogTickAsync();
+        var firstInterval = orchestrator.CurrentWatchdogInterval;
+
+        await orchestrator.RunWatchdogTickAsync();
+        var secondInterval = orchestrator.CurrentWatchdogInterval;
+
+        Assert.True(secondInterval > firstInterval);
+    }
+
+    [Fact]
+    public async Task Watchdog_AfterRecovery_ResetsInterval()
+    {
+        this._mockMonitorService.Setup(m => m.CheckHealthAsync(It.IsAny<TimeSpan>())).ReturnsAsync(false);
+        this._mockLifecycle.Setup(m => m.EnsureAgentRunningAsync()).ReturnsAsync(false);
+        this._mockMonitorService.Setup(m => m.RefreshPortAsync()).Returns(Task.CompletedTask);
+
+        var orchestrator = new MonitorStartupOrchestrator(
+            this._mockMonitorService.Object,
+            this._mockLifecycle.Object,
+            this._mockLogger.Object);
+
+        // Fail a few times to increase interval
+        await orchestrator.RunWatchdogTickAsync();
+        await orchestrator.RunWatchdogTickAsync();
+        Assert.True(orchestrator.CurrentWatchdogInterval > TimeSpan.FromSeconds(60));
+
+        // Recover
+        this._mockMonitorService.Setup(m => m.CheckHealthAsync(It.IsAny<TimeSpan>())).ReturnsAsync(true);
+        await orchestrator.RunWatchdogTickAsync();
+        Assert.Equal(TimeSpan.FromSeconds(60), orchestrator.CurrentWatchdogInterval);
+    }
+
+    [Fact]
+    public async Task NotifyResumed_TriggersImmediateWatchdogCheck()
+    {
+        var healthCheckCount = 0;
+        this._mockMonitorService
+            .Setup(m => m.CheckHealthAsync(It.IsAny<TimeSpan>()))
+            .ReturnsAsync(true)
+            .Callback(() => Interlocked.Increment(ref healthCheckCount));
+
+        var orchestrator = new MonitorStartupOrchestrator(
+            this._mockMonitorService.Object,
+            this._mockLifecycle.Object,
+            this._mockLogger.Object);
+
+        // Signal resume — the next watchdog tick should fire immediately
+        orchestrator.NotifyResumed();
+
+        // RunWatchdogTickAsync should check health
+        await orchestrator.RunWatchdogTickAsync();
+        Assert.True(healthCheckCount >= 1);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test AIUsageTracker.Tests --filter "MonitorStartupOrchestratorWatchdogTests" --no-restore -v minimal`
+Expected: Compile error — `RunWatchdogTickAsync`, `CurrentWatchdogInterval`, `NotifyResumed` do not exist.
+
+- [ ] **Step 3: Implement watchdog in MonitorStartupOrchestrator**
+
+Modify `AIUsageTracker.UI.Slim/Services/MonitorStartupOrchestrator.cs`. Replace the entire file:
+
+```csharp
+// <copyright file="MonitorStartupOrchestrator.cs" company="AIUsageTracker">
+// Copyright (c) AIUsageTracker. All rights reserved.
+// </copyright>
+
+using AIUsageTracker.Core.Interfaces;
+using AIUsageTracker.Core.MonitorClient;
+using AIUsageTracker.Infrastructure.Services;
+using Microsoft.Extensions.Logging;
+
+namespace AIUsageTracker.UI.Slim.Services;
+
+public sealed class MonitorStartupOrchestrator
+{
+    private static readonly TimeSpan BaseInterval = TimeSpan.FromSeconds(60);
+    private static readonly TimeSpan MaxInterval = TimeSpan.FromSeconds(300);
+    private static readonly TimeSpan HealthCheckTimeout = TimeSpan.FromMilliseconds(2000);
+
+    private readonly IMonitorService _monitorService;
+    private readonly MonitorLifecycleService _monitorLifecycleService;
+    private readonly ILogger<MonitorStartupOrchestrator> _logger;
+    private readonly TaskCompletionSource<bool> _resumeSignal = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private TaskCompletionSource<bool>? _activeResumeSignal;
+    private int _consecutiveFailures;
+
+    public MonitorStartupOrchestrator(
+        IMonitorService monitorService,
+        MonitorLifecycleService monitorLifecycleService,
+        ILogger<MonitorStartupOrchestrator> logger)
+    {
+        this._monitorService = monitorService;
+        this._monitorLifecycleService = monitorLifecycleService;
+        this._logger = logger;
+        this.CurrentWatchdogInterval = BaseInterval;
+    }
+
+    public TimeSpan CurrentWatchdogInterval { get; private set; }
+
+    public async Task<MonitorStartupOrchestrationResult> EnsureMonitorReadyAsync(
+        Func<string, StatusType, Task> reportStatusAsync,
+        bool skipInitialHealthCheck = false)
+    {
+        ArgumentNullException.ThrowIfNull(reportStatusAsync);
+
+        try
+        {
+            // If caller already checked health and it failed, skip the redundant check
+            // to avoid wasting another 6+ seconds on a TCP timeout.
+            var isRunning = false;
+            if (!skipInitialHealthCheck)
+            {
+                await this._monitorService.RefreshPortAsync().ConfigureAwait(false);
+                isRunning = await this._monitorService.CheckHealthAsync().ConfigureAwait(false);
+            }
+
+            if (!isRunning)
+            {
+                await reportStatusAsync("Starting monitor...", StatusType.Warning).ConfigureAwait(false);
+
+                var monitorReady = await this._monitorLifecycleService.EnsureAgentRunningAsync().ConfigureAwait(false);
+                if (!monitorReady)
+                {
+                    await this._monitorService.RefreshAgentInfoAsync().ConfigureAwait(false);
+                    return new MonitorStartupOrchestrationResult(IsSuccess: false, IsLaunchFailure: true);
+                }
+
+                await this._monitorService.RefreshPortAsync().ConfigureAwait(false);
+            }
+            else if (await this.TryRestartMonitorForVersionMismatchAsync(reportStatusAsync).ConfigureAwait(false))
+            {
+                await this._monitorService.RefreshPortAsync().ConfigureAwait(false);
+            }
+
+            return new MonitorStartupOrchestrationResult(IsSuccess: true, IsLaunchFailure: false);
+        }
+        catch (Exception ex)
+        {
+            this._logger.LogError(ex, "Startup orchestration failed");
+            return new MonitorStartupOrchestrationResult(IsSuccess: false, IsLaunchFailure: false);
+        }
+    }
+
+    public async Task RunWatchdogLoopAsync(CancellationToken cancellationToken)
+    {
+        this._logger.LogDebug("Monitor watchdog started (interval: {Interval}s)", BaseInterval.TotalSeconds);
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            try
+            {
+                // Wait for the current interval OR resume signal, whichever comes first
+                this._activeResumeSignal = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var delayTask = Task.Delay(this.CurrentWatchdogInterval, cancellationToken);
+                var resumeTask = this._activeResumeSignal.Task;
+
+                await Task.WhenAny(delayTask, resumeTask).ConfigureAwait(false);
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
+
+                await this.RunWatchdogTickAsync().ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                this._logger.LogError(ex, "Watchdog tick failed");
+            }
+        }
+
+        this._logger.LogDebug("Monitor watchdog stopped");
+    }
+
+    public async Task RunWatchdogTickAsync()
+    {
+        try
+        {
+            var isHealthy = await this._monitorService.CheckHealthAsync(HealthCheckTimeout).ConfigureAwait(false);
+
+            if (isHealthy)
+            {
+                if (this._consecutiveFailures > 0)
+                {
+                    this._logger.LogInformation("Monitor recovered after {Failures} failed health checks", this._consecutiveFailures);
+                }
+
+                this._consecutiveFailures = 0;
+                this.CurrentWatchdogInterval = BaseInterval;
+                return;
+            }
+
+            this._consecutiveFailures++;
+            this._logger.LogWarning("Monitor health check failed (consecutive failures: {Count})", this._consecutiveFailures);
+
+            await this._monitorService.RefreshPortAsync().ConfigureAwait(false);
+            var restarted = await this._monitorLifecycleService.EnsureAgentRunningAsync().ConfigureAwait(false);
+
+            if (restarted)
+            {
+                this._logger.LogInformation("Monitor relaunched by watchdog after health check failure");
+                await this._monitorService.RefreshPortAsync().ConfigureAwait(false);
+                this._consecutiveFailures = 0;
+                this.CurrentWatchdogInterval = BaseInterval;
+            }
+            else
+            {
+                // Exponential backoff: 60 -> 120 -> 240 -> 300 (capped)
+                var backoffSeconds = Math.Min(
+                    BaseInterval.TotalSeconds * Math.Pow(2, this._consecutiveFailures - 1),
+                    MaxInterval.TotalSeconds);
+                this.CurrentWatchdogInterval = TimeSpan.FromSeconds(backoffSeconds);
+                this._logger.LogWarning(
+                    "Monitor relaunch failed. Next check in {Seconds}s",
+                    this.CurrentWatchdogInterval.TotalSeconds);
+            }
+        }
+        catch (Exception ex)
+        {
+            this._logger.LogError(ex, "Error during watchdog health check");
+            this._consecutiveFailures++;
+            var backoffSeconds = Math.Min(
+                BaseInterval.TotalSeconds * Math.Pow(2, this._consecutiveFailures - 1),
+                MaxInterval.TotalSeconds);
+            this.CurrentWatchdogInterval = TimeSpan.FromSeconds(backoffSeconds);
+        }
+    }
+
+    public void NotifyResumed()
+    {
+        this._activeResumeSignal?.TrySetResult(true);
+    }
+
+    private async Task<bool> TryRestartMonitorForVersionMismatchAsync(Func<string, StatusType, Task> reportStatusAsync)
+    {
+        try
+        {
+            var healthSnapshot = await this._monitorService.GetHealthSnapshotAsync().ConfigureAwait(false);
+            if (healthSnapshot == null)
+            {
+                return false;
+            }
+
+            var monitorVersion = healthSnapshot.AgentVersion;
+            var uiVersion = typeof(App).Assembly.GetName().Version?.ToString();
+            if (string.IsNullOrEmpty(monitorVersion) || string.IsNullOrEmpty(uiVersion))
+            {
+                return false;
+            }
+
+            if (string.Equals(monitorVersion, uiVersion, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            MonitorService.LogDiagnostic(
+                $"Monitor version mismatch (monitor: {monitorVersion}, ui: {uiVersion}). Restarting monitor...");
+            this._logger.LogWarning(
+                "Monitor version mismatch (monitor: {MonitorVersion}, ui: {UiVersion}). Restarting monitor...",
+                monitorVersion,
+                uiVersion);
+
+            await reportStatusAsync("Restarting monitor (version mismatch)...", StatusType.Warning).ConfigureAwait(false);
+
+            await this._monitorLifecycleService.StopAgentAsync().ConfigureAwait(false);
+            var started = await this._monitorLifecycleService.EnsureAgentRunningAsync().ConfigureAwait(false);
+            if (!started)
+            {
+                MonitorService.LogDiagnostic("Failed to restart monitor after version mismatch.");
+                this._logger.LogError("Failed to restart monitor after version mismatch");
+                return false;
+            }
+
+            MonitorService.LogDiagnostic("Monitor restarted successfully after version mismatch.");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            this._logger.LogError(ex, "Error during monitor version mismatch restart");
+            return false;
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test AIUsageTracker.Tests --filter "MonitorStartupOrchestratorWatchdogTests" --no-restore -v minimal`
+Expected: All 5 tests PASS.
+
+- [ ] **Step 5: Run full test suite to check for regressions**
+
+Run: `dotnet test AIUsageTracker.Tests --no-restore -v minimal -T 4`
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add AIUsageTracker.UI.Slim/Services/MonitorStartupOrchestrator.cs AIUsageTracker.Tests/Core/MonitorStartupOrchestratorWatchdogTests.cs
+git commit -m "feat: add adaptive watchdog to MonitorStartupOrchestrator with power-aware fast path"
+```
+
+---
+
+### Task 5: Wire watchdog into UI Slim startup and power events
+
+**Files:**
+- Modify: `AIUsageTracker.UI.Slim/MainWindow.xaml.cs` (start watchdog after initial startup, subscribe to power events)
+
+- [ ] **Step 1: Find where EnsureMonitorReadyAsync is first called in MainWindow**
+
+Read `AIUsageTracker.UI.Slim/MainWindow.xaml.cs` and locate the initial `EnsureMonitorReadyAsync` call. This is where we'll start the watchdog loop after success.
+
+- [ ] **Step 2: Add watchdog startup and power event subscription**
+
+After the first successful `EnsureMonitorReadyAsync()` call in `MainWindow.xaml.cs`, add:
+
+```csharp
+// Start the watchdog loop in the background
+_ = Task.Run(() => this._monitorStartupOrchestrator.RunWatchdogLoopAsync(this._appCts.Token));
+```
+
+Where `_appCts` is the application-level `CancellationTokenSource` (look for existing one or add as field).
+
+In the `MainWindow` constructor or initialization, subscribe to power events for the fast-path wake signal:
+
+```csharp
+if (OperatingSystem.IsWindows())
+{
+    Microsoft.Win32.SystemEvents.PowerModeChanged += this.OnPowerModeChanged;
+}
+```
+
+Add the handler:
+
+```csharp
+[System.Runtime.Versioning.SupportedOSPlatform("windows")]
+private void OnPowerModeChanged(object sender, Microsoft.Win32.PowerModeChangedEventArgs e)
+{
+    if (e.Mode == Microsoft.Win32.PowerModes.Resume)
+    {
+        this._logger.LogInformation("System resumed — triggering immediate watchdog check");
+        this._monitorStartupOrchestrator.NotifyResumed();
+    }
+}
+```
+
+Unsubscribe in the window closing / dispose path:
+
+```csharp
+if (OperatingSystem.IsWindows())
+{
+    Microsoft.Win32.SystemEvents.PowerModeChanged -= this.OnPowerModeChanged;
+}
+```
+
+- [ ] **Step 3: Build the UI.Slim project to verify compilation**
+
+Run: `dotnet build AIUsageTracker.UI.Slim --no-restore -v minimal`
+Expected: Build succeeds.
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `dotnet test --no-restore -v minimal -T 4`
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add AIUsageTracker.UI.Slim/MainWindow.xaml.cs
+git commit -m "feat: wire watchdog loop and power event subscription into UI Slim MainWindow"
+```
+
+---
+
+### Task 6: Full integration verification
+
+- [ ] **Step 1: Build entire solution**
+
+Run: `dotnet build --no-restore -v minimal`
+Expected: Clean build, no warnings related to new code.
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `dotnet test --no-restore -v minimal -T 4`
+Expected: All tests pass.
+
+- [ ] **Step 3: Verify no analyzer violations**
+
+Run: `dotnet build --no-restore -v minimal /p:TreatWarningsAsErrors=true` (if configured)
+Expected: No new warnings.
+
+- [ ] **Step 4: Final commit if any fixups needed**
+
+Only if Steps 1-3 revealed issues that needed fixing.


### PR DESCRIPTION
## Summary
- **PowerStateListener** hosted service in the Monitor that pauses the job scheduler and cancels in-flight provider refreshes on Windows suspend, resumes and triggers a fresh refresh on wake
- **Adaptive watchdog** in MonitorStartupOrchestrator that health-checks the Monitor every 60s, relaunches it on failure with exponential backoff (60s → 300s cap), and uses `SystemEvents.PowerModeChanged` for immediate wake-triggered checks
- **Scheduler Pause/Resume** on `MonitorJobScheduler` using a semaphore gate that blocks dispatch while letting in-flight jobs complete
- **CancelActiveRefresh** on `ProviderRefreshService` via linked `CancellationTokenSource` for clean cancellation of HTTP requests before suspend

Fixes the issue where the Monitor process dies silently after Windows sleep/wake transitions and nothing detects or relaunches it.

## Test plan
- [ ] 2 new `MonitorJobSchedulerTests` — pause blocks dispatch, resume restores it
- [ ] 1 new `ProviderRefreshServiceTests` — CancelActiveRefresh no-op when no refresh active
- [ ] 2 new `PowerStateListenerTests` — suspend pauses scheduler, resume unpauses
- [ ] 5 new `MonitorStartupOrchestratorWatchdogTests` — health check failure triggers relaunch, success skips, backoff increases, recovery resets, NotifyResumed triggers check
- [ ] Architecture guardrail test passes (sync Wait allowed via `architecture-allow-sync-wait` comment)
- [ ] Full solution builds with 0 errors
- [ ] All 148 Monitor.Tests pass, all core tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)