### PR TITLE
refactor: resolve 7 remaining SonarQube HIGH severity issues

### DIFF
--- a/AIUsageTracker.Infrastructure/Providers/KimiProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/KimiProvider.cs
@@ -186,80 +186,98 @@ public class KimiProvider : ProviderBase
     {
         foreach (var limitItem in limits)
         {
-            if (limitItem.Detail == null || limitItem.Window == null)
+            var card = this.TryBuildLimitCard(limitItem, usedCardIds, content, statusCode, authSource);
+            if (card != null)
             {
-                continue;
+                flatCards.Add(card);
             }
-
-            var win = limitItem.Window;
-            var det = limitItem.Detail;
-
-            if (det.Limit <= 0)
-            {
-                continue;
-            }
-
-            string name = $"{FormatDuration(win.Duration, win.TimeUnit ?? "TIME_UNIT_MINUTE")} Limit";
-            var itemUsed = det.Limit - det.Remaining;
-            var itemUsedPercentage = det.Limit > 0 ? (itemUsed / (double)det.Limit) * 100.0 : 0;
-
-            var resetDisplay = FormatResetTime(det.ResetTime ?? string.Empty);
-            DateTime? itemResetDt = null;
-            if (DateTime.TryParse(det.ResetTime, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dt))
-            {
-                itemResetDt = dt.ToUniversalTime();
-            }
-
-            var quotaBucketKind = DetermineWindowKind(win.Duration, win.TimeUnit);
-            TimeSpan? periodDuration;
-            if (quotaBucketKind == WindowKind.Rolling)
-            {
-                periodDuration = TimeSpan.FromDays(win.Duration);
-            }
-            else if (quotaBucketKind == WindowKind.Burst)
-            {
-                periodDuration = string.Equals(win.TimeUnit, "TIME_UNIT_HOUR", StringComparison.Ordinal)
-                    ? TimeSpan.FromHours(win.Duration)
-                    : TimeSpan.FromMinutes(win.Duration);
-            }
-            else
-            {
-                periodDuration = null;
-            }
-
-            var baseCardId = name.ToLowerInvariant()
-                .Replace(" ", "-", StringComparison.Ordinal)
-                .Replace("/", "-", StringComparison.Ordinal);
-            var cardId = baseCardId;
-            var dupCounter = 2;
-            while (!usedCardIds.Add(cardId))
-            {
-                cardId = $"{baseCardId}-{dupCounter.ToString(CultureInfo.InvariantCulture)}";
-                dupCounter++;
-            }
-
-            flatCards.Add(new ProviderUsage
-            {
-                ProviderId = this.ProviderId,
-                ProviderName = this.Definition.DisplayName,
-                CardId = cardId,
-                GroupId = this.ProviderId,
-                Name = name,
-                WindowKind = quotaBucketKind,
-                UsedPercent = itemUsedPercentage,
-                RequestsUsed = itemUsed,
-                RequestsAvailable = det.Limit,
-                IsQuotaBased = this.Definition.IsQuotaBased,
-                PlanType = this.Definition.PlanType,
-                IsAvailable = true,
-                Description = $"{det.Remaining.ToString(CultureInfo.InvariantCulture)} / {det.Limit.ToString(CultureInfo.InvariantCulture)} remaining (Resets: {resetDisplay})",
-                RawJson = content,
-                HttpStatus = statusCode,
-                NextResetTime = itemResetDt,
-                PeriodDuration = periodDuration,
-                AuthSource = authSource ?? string.Empty,
-            });
         }
+    }
+
+    private ProviderUsage? TryBuildLimitCard(KimiLimitItem limitItem, HashSet<string> usedCardIds, string content, int statusCode, string? authSource)
+    {
+        if (limitItem.Detail == null || limitItem.Window == null)
+        {
+            return null;
+        }
+
+        var win = limitItem.Window;
+        var det = limitItem.Detail;
+
+        if (det.Limit <= 0)
+        {
+            return null;
+        }
+
+        string name = $"{FormatDuration(win.Duration, win.TimeUnit ?? "TIME_UNIT_MINUTE")} Limit";
+        var itemUsed = det.Limit - det.Remaining;
+        var itemUsedPercentage = det.Limit > 0 ? (itemUsed / (double)det.Limit) * 100.0 : 0;
+
+        var resetDisplay = FormatResetTime(det.ResetTime ?? string.Empty);
+        DateTime? itemResetDt = null;
+        if (DateTime.TryParse(det.ResetTime, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dt))
+        {
+            itemResetDt = dt.ToUniversalTime();
+        }
+
+        var quotaBucketKind = DetermineWindowKind(win.Duration, win.TimeUnit);
+        var periodDuration = ResolvePeriodDuration(quotaBucketKind, win);
+        var cardId = DeduplicateCardId(name, usedCardIds);
+
+        return new ProviderUsage
+        {
+            ProviderId = this.ProviderId,
+            ProviderName = this.Definition.DisplayName,
+            CardId = cardId,
+            GroupId = this.ProviderId,
+            Name = name,
+            WindowKind = quotaBucketKind,
+            UsedPercent = itemUsedPercentage,
+            RequestsUsed = itemUsed,
+            RequestsAvailable = det.Limit,
+            IsQuotaBased = this.Definition.IsQuotaBased,
+            PlanType = this.Definition.PlanType,
+            IsAvailable = true,
+            Description = $"{det.Remaining.ToString(CultureInfo.InvariantCulture)} / {det.Limit.ToString(CultureInfo.InvariantCulture)} remaining (Resets: {resetDisplay})",
+            RawJson = content,
+            HttpStatus = statusCode,
+            NextResetTime = itemResetDt,
+            PeriodDuration = periodDuration,
+            AuthSource = authSource ?? string.Empty,
+        };
+    }
+
+    private static string DeduplicateCardId(string name, HashSet<string> usedCardIds)
+    {
+        var baseCardId = name.ToLowerInvariant()
+            .Replace(" ", "-", StringComparison.Ordinal)
+            .Replace("/", "-", StringComparison.Ordinal);
+        var cardId = baseCardId;
+        var dupCounter = 2;
+        while (!usedCardIds.Add(cardId))
+        {
+            cardId = $"{baseCardId}-{dupCounter.ToString(CultureInfo.InvariantCulture)}";
+            dupCounter++;
+        }
+
+        return cardId;
+    }
+
+    private static TimeSpan? ResolvePeriodDuration(WindowKind quotaBucketKind, KimiWindow win)
+    {
+        if (quotaBucketKind == WindowKind.Rolling)
+        {
+            return TimeSpan.FromDays(win.Duration);
+        }
+
+        if (quotaBucketKind == WindowKind.Burst)
+        {
+            return string.Equals(win.TimeUnit, "TIME_UNIT_HOUR", StringComparison.Ordinal)
+                ? TimeSpan.FromHours(win.Duration)
+                : TimeSpan.FromMinutes(win.Duration);
+        }
+
+        return null;
     }
 
     private static WindowKind DetermineWindowKind(long duration, string? unit)

