### PR TITLE
fix: resolve 18 SonarQube LOW severity issues

### DIFF
--- a/AIUsageTracker.Core/MonitorClient/MonitorService.cs
+++ b/AIUsageTracker.Core/MonitorClient/MonitorService.cs
@@ -21,8 +21,11 @@ public class MonitorService : IMonitorService
 
     private const int UsageRequestTimeoutSeconds = 8;
     private const int ConfigRequestTimeoutSeconds = 3;
+#pragma warning disable S1075 // Default agent URL
     private const string DefaultAgentUrl = "http://localhost:5000";
+#pragma warning restore S1075
     private const string ActivityTagMonitorAgentUrl = "monitor.agent_url";
+    private const string HttpStatusCodeTag = "http.status_code";
 
     private static readonly List<string> _diagnosticsLog = new();
     private static readonly ActivitySource ActivitySource = new("AIUsageTracker.Core.MonitorService");
@@ -349,7 +352,7 @@ public class MonitorService : IMonitorService
         if (response != null)
         {
             this.RecordRefreshTelemetry(stopwatch.Elapsed, response.IsSuccessStatusCode);
-            activity?.SetTag("http.status_code", (int)response.StatusCode);
+            activity?.SetTag(HttpStatusCodeTag, (int)response.StatusCode);
             activity?.SetStatus(response.IsSuccessStatusCode ? ActivityStatusCode.Ok : ActivityStatusCode.Error);
             return response.IsSuccessStatusCode;
         }
@@ -495,7 +498,7 @@ public class MonitorService : IMonitorService
         var success = response?.IsSuccessStatusCode == true;
         if (response != null)
         {
-            activity?.SetTag("http.status_code", (int)response.StatusCode);
+            activity?.SetTag(HttpStatusCodeTag, (int)response.StatusCode);
         }
 
         activity?.SetStatus(success ? ActivityStatusCode.Ok : ActivityStatusCode.Error);
