### PR TITLE
fix: prevent ShowUsed/AlwaysOnTop toggles from re-saving during programmatic sync

### DIFF
--- a/AIUsageTracker.UI.Slim/MainWindow.xaml.cs
+++ b/AIUsageTracker.UI.Slim/MainWindow.xaml.cs
@@ -55,6 +55,7 @@ public partial class MainWindow : Window
     private bool _isPrivacyMode = App.IsPrivacyMode;
     private readonly EventHandler<PrivacyChangedEventArgs> _privacyChangedHandler;
     private bool _isLoading;
+    private bool _isApplyingPreferences;
     private DateTime _lastMonitorUpdate = DateTime.MinValue;
     private DateTime _lastRefreshTrigger = DateTime.MinValue;
     private bool _isPollingInProgress;
@@ -483,8 +484,16 @@ public partial class MainWindow : Window
         this.FontStyle = this._preferences.FontItalic ? FontStyles.Italic : FontStyles.Normal;
 
         // Apply UI controls
-        this.AlwaysOnTopCheck.IsChecked = this._preferences.AlwaysOnTop;
-        this.ApplyDisplayModePreference();
+        this._isApplyingPreferences = true;
+        try
+        {
+            this.AlwaysOnTopCheck.IsChecked = this._preferences.AlwaysOnTop;
+            this.ApplyDisplayModePreference();
+        }
+        finally
+        {
+            this._isApplyingPreferences = false;
+        }
         this.UpdatePrivacyButtonState();
         this.EnsureAlwaysOnTop();
 
@@ -759,7 +768,7 @@ public partial class MainWindow : Window
     {
         try
         {
-            if (!this.IsLoaded)
+            if (!this.IsLoaded || this._isApplyingPreferences)
             {
                 return;
             }
@@ -786,7 +795,7 @@ public partial class MainWindow : Window
     {
         try
         {
-            if (!this.IsLoaded)
+            if (!this.IsLoaded || this._isApplyingPreferences)
             {
                 return;
             }


### PR DESCRIPTION
## Summary

Fixes a race condition where the "Show Used" toggle preference was not reliably persisted.

**Root cause:** When `ApplyPreferences()` (triggered on SettingsWindow close) programmatically sets `ShowUsedToggle.IsChecked` and `AlwaysOnTopCheck.IsChecked`, the `Checked`/`Unchecked` events fire. Those handlers (`ShowUsedToggle_Checked`, `AlwaysOnTop_Checked`) each call `SaveUiPreferencesAsync()`, which races with the SettingsWindow's own async save and can overwrite the correct preference with a stale value.

**Fix:** Added `_isApplyingPreferences` guard flag. `ApplyPreferences()` wraps programmatic `IsChecked` assignments with this flag. Both event handlers check the flag and skip the redundant save when it's set.

**Files changed:** `MainWindow.xaml.cs` (1 file, 13 insertions, 4 deletions)

## Test plan
- [x] `dotnet build` - 0 errors
- [x] All 1,491 tests pass
- [ ] Manual: Toggle "Show Used" in Settings, close Settings, reopen - setting should persist
- [ ] Manual: Toggle "Always On Top" in Settings, close Settings, reopen - setting should persist