--- a/AIUsageTracker.Infrastructure/Providers/ZaiProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/ZaiProvider.cs
@@ -87,24 +87,9 @@ public class ZaiProvider : ProviderBase
 
         if (limits == null || limits.Count == 0)
         {
-            this._logger.LogDebug("[ZAI] No limits found in response");
-            return new[]
-            {
-                new ProviderUsage
-             {
-                 ProviderId = this.ProviderId,
-                 ProviderName = providerLabel,
-                 IsAvailable = false,
-                 Description = "No usage data available",
-                 IsQuotaBased = this.Definition.IsQuotaBased,
-                 PlanType = this.Definition.PlanType,
-                 RawJson = responseString,
-                 HttpStatus = httpStatus,
-             },
-            };
+            return this.BuildNoLimitsResult(providerLabel, responseString, httpStatus);
         }
 
-        // Log all limits for debugging
         foreach (var limit in limits)
         {
             this._logger.LogDebug(
@@ -117,6 +102,51 @@ public class ZaiProvider : ProviderBase
                 limit.NextResetTime);
         }
 
+        var (tokenLimit, mcpLimit) = this.SelectLimits(limits);
+
+        this._logger.LogDebug(
+            "[ZAI] Found token limit: {Found}, mcp limit: {McpFound}",
+            tokenLimit != null,
+            mcpLimit != null);
+
+        var tokenResult = this.ProcessTokenLimit(tokenLimit);
+        tokenResult = this.ApplyMcpAdjustment(tokenResult, mcpLimit);
+
+        var tokenWindowDuration = tokenLimit?.Unit == 3 && tokenLimit.Number.HasValue
+            ? TimeSpan.FromHours(tokenLimit.Number.Value)
+            : (TimeSpan?)null;
+
+        var (nextResetTime, resetStr) = this.ResolveResetTimeInfo(tokenLimit, tokenWindowDuration, limits);
+
+        if (!tokenResult.RemainingPercent.HasValue)
+        {
+            return this.BuildUnknownUsageResult(providerLabel, responseString, httpStatus, tokenResult);
+        }
+
+        return new[] { this.BuildUsageResult(tokenResult, providerLabel, responseString, httpStatus, nextResetTime, resetStr) };
+    }
+
+    private IEnumerable<ProviderUsage> BuildNoLimitsResult(string providerLabel, string responseString, int httpStatus)
+    {
+        this._logger.LogDebug("[ZAI] No limits found in response");
+        return new[]
+        {
+            new ProviderUsage
+            {
+                ProviderId = this.ProviderId,
+                ProviderName = providerLabel,
+                IsAvailable = false,
+                Description = "No usage data available",
+                IsQuotaBased = this.Definition.IsQuotaBased,
+                PlanType = this.Definition.PlanType,
+                RawJson = responseString,
+                HttpStatus = httpStatus,
+            },
+        };
+    }
+
+    private (ZaiQuotaLimitItem? TokenLimit, ZaiQuotaLimitItem? McpLimit) SelectLimits(List<ZaiQuotaLimitItem> limits)
+    {
         var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
         var nowSec = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
 
@@ -127,43 +157,39 @@ public class ZaiProvider : ProviderBase
         var tokenLimit = tokenLimits.Where(l => IsFutureTimestamp(l.NextResetTime, nowMs, nowSec))
                                     .OrderBy(l => l.Remaining ?? long.MaxValue)
                                     .FirstOrDefault()
-                         ?? tokenLimits.FirstOrDefault();
+                          ?? tokenLimits.FirstOrDefault();
 
         var mcpLimit = limits.FirstOrDefault(l =>
             l.Type != null && (l.Type.Equals("TIME_LIMIT", StringComparison.OrdinalIgnoreCase) ||
                                l.Type.Equals("Time", StringComparison.OrdinalIgnoreCase)));
 
-        this._logger.LogDebug(
-            "[ZAI] Found token limit: {Found}, mcp limit: {McpFound}",
-            tokenLimit != null,
-            mcpLimit != null);
+        return (tokenLimit, mcpLimit);
+    }
 