@@ -515,7 +518,7 @@ public class MonitorService : IMonitorService
         {
             if (response != null)
             {
-                activity?.SetTag("http.status_code", (int)response.StatusCode);
+                activity?.SetTag(HttpStatusCodeTag, (int)response.StatusCode);
             }
 
             activity?.SetStatus(ActivityStatusCode.Error, "Health endpoint unavailable");
@@ -559,7 +562,7 @@ public class MonitorService : IMonitorService
             using var response = await this._httpClient.GetAsync(this.BuildMonitorUrl(MonitorApiRoutes.Health)).ConfigureAwait(false);
             if (!response.IsSuccessStatusCode)
             {
-                activity?.SetTag("http.status_code", (int)response.StatusCode);
+                activity?.SetTag(HttpStatusCodeTag, (int)response.StatusCode);
                 activity?.SetStatus(ActivityStatusCode.Error, "Health endpoint returned non-success");
                 return new AgentContractHandshakeResult
                 {

--- a/AIUsageTracker.Infrastructure/Configuration/JsonConfigLoader.cs
+++ b/AIUsageTracker.Infrastructure/Configuration/JsonConfigLoader.cs
@@ -15,6 +15,7 @@ namespace AIUsageTracker.Infrastructure.Configuration;
 public class JsonConfigLoader : IConfigLoader
 {
     private const string AuthConfigFileName = "auth.json";
+    private const string OpenCodeDirectoryName = "opencode";
     private static readonly JsonSerializerOptions CaseInsensitiveOptions = new() { PropertyNameCaseInsensitive = true };
 
     private readonly ILogger<JsonConfigLoader> _logger;
@@ -184,10 +185,10 @@ public class JsonConfigLoader : IConfigLoader
         // ~/.opencode/ is a legacy path with potentially stale keys.
         // ~/.local/share/opencode/ is the active XDG data directory maintained by OpenCode.
         yield return Path.Combine(userProfileRoot, ".opencode", AuthConfigFileName);
-        yield return Path.Combine(userProfileRoot, ".config", "opencode", AuthConfigFileName);
-        yield return Path.Combine(userProfileRoot, "AppData", "Roaming", "opencode", AuthConfigFileName);
-        yield return Path.Combine(userProfileRoot, "AppData", "Local", "opencode", AuthConfigFileName);
-        yield return Path.Combine(userProfileRoot, ".local", "share", "opencode", AuthConfigFileName);
+        yield return Path.Combine(userProfileRoot, ".config", OpenCodeDirectoryName, AuthConfigFileName);
+        yield return Path.Combine(userProfileRoot, "AppData", "Roaming", OpenCodeDirectoryName, AuthConfigFileName);
+        yield return Path.Combine(userProfileRoot, "AppData", "Local", OpenCodeDirectoryName, AuthConfigFileName);
+        yield return Path.Combine(userProfileRoot, ".local", "share", OpenCodeDirectoryName, AuthConfigFileName);
     }
 
     private async Task MergeConfigFileAsync(Dictionary<string, ProviderConfig> mergedConfigs, string path, bool isAuthFile)

--- a/AIUsageTracker.Infrastructure/Extensions/HttpRequestBuilderExtensions.cs
+++ b/AIUsageTracker.Infrastructure/Extensions/HttpRequestBuilderExtensions.cs
@@ -230,7 +230,7 @@ public static class HttpRequestBuilderExtensions
                 new ProviderRateLimitException(providerId, GetRetryAfter(response)),
 
             HttpFailureClassification.Server =>
-                new ProviderServerException(providerId, statusCode, $"Server error ({((int)statusCode).ToString(CultureInfo.InvariantCulture)})"),
+                new ProviderServerException(providerId, statusCode, $"Server error ({statusCode.ToString(CultureInfo.InvariantCulture)})"),
 
             HttpFailureClassification.Client when response.StatusCode == HttpStatusCode.NotFound =>
                 new ProviderException(
@@ -242,7 +242,7 @@ public static class HttpRequestBuilderExtensions
             _ =>
                 new ProviderException(
                     providerId,
-                    $"Request failed ({((int)statusCode).ToString(CultureInfo.InvariantCulture)})",
+                    $"Request failed ({statusCode.ToString(CultureInfo.InvariantCulture)})",
                     ProviderErrorType.InvalidResponseError,
                     statusCode),
         };

--- a/AIUsageTracker.Infrastructure/Providers/CodexProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/CodexProvider.cs
@@ -17,6 +17,9 @@ namespace AIUsageTracker.Infrastructure.Providers;
 
 public class CodexProvider : ProviderBase
 {
+    private const string CodexSparkProviderId = "codex.spark";
+    private const string WeeklyWindowLabel = "Weekly";
+
     public static ProviderDefinition StaticDefinition { get; } = new(
         "codex",
         "OpenAI (Codex)",
@@ -45,11 +48,11 @@ public class CodexProvider : ProviderBase
             ProviderEndpoints.OpenAI.ProfileClaimKey,
         },
         FamilyMode = ProviderFamilyMode.Standalone,
-        CoReportedProviderIds = new[] { "codex.spark" },
+        CoReportedProviderIds = new[] { CodexSparkProviderId },
         QuotaWindows = new QuotaWindowDefinition[]
         {
             new(WindowKind.Burst,   "5h",     PeriodDuration: TimeSpan.FromHours(5)),
-            new(WindowKind.Rolling, "Weekly", PeriodDuration: TimeSpan.FromDays(7)),
+            new(WindowKind.Rolling, WeeklyWindowLabel, PeriodDuration: TimeSpan.FromDays(7)),
         },
     };
 
@@ -59,7 +62,7 @@ public class CodexProvider : ProviderBase
     /// enabling a separate dual-bar card (5h burst + weekly rolling) in the main window.
     /// </summary>
     public static ProviderDefinition SparkDefinition { get; } = new(
-        "codex.spark",
+        CodexSparkProviderId,
         "OpenAI (GPT-5.3 Codex Spark)",
         PlanType.Coding,
         isQuotaBased: true)
@@ -79,7 +82,7 @@ public class CodexProvider : ProviderBase
         QuotaWindows = new QuotaWindowDefinition[]
         {
             new(WindowKind.Burst,   "5h",     PeriodDuration: TimeSpan.FromHours(5)),
-            new(WindowKind.Rolling, "Weekly", PeriodDuration: TimeSpan.FromDays(7)),
+            new(WindowKind.Rolling, WeeklyWindowLabel, PeriodDuration: TimeSpan.FromDays(7)),
         },
     };
 
@@ -511,7 +514,7 @@ public class CodexProvider : ProviderBase
                 ProviderName = StaticDefinition.DisplayName,
                 CardId = "weekly",
                 GroupId = this.ProviderId,
-                Name = "Weekly",
+                Name = WeeklyWindowLabel,
                 WindowKind = WindowKind.Rolling,
                 UsedPercent = secondaryUsedPercent.Value,
                 RequestsUsed = secondaryUsedPercent.Value,
@@ -533,13 +536,13 @@ public class CodexProvider : ProviderBase
         // the "OpenAI (GPT-5.3 Codex Spark)" card is dual-bar capable.
         if (sparkWindow.HasWindowData)
         {
-            var sparkDisplayName = StaticDefinition.DisplayNameOverrides.GetValueOrDefault("codex.spark", "OpenAI (GPT-5.3 Codex Spark)");
+            var sparkDisplayName = StaticDefinition.DisplayNameOverrides.GetValueOrDefault(CodexSparkProviderId, "OpenAI (GPT-5.3 Codex Spark)");
             var sparkBurstUsed = sparkWindow.PrimaryUsedPercent ?? 0.0;
             var sparkBurstResetTime = ResolveResetTimeFromSeconds(sparkWindow.PrimaryResetAfterSeconds);
 
             usages.Add(new ProviderUsage
             {
-                ProviderId = "codex.spark",
+                ProviderId = CodexSparkProviderId,
                 ProviderName = sparkDisplayName,
                 CardId = "spark.burst",
                 GroupId = this.ProviderId,
@@ -565,11 +568,11 @@ public class CodexProvider : ProviderBase
 
             usages.Add(new ProviderUsage
             {
-                ProviderId = "codex.spark",
+                ProviderId = CodexSparkProviderId,
                 ProviderName = sparkDisplayName,
                 CardId = "spark.weekly",
                 GroupId = this.ProviderId,
-                Name = "Weekly",
+                Name = WeeklyWindowLabel,
                 WindowKind = WindowKind.Rolling,
                 UsedPercent = sparkWeeklyUsed,
                 RequestsUsed = sparkWeeklyUsed,

--- a/AIUsageTracker.Infrastructure/Providers/GeminiProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/GeminiProvider.cs
@@ -55,8 +55,10 @@ public class GeminiProvider : ProviderBase
 
     private const string GeminiPluginClientSecret = "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";
 
+#pragma warning disable S1075 // URIs are provider API endpoints
     private const string OAuthTokenUrl = "https://oauth2.googleapis.com/token";
     private const string QuotaUrl = "https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota";
+#pragma warning restore S1075
     private static readonly JsonSerializerOptions CaseInsensitiveOptions = new() { PropertyNameCaseInsensitive = true };
 
     private readonly HttpClient _httpClient;

--- a/AIUsageTracker.Infrastructure/Providers/GitHubCopilotProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/GitHubCopilotProvider.cs
@@ -13,9 +13,11 @@ namespace AIUsageTracker.Infrastructure.Providers;
 
 public class GitHubCopilotProvider : ProviderBase
 {
+#pragma warning disable S1075 // URIs are provider API endpoints
     private const string GitHubUserUrl = "https://api.github.com/user";
     private const string CopilotUserUrl = "https://api.github.com/copilot_internal/user";
     private const string CopilotTokenUrl = "https://api.github.com/copilot_internal/v2/token";
+#pragma warning restore S1075
     private const string ProviderDisplayName = "GitHub Copilot";
 
     private readonly IGitHubAuthService _authService;

--- a/AIUsageTracker.Monitor/Program.cs
+++ b/AIUsageTracker.Monitor/Program.cs
@@ -285,9 +285,8 @@ public partial class Program
         logger.LogInformation("  Agent ready! Listening on http://localhost:{Port}", port);
         logger.LogInformation(DebugBannerSeparator);
         logger.LogInformation(string.Empty);
-        logger.LogInformation("  API Endpoints:");
-        logger.LogInformation("    GET  http://localhost:{Port1}{Health} | GET  http://localhost:{Port2}{Usage} | GET  http://localhost:{Port3}{Config}", port, MonitorApiRoutes.Health, port, MonitorApiRoutes.Usage, port, MonitorApiRoutes.Config);
-        logger.LogInformation("    POST http://localhost:{Port}{Refresh}", port, MonitorApiRoutes.Refresh);
+        logger.LogInformation("  API Endpoints: GET http://localhost:{Port}{Health} | GET http://localhost:{Port}{Usage} | GET http://localhost:{Port}{Config} | POST http://localhost:{Port}{Refresh}",
+            port, MonitorApiRoutes.Health, port, MonitorApiRoutes.Usage, port, MonitorApiRoutes.Config, port, MonitorApiRoutes.Refresh);
         logger.LogInformation(string.Empty);
         logger.LogInformation("  Press Ctrl+C to stop");
         logger.LogInformation(DebugBannerSeparator);

--- a/AIUsageTracker.UI.Slim/SettingsWindow.xaml.cs
+++ b/AIUsageTracker.UI.Slim/SettingsWindow.xaml.cs
@@ -22,7 +22,9 @@ namespace AIUsageTracker.UI.Slim;
 
 public partial class SettingsWindow : Window
 {
+#pragma warning disable S1075 // Pack URI scheme is required by WPF
     private const string PackApplicationUri = "pack://application:,,,/";
+#pragma warning restore S1075
 
     private static readonly JsonSerializerOptions BundleJsonOptions = new()
     {


### PR DESCRIPTION
## Summary
Resolves all 18 remaining LOW severity SonarQube issues.

**S1075 - Hardcoded URIs (7 issues):**
Suppress false positives via `#pragma warning disable S1075` for provider API endpoint constants that are already centralized (GeminiProvider, GitHubCopilotProvider, MonitorService, SettingsWindow).

**S1192 - Repeated string literals (4 issues):**
- CodexProvider: Extract `CodexSparkProviderId` and `WeeklyWindowLabel` constants
- JsonConfigLoader: Extract `OpenCodeDirectoryName` constant
- MonitorService: Extract `HttpStatusCodeTag` constant

**S1905 - Unnecessary casts (2 issues):**
Remove `(int)` cast on `statusCode` which is already `int`.

**S6664 - Excessive logging (2 issues):**
Consolidate endpoint logging in `LogDebugReadyBanner` from 2 lines to 1.

**False positives (3 issues):**
- S1481: `version` variable in `_Layout.cshtml` is used in the Razor template at line 91
- S2325 (2): `SelectLimits` and `ClassifyHistoryEntries` use `this._logger` (instance data)

## Test plan
- [x] `dotnet build` - 0 errors
- [x] All 1,491 tests pass across 3 test projects
- [ ] SonarQube scan to verify LOW issues resolved