-        var tokenResult = this.ProcessTokenLimit(tokenLimit);
-
-        if (mcpLimit != null && mcpLimit.Percentage > 0)
+    private TokenLimitResult ApplyMcpAdjustment(TokenLimitResult tokenResult, ZaiQuotaLimitItem? mcpLimit)
+    {
+        if (mcpLimit == null || mcpLimit.Percentage <= 0)
         {
-            this._logger.LogDebug("[ZAI] Processing TIME_LIMIT - Percentage: {Percentage}", mcpLimit.Percentage);
-            double mcpRemainingPercent = Math.Max(0, 100 - mcpLimit.Percentage.Value);
-            tokenResult = tokenResult with
-            {
-                RemainingPercent = tokenResult.RemainingPercent.HasValue
-                    ? Math.Min(tokenResult.RemainingPercent.Value, mcpRemainingPercent)
-                    : mcpRemainingPercent,
-            };
-            this._logger.LogDebug("[ZAI] MCP remaining percent: {McpRemainingPercent}", mcpRemainingPercent);
+            return tokenResult;
         }
 
-        var tokenWindowDuration = tokenLimit?.Unit == 3 && tokenLimit.Number.HasValue
-            ? TimeSpan.FromHours(tokenLimit.Number.Value)
-            : (TimeSpan?)null;
-
-        var (nextResetTime, resetStr) = this.ResolveResetTimeInfo(tokenLimit, tokenWindowDuration, limits);
-
-        if (!tokenResult.RemainingPercent.HasValue)
+        this._logger.LogDebug("[ZAI] Processing TIME_LIMIT - Percentage: {Percentage}", mcpLimit.Percentage);
+        double mcpRemainingPercent = Math.Max(0, 100 - mcpLimit.Percentage.Value);
+        var adjusted = tokenResult with
         {
-            return new[]
-            {
-                new ProviderUsage
+            RemainingPercent = tokenResult.RemainingPercent.HasValue
+                ? Math.Min(tokenResult.RemainingPercent.Value, mcpRemainingPercent)
+                : mcpRemainingPercent,
+        };
+        this._logger.LogDebug("[ZAI] MCP remaining percent: {McpRemainingPercent}", mcpRemainingPercent);
+        return adjusted;
+    }
+
+    private IEnumerable<ProviderUsage> BuildUnknownUsageResult(string providerLabel, string responseString, int httpStatus, TokenLimitResult tokenResult)
+    {
+        return new[]
+        {
+            new ProviderUsage
             {
                 ProviderId = this.ProviderId,
                 ProviderName = providerLabel,
@@ -174,22 +200,31 @@ public class ZaiProvider : ProviderBase
                 RawJson = responseString,
                 HttpStatus = httpStatus,
             },
-            };
-        }
+        };
+    }
 
-        var finalRemainingPercent = Math.Min(tokenResult.RemainingPercent.Value, 100);
+    private ProviderUsage BuildUsageResult(
+        TokenLimitResult tokenResult,
+        string providerLabel,
+        string responseString,
+        int httpStatus,
+        DateTime? nextResetTime,
+        string resetStr)
+    {
+        var finalRemainingPercent = Math.Min(tokenResult.RemainingPercent!.Value, 100);
         var finalUsedPercent = Math.Max(0, 100.0 - finalRemainingPercent);
 
-        if (!tokenResult.HasRawLimitData)
-        {
-            tokenResult = tokenResult with
+        tokenResult = !tokenResult.HasRawLimitData
+            ? tokenResult with
             {
                 RequestsAvailable = 100,
                 RequestsUsed = Math.Max(0, 100 - finalRemainingPercent),
-            };
-        }
+            }
+            : tokenResult;
 
-        var finalDescription = (string.IsNullOrEmpty(tokenResult.DetailInfo) ? $"{finalRemainingPercent.ToString("F1", CultureInfo.InvariantCulture)}% remaining" : tokenResult.DetailInfo) + resetStr;
+        var finalDescription = (string.IsNullOrEmpty(tokenResult.DetailInfo)
+            ? $"{finalRemainingPercent.ToString("F1", CultureInfo.InvariantCulture)}% remaining"
+            : tokenResult.DetailInfo) + resetStr;
 
         this._logger.LogInformation(
             "Z.AI Provider Usage - ProviderId: {ProviderId}, ProviderName: {ProviderName}, UsedPercent: {UsedPercent}%, RequestsUsed: {RequestsUsed}%, Description: {Description}, IsAvailable: {IsAvailable}",
@@ -200,9 +235,7 @@ public class ZaiProvider : ProviderBase
             finalDescription,
             true);
 
-        return new[]
-        {
-            new ProviderUsage
+        return new ProviderUsage
         {
             ProviderId = this.ProviderId,
             ProviderName = providerLabel,
@@ -217,7 +250,6 @@ public class ZaiProvider : ProviderBase
             IsAvailable = true,
             RawJson = responseString,
             HttpStatus = httpStatus,
-        },
         };
     }
 

--- a/AIUsageTracker.Monitor/Program.cs
+++ b/AIUsageTracker.Monitor/Program.cs
@@ -44,16 +44,7 @@ public partial class Program
                 $"Preferred monitor log directory '{resolvedLogPath.PreferredDirectory}' unavailable. Using fallback '{resolvedLogPath.LogDirectory}'.").ConfigureAwait(false);
         }
 
-        using var loggerFactory = LoggerFactory.Create(builder =>
-        {
-            builder
-                .SetMinimumLevel(isDebugMode ? LogLevel.Debug : LogLevel.Information)
-                .AddProvider(new FileLoggerProvider(resolvedLogPath.LogFile));
-            if (isDebugMode)
-            {
-                builder.AddConsole();
-            }
-        });
+        using var loggerFactory = CreateLoggerFactory(isDebugMode, resolvedLogPath.LogFile);
 
         var logger = loggerFactory.CreateLogger("Monitor");
 
@@ -65,21 +56,7 @@ public partial class Program
                 resolvedLogPath.LogDirectory);
         }
 
-        // Rotate logs: keep only last 7 days
-        try
-        {
-            var cutoffDate = DateTime.Now.AddDays(-7);
-            foreach (var fileInfo in Directory.GetFiles(resolvedLogPath.LogDirectory, "monitor_*.log")
-                         .Select(log => new FileInfo(log))
-                         .Where(fi => fi.LastWriteTime < cutoffDate))
-            {
-                fileInfo.Delete();
-            }
-        }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
-        {
-            logger.LogError(ex, "Log rotation error");
-        }
+        RotateOldLogs(resolvedLogPath.LogDirectory, logger);
 
         var monitorVersion = System.Reflection.CustomAttributeExtensions
             .GetCustomAttribute<System.Reflection.AssemblyInformationalVersionAttribute>(typeof(Program).Assembly)
@@ -120,68 +97,7 @@ public partial class Program
             logger.LogDebug("Configuring web host on port {Port}...", port);
             logger.LogDebug("Base Directory: {BaseDir}", AppDomain.CurrentDomain.BaseDirectory);
 
-            var builder = WebApplication.CreateBuilder(args);
-
-            // Configure URLs with the available port
-            builder.WebHost.UseUrls($"http://localhost:{port}");
-
-            // Suppress default console logging in debug mode (we handle our own)
-            if (isDebugMode)
-            {
-                builder.Logging.SetMinimumLevel(LogLevel.Information);
-            }
-
-            builder.Services.AddCors(options =>
-            {
-                options.AddDefaultPolicy(policy =>
-                {
-                    policy.WithOrigins("http://localhost:5100", "http://localhost:5000") // Explicit origins for SignalR/CORS safety
-                          .WithMethods("GET", "POST", "DELETE")
-                          .WithHeaders("Content-Type", "Authorization", "X-Requested-With")
-                          .AllowCredentials(); // Required for SignalR with WebSockets/Long Polling
-                });
-            });
-
-            builder.Services.AddSignalR();
-
-            // Configure JSON serialization — delegates to the Core canonical options
-            builder.Services.ConfigureHttpJsonOptions(options =>
-                MonitorJsonSerializer.Configure(options.SerializerOptions));
-
-            RegisterServices(builder, loggerFactory, pathProvider, logger, isDebugMode);
-
-            var app = builder.Build();
-
-            // Async database initialization
-            using (var scope = app.Services.CreateScope())
-            {
-                var db = scope.ServiceProvider.GetRequiredService<UsageDatabase>();
-                await db.InitializeAsync().ConfigureAwait(false);
-            }
-
-            app.UseCors();
-
-            app.MapHub<UsageHub>("/hubs/usage");
-
-            if (isDebugMode)
-            {
-                logger.LogDebug("Registering API endpoints...");
-            }
-
-            const string contractVersion = MonitorApiContract.CurrentVersion;
-            const string minClientContractVersion = MonitorApiContract.MinimumClientVersion;
-            var agentVersion = typeof(UsageDatabase).Assembly.GetName().Version?.ToString() ?? "unknown";
-
-            MonitorEndpointsRegistration.MapAll(
-                app,
-                isDebugMode,
-                port,
-                agentVersion,
-                contractVersion,
-                minClientContractVersion,
-                args);
-
-            await app.StartAsync().ConfigureAwait(false);
+            var app = await BuildAndStartWebApp(args, port, loggerFactory, pathProvider, logger, isDebugMode).ConfigureAwait(false);
 
             if (isDebugMode)
             {
@@ -201,17 +117,122 @@ public partial class Program
         }
         finally
         {
-            if (holdsStartupMutex)
+            ReleaseStartupMutex(startupMutex, holdsStartupMutex, logger);
+        }
+    }
+
+    private static ILoggerFactory CreateLoggerFactory(bool isDebugMode, string logFilePath)
+    {
+        return LoggerFactory.Create(builder =>
+        {
+            builder
+                .SetMinimumLevel(isDebugMode ? LogLevel.Debug : LogLevel.Information)
+                .AddProvider(new FileLoggerProvider(logFilePath));
+            if (isDebugMode)
             {
-                try
-                {
-                    startupMutex.ReleaseMutex();
-                }
-                catch (ApplicationException ex)
-                {
-                    logger.LogDebug(ex, "Startup mutex ownership was lost before shutdown.");
-                }
+                builder.AddConsole();
             }
+        });
+    }
+
+    private static void RotateOldLogs(string logDirectory, ILogger logger)
+    {
+        try
+        {
+            var cutoffDate = DateTime.Now.AddDays(-7);
+            foreach (var fileInfo in Directory.GetFiles(logDirectory, "monitor_*.log")
+                         .Select(log => new FileInfo(log))
+                         .Where(fi => fi.LastWriteTime < cutoffDate))
+            {
+                fileInfo.Delete();
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            logger.LogError(ex, "Log rotation error");
+        }
+    }
+
+    private static async Task<WebApplication> BuildAndStartWebApp(
+        string[] args,
+        int port,
+        ILoggerFactory loggerFactory,
+        IAppPathProvider pathProvider,
+        ILogger logger,
+        bool isDebugMode)
+    {
+        var builder = WebApplication.CreateBuilder(args);
+        builder.WebHost.UseUrls($"http://localhost:{port}");
+
+        if (isDebugMode)
+        {
+            builder.Logging.SetMinimumLevel(LogLevel.Information);
+        }
+
+        builder.Services.AddCors(options =>
+        {
+            options.AddDefaultPolicy(policy =>
+            {
+                policy.WithOrigins("http://localhost:5100", "http://localhost:5000")
+                      .WithMethods("GET", "POST", "DELETE")
+                      .WithHeaders("Content-Type", "Authorization", "X-Requested-With")
+                      .AllowCredentials();
+            });
+        });
+
+        builder.Services.AddSignalR();
+        builder.Services.ConfigureHttpJsonOptions(options =>
+            MonitorJsonSerializer.Configure(options.SerializerOptions));
+
+        RegisterServices(builder, loggerFactory, pathProvider, logger, isDebugMode);
+
+        var app = builder.Build();
+
+        using (var scope = app.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<UsageDatabase>();
+            await db.InitializeAsync().ConfigureAwait(false);
+        }
+
+        app.UseCors();
+        app.MapHub<UsageHub>("/hubs/usage");
+
+        if (isDebugMode)
+        {
+            logger.LogDebug("Registering API endpoints...");
+        }
+
+        const string contractVersion = MonitorApiContract.CurrentVersion;
+        const string minClientContractVersion = MonitorApiContract.MinimumClientVersion;
+        var agentVersion = typeof(UsageDatabase).Assembly.GetName().Version?.ToString() ?? "unknown";
+
+        MonitorEndpointsRegistration.MapAll(
+            app,
+            isDebugMode,
+            port,
+            agentVersion,
+            contractVersion,
+            minClientContractVersion,
+            args);
+
+        await app.StartAsync().ConfigureAwait(false);
+        return app;
+    }
+
+    private static void ReleaseStartupMutex(Mutex startupMutex, bool holdsMutex, ILogger logger)
+    {
+        if (!holdsMutex)
+        {
+            return;
+        }
+
+        try
+        {
+            startupMutex.ReleaseMutex();
+        }
+        catch (ApplicationException ex)
+        {
+            logger.LogDebug(ex, "Startup mutex ownership was lost before shutdown.");
         }
     }
 

--- a/AIUsageTracker.UI.Slim/ProviderCardRenderer.cs
+++ b/AIUsageTracker.UI.Slim/ProviderCardRenderer.cs
@@ -82,20 +82,7 @@ internal sealed class ProviderCardRenderer
 
         var contentPadding = isCompact ? 4 : 6;
         var contentPanel = new DockPanel { LastChildFill = false, Margin = new Thickness(contentPadding, 0, contentPadding, 0) };
-        if (isChild)
-        {
-            AddDockedElement(contentPanel, this.CreateBulletMarker(), Dock.Left);
-        }
-        else
-        {
-            var iconSize = isCompact ? 12 : 14;
-            var providerIcon = this._createProviderIcon(providerId);
-            providerIcon.Margin = new Thickness(0, 0, isCompact ? 4 : 6, 0);
-            providerIcon.Width = iconSize;
-            providerIcon.Height = iconSize;
-            providerIcon.VerticalAlignment = VerticalAlignment.Center;
-            AddDockedElement(contentPanel, providerIcon, Dock.Left);
-        }
+        this.AddCardIcon(contentPanel, providerId, isChild, isCompact);
 
         // Right-side slots rendered from right to left (rightmost = first added)
         this.RenderSlot(contentPanel, this._preferences.CardResetInfo, usage, presentation, showUsed, cardPaceColor);
@@ -117,6 +104,21 @@ internal sealed class ProviderCardRenderer
                 isChild),
             Dock.Left);
 
+        this.AddStatusBadges(contentPanel, presentation);
+        grid.Children.Add(contentPanel);
+
+        if (presentation.IsStale)
+        {
+            grid.Opacity = 0.55;
+        }
+
+        this.AttachTooltip(grid, usage, friendlyName);
+
+        return grid;
+    }
+
+    private void AddStatusBadges(DockPanel contentPanel, ProviderCardPresentation presentation)
+    {
         if (presentation.IsExpired)
         {
             AddDockedElement(
@@ -132,7 +134,6 @@ internal sealed class ProviderCardRenderer
 
         if (presentation.IsStale)
         {
-            // Add visible "Stale" badge before the provider name
             AddDockedElement(
                 contentPanel,
                 this.CreateDockedTextBlock(
@@ -143,22 +144,33 @@ internal sealed class ProviderCardRenderer
                     margin: new Thickness(6, 0, 0, 0)),
                 Dock.Right);
         }
+    }
 
-        grid.Children.Add(contentPanel);
-
-        if (presentation.IsStale)
-        {
-            grid.Opacity = 0.55;
-        }
-
+    private void AttachTooltip(Grid grid, ProviderUsage usage, string friendlyName)
+    {
         var toolTipContent = MainWindowRuntimeLogic.BuildTooltipContent(usage, friendlyName);
         if (!string.IsNullOrEmpty(toolTipContent))
         {
             grid.ToolTip = this._createToolTip(grid, toolTipContent);
             this._configureToolTip(grid);
         }
+    }
 
-        return grid;
+    private void AddCardIcon(DockPanel contentPanel, string providerId, bool isChild, bool isCompact)
+    {
+        if (isChild)
+        {
+            AddDockedElement(contentPanel, this.CreateBulletMarker(), Dock.Left);
+            return;
+        }
+
+        var iconSize = isCompact ? 12 : 14;
+        var providerIcon = this._createProviderIcon(providerId);
+        providerIcon.Margin = new Thickness(0, 0, isCompact ? 4 : 6, 0);
+        providerIcon.Width = iconSize;
+        providerIcon.Height = iconSize;
+        providerIcon.VerticalAlignment = VerticalAlignment.Center;
+        AddDockedElement(contentPanel, providerIcon, Dock.Left);
     }
 
     private static string ResolveFriendlyName(ProviderUsage usage, ProviderDefinition? definition, string providerId)
@@ -384,66 +396,77 @@ internal sealed class ProviderCardRenderer
             case CardSlotContent.PaceBadge:
                 this.RenderPaceBadgeSlot(panel, paceColor);
                 break;
-
             case CardSlotContent.ProjectedPercent:
-                if (paceColor.IsPaceAdjusted)
-                {
-                    this.AddSlotText(panel, $"Projected: {paceColor.ProjectedPercent.ToString("F0", CultureInfo.InvariantCulture)}%", this._getResourceBrush(ResourceKeyTertiaryText, Brushes.Gray), 9);
-                }
-
+                this.RenderProjectedPercent(panel, paceColor);
                 break;
-
             case CardSlotContent.DailyBudget:
-                if (usage.PeriodDuration.HasValue && usage.PeriodDuration.Value.TotalDays >= 1)
-                {
-                    var dailyBudget = 100.0 / usage.PeriodDuration.Value.TotalDays;
-                    this.AddSlotText(panel, $"{dailyBudget.ToString("F0", CultureInfo.InvariantCulture)}%/day budget", this._getResourceBrush(ResourceKeyTertiaryText, Brushes.Gray), 9);
-                }
-
+                this.RenderDailyBudget(panel, usage);
                 break;
-
             case CardSlotContent.UsageRate:
-                if (this._preferences.ShowUsagePerHour && usage.UsagePerHour.HasValue)
-                {
-                    this.AddSlotText(panel, $"{usage.UsagePerHour.Value:F1}/hr", this._getResourceBrush(ResourceKeyTertiaryText, Brushes.Gray), 9);
-                }
-
+                this.RenderUsageRate(panel, usage);
                 break;
-
             case CardSlotContent.UsedPercent:
                 this.AddSlotText(panel, $"{usage.UsedPercent.ToString("F0", CultureInfo.InvariantCulture)}% used", this._getResourceBrush(ResourceKeySecondaryText, Brushes.Gray), 10);
                 break;
-
             case CardSlotContent.RemainingPercent:
                 this.AddSlotText(panel, $"{Math.Max(0, 100 - usage.UsedPercent).ToString("F0", CultureInfo.InvariantCulture)}% remaining", this._getResourceBrush(ResourceKeySecondaryText, Brushes.Gray), 10);
                 break;
-
             case CardSlotContent.ResetAbsolute:
             case CardSlotContent.ResetAbsoluteDate:
             case CardSlotContent.ResetRelative:
                 this.RenderResetSlot(panel, slot, usage, presentation);
                 break;
-
             case CardSlotContent.StatusText:
                 this.RenderStatusTextSlot(panel, presentation, showUsed);
                 break;
-
             case CardSlotContent.AccountName:
-                if (!string.IsNullOrWhiteSpace(usage.AccountName))
-                {
-                    var name = this._isPrivacyMode ? "****" : usage.AccountName;
-                    this.AddSlotText(panel, name, this._getResourceBrush(ResourceKeyTertiaryText, Brushes.Gray), 9);
-                }
-
+                this.RenderAccountName(panel, usage);
                 break;
-
             case CardSlotContent.AuthSource:
-                if (!string.IsNullOrWhiteSpace(usage.AuthSource))
-                {
-                    this.AddSlotText(panel, usage.AuthSource, this._getResourceBrush(ResourceKeyTertiaryText, Brushes.Gray), 9);
-                }
-
+                this.RenderAuthSource(panel, usage);
                 break;
+        }
+    }
+
+    private void RenderProjectedPercent(DockPanel panel, PaceColorResult paceColor)
+    {
+        if (paceColor.IsPaceAdjusted)
+        {
+            this.AddSlotText(panel, $"Projected: {paceColor.ProjectedPercent.ToString("F0", CultureInfo.InvariantCulture)}%", this._getResourceBrush(ResourceKeyTertiaryText, Brushes.Gray), 9);
+        }
+    }
+
+    private void RenderDailyBudget(DockPanel panel, ProviderUsage usage)
+    {
+        if (usage.PeriodDuration.HasValue && usage.PeriodDuration.Value.TotalDays >= 1)
+        {
+            var dailyBudget = 100.0 / usage.PeriodDuration.Value.TotalDays;
+            this.AddSlotText(panel, $"{dailyBudget.ToString("F0", CultureInfo.InvariantCulture)}%/day budget", this._getResourceBrush(ResourceKeyTertiaryText, Brushes.Gray), 9);
+        }
+    }
+
+    private void RenderUsageRate(DockPanel panel, ProviderUsage usage)
+    {
+        if (this._preferences.ShowUsagePerHour && usage.UsagePerHour.HasValue)
+        {
+            this.AddSlotText(panel, $"{usage.UsagePerHour.Value:F1}/hr", this._getResourceBrush(ResourceKeyTertiaryText, Brushes.Gray), 9);
+        }
+    }
+
+    private void RenderAccountName(DockPanel panel, ProviderUsage usage)
+    {
+        if (!string.IsNullOrWhiteSpace(usage.AccountName))
+        {
+            var name = this._isPrivacyMode ? "****" : usage.AccountName;
+            this.AddSlotText(panel, name, this._getResourceBrush(ResourceKeyTertiaryText, Brushes.Gray), 9);
+        }
+    }
+
+    private void RenderAuthSource(DockPanel panel, ProviderUsage usage)
+    {
+        if (!string.IsNullOrWhiteSpace(usage.AuthSource))
+        {
+            this.AddSlotText(panel, usage.AuthSource, this._getResourceBrush(ResourceKeyTertiaryText, Brushes.Gray), 9);
         }
     }
 

--- a/AIUsageTracker.UI.Slim/ProviderCardRenderer.cs
+++ b/AIUsageTracker.UI.Slim/ProviderCardRenderer.cs
@@ -52,19 +52,7 @@ internal sealed class ProviderCardRenderer
     public FrameworkElement CreateProviderCard(ProviderUsage usage, bool showUsed, bool isChild = false, ProviderDefinition? definition = null)
     {
         var providerId = usage.ProviderId ?? string.Empty;
-        string friendlyName;
-        if (!string.IsNullOrEmpty(usage.CardId))
-        {
-            friendlyName = usage.ProviderName ?? string.Empty;
-        }
-        else if (definition != null)
-        {
-            friendlyName = definition.ResolveDisplayName(providerId) ?? usage.ProviderName;
-        }
-        else
-        {
-            friendlyName = ProviderMetadataCatalog.ResolveDisplayLabel(usage);
-        }
+        var friendlyName = ResolveFriendlyName(usage, definition, providerId);
 
         var presentation = MainWindowRuntimeLogic.Create(usage, showUsed, this._preferences.EnablePaceAdjustment);
 
@@ -90,39 +78,7 @@ internal sealed class ProviderCardRenderer
 
         var cardPaceColor = presentation.DualBar?.Secondary.PaceColor ?? presentation.PaceColor;
 
-        var useBackgroundBar = this._preferences.CardBackgroundBar;
-        if (useBackgroundBar)
-        {
-            pGrid.Visibility = presentation.ShouldHaveProgress ? Visibility.Visible : Visibility.Collapsed;
-            grid.Children.Add(pGrid);
-
-            var bg = new Border
-            {
-                Background = this._getResourceBrush("CardBackground", Brushes.DarkGray),
-                CornerRadius = new CornerRadius(0),
-                Visibility = presentation.ShouldHaveProgress ? Visibility.Collapsed : Visibility.Visible,
-            };
-            grid.Children.Add(bg);
-        }
-        else
-        {
-            // Color-indicator-only mode: thin color stripe on the left edge
-            grid.Children.Add(new Border
-            {
-                Background = this._getResourceBrush("CardBackground", Brushes.DarkGray),
-            });
-
-            if (presentation.ShouldHaveProgress)
-            {
-                grid.Children.Add(new Border
-                {
-                    Width = 3,
-                    HorizontalAlignment = HorizontalAlignment.Left,
-                    Background = this.GetProgressBarColor(cardPaceColor),
-                    Opacity = 0.8,
-                });
-            }
-        }
+        this.AddCardBackground(grid, pGrid, presentation, cardPaceColor);
 
         var contentPadding = isCompact ? 4 : 6;
         var contentPanel = new DockPanel { LastChildFill = false, Margin = new Thickness(contentPadding, 0, contentPadding, 0) };
@@ -203,6 +159,57 @@ internal sealed class ProviderCardRenderer
         }
 
         return grid;
+    }
+
+    private static string ResolveFriendlyName(ProviderUsage usage, ProviderDefinition? definition, string providerId)
+    {
+        if (!string.IsNullOrEmpty(usage.CardId))
+        {
+            return usage.ProviderName ?? string.Empty;
+        }
+
+        if (definition != null)
+        {
+            return definition.ResolveDisplayName(providerId) ?? usage.ProviderName;
+        }
+
+        return ProviderMetadataCatalog.ResolveDisplayLabel(usage);
+    }
+
+    private void AddCardBackground(Grid grid, Grid pGrid, ProviderCardPresentation presentation, PaceColorResult cardPaceColor)
+    {
+        var useBackgroundBar = this._preferences.CardBackgroundBar;
+        if (useBackgroundBar)
+        {
+            pGrid.Visibility = presentation.ShouldHaveProgress ? Visibility.Visible : Visibility.Collapsed;
+            grid.Children.Add(pGrid);
+
+            var bg = new Border
+            {
+                Background = this._getResourceBrush("CardBackground", Brushes.DarkGray),
+                CornerRadius = new CornerRadius(0),
+                Visibility = presentation.ShouldHaveProgress ? Visibility.Collapsed : Visibility.Visible,
+            };
+            grid.Children.Add(bg);
+        }
+        else
+        {
+            grid.Children.Add(new Border
+            {
+                Background = this._getResourceBrush("CardBackground", Brushes.DarkGray),
+            });
+
+            if (presentation.ShouldHaveProgress)
+            {
+                grid.Children.Add(new Border
+                {
+                    Width = 3,
+                    HorizontalAlignment = HorizontalAlignment.Left,
+                    Background = this.GetProgressBarColor(cardPaceColor),
+                    Opacity = 0.8,
+                });
+            }
+        }
     }
 
     private void BuildDualProgressBar(Grid pGrid, ProviderCardPresentation presentation, bool showUsed)
@@ -375,17 +382,7 @@ internal sealed class ProviderCardRenderer
         switch (slot)
         {
             case CardSlotContent.PaceBadge:
-                if (paceColor.IsPaceAdjusted)
-                {
-                    var badgeBrush = paceColor.PaceTier switch
-                    {
-                        PaceTier.OverPace => this._getResourceBrush(ResourceKeyProgressBarRed, Brushes.IndianRed),
-                        _ => this._getResourceBrush(ResourceKeyProgressBarGreen, Brushes.MediumSeaGreen),
-                    };
-                    this.AddSlotText(panel, paceColor.ProjectedText, this._getResourceBrush(ResourceKeyTertiaryText, Brushes.Gray), 9);
-                    this.AddSlotText(panel, paceColor.BadgeText, badgeBrush, 9, FontWeights.SemiBold);
-                }
-
+                this.RenderPaceBadgeSlot(panel, paceColor);
                 break;
 
             case CardSlotContent.ProjectedPercent:
@@ -428,19 +425,7 @@ internal sealed class ProviderCardRenderer
                 break;
 
             case CardSlotContent.StatusText:
-                var statusText = presentation.DualBar != null && !this._preferences.ShowDualQuotaBars
-                    ? MainWindowRuntimeLogic.BuildSingleDualQuotaStatusText(
-                        presentation, showUsed, this._preferences.DualQuotaSingleBarMode)
-                    : presentation.StatusText;
-
-                Brush statusBrush = presentation.StatusTone switch
-                {
-                    ProviderCardStatusTone.Missing => Brushes.IndianRed,
-                    ProviderCardStatusTone.Warning => Brushes.Orange,
-                    ProviderCardStatusTone.Error => Brushes.Red,
-                    _ => this._getResourceBrush(ResourceKeySecondaryText, Brushes.Gray),
-                };
-                this.AddSlotText(panel, statusText, statusBrush, 10);
+                this.RenderStatusTextSlot(panel, presentation, showUsed);
                 break;
 
             case CardSlotContent.AccountName:
@@ -460,6 +445,39 @@ internal sealed class ProviderCardRenderer
 
                 break;
         }
+    }
+
+    private void RenderPaceBadgeSlot(DockPanel panel, PaceColorResult paceColor)
+    {
+        if (!paceColor.IsPaceAdjusted)
+        {
+            return;
+        }
+
+        var badgeBrush = paceColor.PaceTier switch
+        {
+            PaceTier.OverPace => this._getResourceBrush(ResourceKeyProgressBarRed, Brushes.IndianRed),
+            _ => this._getResourceBrush(ResourceKeyProgressBarGreen, Brushes.MediumSeaGreen),
+        };
+        this.AddSlotText(panel, paceColor.ProjectedText, this._getResourceBrush(ResourceKeyTertiaryText, Brushes.Gray), 9);
+        this.AddSlotText(panel, paceColor.BadgeText, badgeBrush, 9, FontWeights.SemiBold);
+    }
+
+    private void RenderStatusTextSlot(DockPanel panel, ProviderCardPresentation presentation, bool showUsed)
+    {
+        var statusText = presentation.DualBar != null && !this._preferences.ShowDualQuotaBars
+            ? MainWindowRuntimeLogic.BuildSingleDualQuotaStatusText(
+                presentation, showUsed, this._preferences.DualQuotaSingleBarMode)
+            : presentation.StatusText;
+
+        Brush statusBrush = presentation.StatusTone switch
+        {
+            ProviderCardStatusTone.Missing => Brushes.IndianRed,
+            ProviderCardStatusTone.Warning => Brushes.Orange,
+            ProviderCardStatusTone.Error => Brushes.Red,
+            _ => this._getResourceBrush(ResourceKeySecondaryText, Brushes.Gray),
+        };
+        this.AddSlotText(panel, statusText, statusBrush, 10);
     }
 
     private void RenderResetSlot(DockPanel panel, CardSlotContent slot, ProviderUsage usage, ProviderCardPresentation presentation)

--- a/AIUsageTracker.UI.Slim/SettingsWindow.xaml.cs
+++ b/AIUsageTracker.UI.Slim/SettingsWindow.xaml.cs
@@ -868,39 +868,7 @@ public partial class SettingsWindow : Window
 
         foreach (var config in this._configs)
         {
-            var behavior = ResolveProviderSettingsBehavior(
-                config,
-                this._usages.FirstOrDefault(u => string.Equals(u.ProviderId, config.ProviderId, StringComparison.OrdinalIgnoreCase)),
-                isDerived: false);
-
-            if (behavior.InputMode == ProviderInputMode.StandardApiKey && string.IsNullOrWhiteSpace(config.ApiKey))
-            {
-                var removed = await this._monitorService.RemoveConfigAsync(config.ProviderId).ConfigureAwait(true);
-                if (!removed)
-                {
-                    failedConfigs.Add(config.ProviderId);
-                    continue;
-                }
-
-                if (!this._preferences.SuppressedProviderIds.Contains(config.ProviderId, StringComparer.OrdinalIgnoreCase))
-                {
-                    this._preferences.SuppressedProviderIds.Add(config.ProviderId);
-                }
-
-                removedProviderIds.Add(config.ProviderId);
-                continue;
-            }
-
-            if (this._preferences.SuppressedProviderIds.Contains(config.ProviderId, StringComparer.OrdinalIgnoreCase))
-            {
-                this._preferences.SuppressedProviderIds.Remove(config.ProviderId);
-            }
-
-            var saved = await this._monitorService.SaveConfigAsync(config).ConfigureAwait(true);
-            if (!saved)
-            {
-                failedConfigs.Add(config.ProviderId);
-            }
+            await this.ProcessSingleProviderConfigAsync(config, failedConfigs, removedProviderIds).ConfigureAwait(true);
         }
 
         this._monitorService.InvalidateGroupedUsageCache();
@@ -916,16 +884,50 @@ public partial class SettingsWindow : Window
             this.PopulateProviders();
         }
 
-        if (failedConfigs.Count > 0)
+        if (failedConfigs.Count > 0 && showErrorDialog)
         {
-            if (showErrorDialog)
+            MessageBox.Show(
+                $"Failed to save provider settings for: {string.Join(", ", failedConfigs)}",
+                "Save Error",
+                MessageBoxButton.OK,
+                MessageBoxImage.Error);
+        }
+    }
+
+    private async Task ProcessSingleProviderConfigAsync(ProviderConfig config, List<string> failedConfigs, List<string> removedProviderIds)
+    {
+        var behavior = ResolveProviderSettingsBehavior(
+            config,
+            this._usages.FirstOrDefault(u => string.Equals(u.ProviderId, config.ProviderId, StringComparison.OrdinalIgnoreCase)),
+            isDerived: false);
+
+        if (behavior.InputMode == ProviderInputMode.StandardApiKey && string.IsNullOrWhiteSpace(config.ApiKey))
+        {
+            var removed = await this._monitorService.RemoveConfigAsync(config.ProviderId).ConfigureAwait(true);
+            if (!removed)
             {
-                MessageBox.Show(
-                    $"Failed to save provider settings for: {string.Join(", ", failedConfigs)}",
-                    "Save Error",
-                    MessageBoxButton.OK,
-                    MessageBoxImage.Error);
+                failedConfigs.Add(config.ProviderId);
+                return;
             }
+
+            if (!this._preferences.SuppressedProviderIds.Contains(config.ProviderId, StringComparer.OrdinalIgnoreCase))
+            {
+                this._preferences.SuppressedProviderIds.Add(config.ProviderId);
+            }
+
+            removedProviderIds.Add(config.ProviderId);
+            return;
+        }
+
+        if (this._preferences.SuppressedProviderIds.Contains(config.ProviderId, StringComparer.OrdinalIgnoreCase))
+        {
+            this._preferences.SuppressedProviderIds.Remove(config.ProviderId);
+        }
+
+        var saved = await this._monitorService.SaveConfigAsync(config).ConfigureAwait(true);
+        if (!saved)
+        {
+            failedConfigs.Add(config.ProviderId);
         }
     }
 

--- a/AIUsageTracker.Web/Pages/Index.cshtml
+++ b/AIUsageTracker.Web/Pages/Index.cshtml
@@ -108,8 +108,7 @@
                     </a>
                     <a class="btn btn-secondary btn-sm @(Model.EnableExperimentalAnomalyDetection ? "btn-experimental-on" : "")"
                        href="/?showInactive=@(Model.ShowInactiveProviders.ToString().ToLower())&showUsed=@(Model.ShowUsedPercentage.ToString().ToLower())&expAnomaly=@((!Model.EnableExperimentalAnomalyDetection).ToString().ToLower())"
-                       title="Experimental feature. Disabled by default."
-                       aria-label="Enable Anomaly Detection (Exp)">
+                       title="Experimental feature. Disabled by default.">
                         @(Model.EnableExperimentalAnomalyDetection ? "Disable Anomaly Detection (Exp)" : "Enable Anomaly Detection (Exp)")
                     </a>
                 </div>


### PR DESCRIPTION
## Summary
Resolves all 7 remaining HIGH severity SonarQube issues.

**S3776 - Cognitive Complexity (6 issues):**
Further extracted helper methods from methods that were still slightly above the 15 threshold:

| File | Helpers Extracted |
|------|------------------|
| KimiProvider.cs | TryBuildLimitCard, DeduplicateCardId, ResolvePeriodDuration |
| ZaiProvider.cs | BuildNoLimitsResult, SelectLimits, ApplyMcpAdjustment, BuildUsageResult, BuildUnknownUsageResult |
| Monitor/Program.cs | CreateLoggerFactory, RotateOldLogs, BuildAndStartWebApp, ReleaseStartupMutex |
| SettingsWindow.xaml.cs | ProcessSingleProviderConfigAsync |
| ProviderCardRenderer.cs:52 | ResolveFriendlyName, AddCardBackground |
| ProviderCardRenderer.cs:362 | RenderPaceBadgeSlot, RenderStatusTextSlot |

**S7927 - Web Accessibility (1 issue):**
Removed static `aria-label` from anomaly detection toggle in Index.cshtml. The visible text toggles between "Enable"/"Disable", so a static aria-label would mismatch in one state. Letting the visible text serve as the accessible name is correct.

## Test plan
- [x] `dotnet build` - 0 errors, 0 warnings
- [x] All 1,491 tests pass across 3 test projects
- [ ] SonarQube scan to verify HIGH issues resolved