### PR TITLE
refactor: centralize display name resolution to GetConfiguredDisplayName

### DIFF
--- a/AIUsageTracker.CLI/Program.cs
+++ b/AIUsageTracker.CLI/Program.cs
@@ -322,7 +322,7 @@ public static class Program
             var used = item.IsCurrencyUsage
                 ? $"${item.RequestsUsed.ToString("F2", CultureInfo.InvariantCulture)}"
                 : item.RequestsUsed.ToString(System.Globalization.CultureInfo.InvariantCulture);
-            var providerDisplayName = ProviderMetadataCatalog.ResolveDisplayLabel(item.ProviderId, item.ProviderName);
+            var providerDisplayName = item.ProviderName ?? ProviderMetadataCatalog.GetConfiguredDisplayName(item.ProviderId ?? string.Empty);
             Console.WriteLine($"{item.FetchedAt.ToShortDateString(),-12} | {providerDisplayName,-20} | {"(Total)",-25} | {used,-15}");
         }
     }
@@ -555,7 +555,7 @@ public static class Program
 
         var type = u.IsQuotaBased ? "Quota" : "Pay-As-You-Go";
         var accountInfo = !string.IsNullOrWhiteSpace(u.AccountName) ? $" [{u.AccountName}]" : string.Empty;
-        var providerDisplayName = ProviderMetadataCatalog.ResolveDisplayLabel(u.ProviderId, u.ProviderName);
+        var providerDisplayName = u.ProviderName ?? ProviderMetadataCatalog.GetConfiguredDisplayName(u.ProviderId ?? string.Empty);
 
         var description = u.Description;
 
@@ -587,7 +587,7 @@ public static class Program
         }
         else
         {
-            Console.WriteLine(string.Join(Environment.NewLine, configs.Select(c => $"ID: {c.ProviderId}, Name: {ProviderMetadataCatalog.ResolveDisplayLabel(c.ProviderId)}")));
+            Console.WriteLine(string.Join(Environment.NewLine, configs.Select(c => $"ID: {c.ProviderId}, Name: {ProviderMetadataCatalog.GetConfiguredDisplayName(c.ProviderId)}")));
         }
     }
 }

--- a/AIUsageTracker.Infrastructure/Configuration/TokenDiscoveryService.cs
+++ b/AIUsageTracker.Infrastructure/Configuration/TokenDiscoveryService.cs
@@ -57,7 +57,7 @@ public class TokenDiscoveryService
         return ProviderMetadataCatalog.GetProviderIdsWithDedicatedSessionAuthFiles()
             .Select(providerId => new ProviderSessionTokenResolver(
                 discoverySpec: ProviderMetadataCatalog.Find(providerId)!.CreateAuthDiscoverySpec(),
-                description: $"Discovered in {ProviderMetadataCatalog.ResolveDisplayLabel(providerId)} session auth",
+                description: $"Discovered in {ProviderMetadataCatalog.GetConfiguredDisplayName(providerId)} session auth",
                 sourcePrefix: "Config",
                 logger: logger,
                 pathProvider: pathProvider))

--- a/AIUsageTracker.Infrastructure/Providers/AntigravityProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/AntigravityProvider.cs
@@ -74,6 +74,8 @@ public class AntigravityProvider : ProviderBase
     {
         ArgumentNullException.ThrowIfNull(config);
 
+        var providerLabel = ProviderMetadataCatalog.GetConfiguredDisplayName(config.ProviderId);
+
         var results = new List<ProviderUsage>();
 
         try
@@ -82,10 +84,10 @@ public class AntigravityProvider : ProviderBase
             var processInfos = this.FindProcessInfos();
             if (processInfos.Count == 0)
             {
-                return this.BuildNoProcessResult(config);
+                return this.BuildNoProcessResult(config, providerLabel);
             }
 
-            await this.CollectInstanceUsagesAsync(processInfos, results, config).ConfigureAwait(false);
+            await this.CollectInstanceUsagesAsync(processInfos, results, config, providerLabel).ConfigureAwait(false);
 
             if (results.Count == 0)
             {
@@ -121,17 +123,17 @@ public class AntigravityProvider : ProviderBase
         };
     }
 
-    private IEnumerable<ProviderUsage> BuildNoProcessResult(ProviderConfig config)
+    private IEnumerable<ProviderUsage> BuildNoProcessResult(ProviderConfig config, string providerLabel)
     {
         if (this._cachedUsage != null)
         {
-            return this.BuildCachedOfflineResult(config);
+            return this.BuildCachedOfflineResult(config, providerLabel);
         }
 
         return new[] { CreateNotRunningUsage(this.ProviderId, this.Definition) };
     }
 
-    private IEnumerable<ProviderUsage> BuildCachedOfflineResult(ProviderConfig config)
+    private IEnumerable<ProviderUsage> BuildCachedOfflineResult(ProviderConfig config, string providerLabel)
     {
         var timeSinceRefresh = DateTime.UtcNow - this._cacheTimestamp;
         var minutesAgo = (int)timeSinceRefresh.TotalMinutes;
@@ -150,7 +152,7 @@ public class AntigravityProvider : ProviderBase
                     new ProviderUsage
                     {
                         ProviderId = this.ProviderId,
-                        ProviderName = this.Definition.DisplayName,
+                        ProviderName = providerLabel,
                         IsAvailable = true,
                         UsedPercent = 0,
                         RequestsUsed = 0,
@@ -173,7 +175,7 @@ public class AntigravityProvider : ProviderBase
             new ProviderUsage
             {
                 ProviderId = this.ProviderId,
-                ProviderName = this.Definition.DisplayName,
+                ProviderName = providerLabel,
                 IsAvailable = true,
                 UsedPercent = 0,
                 RequestsUsed = 0,
@@ -189,7 +191,8 @@ public class AntigravityProvider : ProviderBase
     private async Task CollectInstanceUsagesAsync(
         List<(int Pid, string Token, int? Port)> processInfos,
         List<ProviderUsage> results,
-        ProviderConfig config)
+        ProviderConfig config,
+        string providerLabel)
     {
         foreach (var info in processInfos)
         {
@@ -205,7 +208,7 @@ public class AntigravityProvider : ProviderBase
 
                 var candidatePorts = await this.ResolveCandidatePortsAsync(pid, commandLinePort).ConfigureAwait(false);
 
-                var usageItems = await this.TryFetchUsageFromPortsAsync(candidatePorts, csrfToken, config, pid).ConfigureAwait(false);
+                var usageItems = await this.TryFetchUsageFromPortsAsync(candidatePorts, csrfToken, config, pid, providerLabel).ConfigureAwait(false);
 
                 var mainItem = usageItems.FirstOrDefault(u => string.Equals(u.ProviderId, this.ProviderId, StringComparison.Ordinal));
 
@@ -244,7 +247,7 @@ public class AntigravityProvider : ProviderBase
         return candidatePorts;
     }
 
-    private async Task<List<ProviderUsage>> TryFetchUsageFromPortsAsync(List<int> candidatePorts, string csrfToken, ProviderConfig config, int pid)
+    private async Task<List<ProviderUsage>> TryFetchUsageFromPortsAsync(List<int> candidatePorts, string csrfToken, ProviderConfig config, int pid, string providerLabel)
     {
         List<ProviderUsage>? usageItems = null;
         Exception? lastPortException = null;
@@ -252,7 +255,7 @@ public class AntigravityProvider : ProviderBase
         {
             try
             {
-                usageItems = await this.FetchUsageAsync(candidatePort, csrfToken, config).ConfigureAwait(false);
+                usageItems = await this.FetchUsageAsync(candidatePort, csrfToken, config, providerLabel).ConfigureAwait(false);
                 break;
             }
             catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or JsonException)
@@ -684,7 +687,7 @@ public class AntigravityProvider : ProviderBase
             .ToList();
     }
 
-    private async Task<List<ProviderUsage>> FetchUsageAsync(int port, string csrfToken, ProviderConfig config)
+    private async Task<List<ProviderUsage>> FetchUsageAsync(int port, string csrfToken, ProviderConfig config, string providerLabel)
     {
         var body = new { metadata = new { ideName = AntigravityApiIdentifier, extensionName = AntigravityApiIdentifier, ideVersion = "unknown", locale = "en" } };
         string? responseString = null;
@@ -770,7 +773,7 @@ public class AntigravityProvider : ProviderBase
                 new ProviderUsage
                 {
                     ProviderId = this.ProviderId,
-                    ProviderName = this.Definition.DisplayName,
+                    ProviderName = providerLabel,
                     IsAvailable = true,
                     UsedPercent = 0,
                     RequestsUsed = 0,
@@ -784,7 +787,7 @@ public class AntigravityProvider : ProviderBase
         }
 
         var sortedEntries = SortEntries(entries);
-        var summary = this.BuildSummaryUsage(data.UserStatus, sortedEntries, minRemaining.Value, responseString, httpStatus);
+        var summary = this.BuildSummaryUsage(data.UserStatus, sortedEntries, minRemaining.Value, responseString, httpStatus, providerLabel);
         ApplySummaryRawNumbers(summary, configMap);
 
         var results = this.BuildChildUsages(sortedEntries, configMap, config, data.UserStatus.Email ?? string.Empty);
@@ -829,12 +832,12 @@ public class AntigravityProvider : ProviderBase
         return null;
     }
 
-    private ProviderUsage BuildSummaryUsage(UserStatus userStatus, List<ModelEntry> sortedEntries, double remainingPctTotal, string? rawJson = null, int httpStatus = 200)
+    private ProviderUsage BuildSummaryUsage(UserStatus userStatus, List<ModelEntry> sortedEntries, double remainingPctTotal, string? rawJson, int httpStatus, string providerLabel)
     {
         return new ProviderUsage
         {
             ProviderId = this.ProviderId,
-            ProviderName = this.Definition.DisplayName,
+            ProviderName = providerLabel,
             UsedPercent = 100 - remainingPctTotal,
             RequestsUsed = 100 - remainingPctTotal,
             RequestsAvailable = 100,

--- a/AIUsageTracker.Infrastructure/Providers/ClaudeCodeProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/ClaudeCodeProvider.cs
@@ -77,6 +77,8 @@ public class ClaudeCodeProvider : ProviderBase
     {
         ArgumentNullException.ThrowIfNull(config);
 
+        var providerLabel = ProviderMetadataCatalog.GetConfiguredDisplayName(config.ProviderId);
+
         // Check if API key is configured
         if (string.IsNullOrEmpty(config.ApiKey))
         {
@@ -85,7 +87,7 @@ public class ClaudeCodeProvider : ProviderBase
                 new ProviderUsage
             {
                 ProviderId = this.ProviderId,
-                ProviderName = this.Definition.DisplayName,
+                ProviderName = providerLabel,
                 IsAvailable = false,
                 Description = "No API key configured",
                 State = ProviderUsageState.Missing,
@@ -116,7 +118,7 @@ public class ClaudeCodeProvider : ProviderBase
         // Try OAuth usage endpoint first (for subscription users)
         try
         {
-            var oauthUsages = await this.GetUsageFromOAuthAsync(effectiveApiKey).ConfigureAwait(false);
+                var oauthUsages = await this.GetUsageFromOAuthAsync(effectiveApiKey, providerLabel).ConfigureAwait(false);
             if (oauthUsages != null)
             {
                 return oauthUsages;
@@ -133,7 +135,7 @@ public class ClaudeCodeProvider : ProviderBase
         {
             try
             {
-                var apiUsage = await this.GetUsageFromApiAsync(effectiveApiKey).ConfigureAwait(false);
+                var apiUsage = await this.GetUsageFromApiAsync(effectiveApiKey, providerLabel).ConfigureAwait(false);
                 if (apiUsage != null)
                 {
                     return new[] { apiUsage };
@@ -146,7 +148,7 @@ public class ClaudeCodeProvider : ProviderBase
         }
 
         // Fall back to CLI if API fails
-        return await this.GetUsageFromCliAsync().ConfigureAwait(false);
+        return await this.GetUsageFromCliAsync(providerLabel).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -154,7 +156,7 @@ public class ClaudeCodeProvider : ProviderBase
     /// </summary>
     /// <param name="accessToken">The OAuth access token from credentials file.</param>
     /// <returns>Provider usages if successful, null otherwise.</returns>
-    internal async Task<IEnumerable<ProviderUsage>?> GetUsageFromOAuthAsync(string accessToken)
+    internal async Task<IEnumerable<ProviderUsage>?> GetUsageFromOAuthAsync(string accessToken, string providerLabel)
     {
         try
         {
@@ -180,7 +182,7 @@ public class ClaudeCodeProvider : ProviderBase
                 return null;
             }
 
-            return this.ParseOAuthUsageResponse(usageResponse, responseBody, (int)statusCode);
+            return this.ParseOAuthUsageResponse(usageResponse, responseBody, (int)statusCode, providerLabel);
         }
         catch (HttpRequestException ex)
         {
@@ -251,17 +253,16 @@ public class ClaudeCodeProvider : ProviderBase
         }
     }
 
-    private List<ProviderUsage> ParseOAuthUsageResponse(OAuthUsageResponse response, string rawJson, int httpStatus)
+    private List<ProviderUsage> ParseOAuthUsageResponse(OAuthUsageResponse response, string rawJson, int httpStatus, string providerLabel)
     {
         var results = new List<ProviderUsage>();
 
-        // Current session (5-hour burst quota)
         if (response.FiveHour != null)
         {
             results.Add(new ProviderUsage
             {
                 ProviderId = this.ProviderId,
-                ProviderName = this.Definition.DisplayName,
+                ProviderName = providerLabel,
                 CardId = "current-session",
                 GroupId = this.ProviderId,
                 Name = "Current Session",
@@ -282,7 +283,7 @@ public class ClaudeCodeProvider : ProviderBase
             results.Add(new ProviderUsage
             {
                 ProviderId = this.ProviderId,
-                ProviderName = this.Definition.DisplayName,
+                ProviderName = providerLabel,
                 CardId = "sonnet",
                 GroupId = this.ProviderId,
                 Name = "Sonnet",
@@ -303,7 +304,7 @@ public class ClaudeCodeProvider : ProviderBase
             results.Add(new ProviderUsage
             {
                 ProviderId = this.ProviderId,
-                ProviderName = this.Definition.DisplayName,
+                ProviderName = providerLabel,
                 CardId = "opus",
                 GroupId = this.ProviderId,
                 Name = "Opus",
@@ -331,7 +332,7 @@ public class ClaudeCodeProvider : ProviderBase
             results.Add(new ProviderUsage
             {
                 ProviderId = this.ProviderId,
-                ProviderName = this.Definition.DisplayName,
+                ProviderName = providerLabel,
                 CardId = "all-models",
                 GroupId = this.ProviderId,
                 Name = "All Models",
@@ -352,7 +353,7 @@ public class ClaudeCodeProvider : ProviderBase
             results.Add(new ProviderUsage
             {
                 ProviderId = this.ProviderId,
-                ProviderName = this.Definition.DisplayName,
+                ProviderName = providerLabel,
                 IsQuotaBased = true,
                 PlanType = this.Definition.PlanType,
                 IsAvailable = true,
@@ -365,7 +366,7 @@ public class ClaudeCodeProvider : ProviderBase
         return results;
     }
 
-    private async Task<ProviderUsage?> GetUsageFromApiAsync(string apiKey)
+    private async Task<ProviderUsage?> GetUsageFromApiAsync(string apiKey, string providerLabel)
     {
         try
         {
@@ -412,7 +413,7 @@ public class ClaudeCodeProvider : ProviderBase
                 return new ProviderUsage
                 {
                     ProviderId = this.ProviderId,
-                    ProviderName = this.Definition.DisplayName,
+                    ProviderName = providerLabel,
                     UsedPercent = usagePercentage,
                     RequestsUsed = 0, // Anthropic doesn't provide cost via API
                     RequestsAvailable = 0,
@@ -467,7 +468,7 @@ public class ClaudeCodeProvider : ProviderBase
         return info;
     }
 
-    private async Task<IEnumerable<ProviderUsage>> GetUsageFromCliAsync()
+    private async Task<IEnumerable<ProviderUsage>> GetUsageFromCliAsync(string providerLabel)
     {
         return await Task.Run(async () =>
         {
@@ -492,7 +493,7 @@ public class ClaudeCodeProvider : ProviderBase
                         new ProviderUsage
                     {
                         ProviderId = this.ProviderId,
-                        ProviderName = this.Definition.DisplayName,
+                        ProviderName = providerLabel,
                         IsAvailable = true,
                         Description = "Connected (API key configured)",
                         IsStatusOnly = true,
@@ -529,7 +530,7 @@ public class ClaudeCodeProvider : ProviderBase
                         new ProviderUsage
                     {
                         ProviderId = this.ProviderId,
-                        ProviderName = this.Definition.DisplayName,
+                        ProviderName = providerLabel,
                         IsAvailable = true,
                         Description = "Connected (API key configured)",
                         IsStatusOnly = true,
@@ -541,7 +542,7 @@ public class ClaudeCodeProvider : ProviderBase
                     };
                 }
 
-                return new[] { this.ParseCliOutput(output) };
+                return new[] { this.ParseCliOutput(output, providerLabel) };
             }
             catch (Exception ex) when (ex is InvalidOperationException or System.ComponentModel.Win32Exception or IOException)
             {
@@ -553,7 +554,7 @@ public class ClaudeCodeProvider : ProviderBase
                     new ProviderUsage
                 {
                     ProviderId = this.ProviderId,
-                    ProviderName = this.Definition.DisplayName,
+                    ProviderName = providerLabel,
                     IsAvailable = true,
                     Description = "Connected (API key configured)",
                     IsStatusOnly = true,
@@ -567,7 +568,7 @@ public class ClaudeCodeProvider : ProviderBase
         }).ConfigureAwait(false);
     }
 
-    private ProviderUsage ParseCliOutput(string output)
+    private ProviderUsage ParseCliOutput(string output, string providerLabel)
     {
         // Parse Claude Code usage output
         double currentUsage = 0;
@@ -600,7 +601,7 @@ public class ClaudeCodeProvider : ProviderBase
         return new ProviderUsage
         {
             ProviderId = this.ProviderId,
-            ProviderName = this.Definition.DisplayName,
+            ProviderName = providerLabel,
             UsedPercent = Math.Min(usagePercentage, 100),
             RequestsUsed = currentUsage,
             RequestsAvailable = budgetLimit,

--- a/AIUsageTracker.Infrastructure/Providers/CodexProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/CodexProvider.cs
@@ -461,6 +461,7 @@ public class CodexProvider : ProviderBase
         string? rawJson = null,
         int httpStatus = 200)
     {
+        var providerLabel = ProviderMetadataCatalog.GetConfiguredDisplayName(this.ProviderId);
         var planType = root.ReadString("plan_type") ?? jwtPlanType ?? "unknown";
         var primaryUsedPercent = root.ReadDouble(JsonKeyRateLimit, JsonKeyPrimaryWindow, JsonKeyUsedPercent) ?? 0.0;
         var primaryResetSeconds = root.ReadDouble(JsonKeyRateLimit, JsonKeyPrimaryWindow, JsonKeyResetAfterSeconds);
@@ -478,7 +479,7 @@ public class CodexProvider : ProviderBase
         var burstCard = new ProviderUsage
         {
             ProviderId = this.ProviderId,
-            ProviderName = StaticDefinition.DisplayName,
+            ProviderName = providerLabel,
             CardId = "burst",
             GroupId = this.ProviderId,
             Name = "5h",
@@ -511,7 +512,7 @@ public class CodexProvider : ProviderBase
             usages.Add(new ProviderUsage
             {
                 ProviderId = this.ProviderId,
-                ProviderName = StaticDefinition.DisplayName,
+                ProviderName = providerLabel,
                 CardId = "weekly",
                 GroupId = this.ProviderId,
                 Name = WeeklyWindowLabel,
@@ -536,7 +537,7 @@ public class CodexProvider : ProviderBase
         // the "OpenAI (GPT-5.3 Codex Spark)" card is dual-bar capable.
         if (sparkWindow.HasWindowData)
         {
-            var sparkDisplayName = StaticDefinition.DisplayNameOverrides.GetValueOrDefault(CodexSparkProviderId, "OpenAI (GPT-5.3 Codex Spark)");
+            var sparkDisplayName = ProviderMetadataCatalog.GetConfiguredDisplayName(CodexSparkProviderId);
             var sparkBurstUsed = sparkWindow.PrimaryUsedPercent ?? 0.0;
             var sparkBurstResetTime = ResolveResetTimeFromSeconds(sparkWindow.PrimaryResetAfterSeconds);
 

--- a/AIUsageTracker.Infrastructure/Providers/DeepSeekProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/DeepSeekProvider.cs
@@ -59,6 +59,8 @@ public class DeepSeekProvider : ProviderBase
             };
         }
 
+        var providerLabel = ProviderMetadataCatalog.GetConfiguredDisplayName(config.ProviderId);
+
         try
         {
             var request = CreateBearerRequest(HttpMethod.Get, UserBalanceEndpoint, config.ApiKey);
@@ -76,7 +78,7 @@ public class DeepSeekProvider : ProviderBase
                     new ProviderUsage
                     {
                         ProviderId = this.ProviderId,
-                        ProviderName = this.Definition.DisplayName ?? this.ProviderId,
+                        ProviderName = providerLabel ?? this.ProviderId,
                         IsAvailable = true, // Key exists, just failed request
                         Description = $"API Error ({response.StatusCode})",
                         PlanType = this.Definition.PlanType,
@@ -109,7 +111,7 @@ public class DeepSeekProvider : ProviderBase
                     new ProviderUsage
                     {
                         ProviderId = this.ProviderId,
-                        ProviderName = this.Definition.DisplayName,
+                        ProviderName = providerLabel,
                         IsAvailable = true,
                         UsedPercent = 0,
                         RequestsUsed = 0,
@@ -131,7 +133,7 @@ public class DeepSeekProvider : ProviderBase
                 flatCards.Add(new ProviderUsage
                 {
                     ProviderId = this.ProviderId,
-                    ProviderName = this.Definition.DisplayName,
+                    ProviderName = providerLabel,
                     Name = $"Balance ({currencyCode})",
                     CardId = $"balance-{currencyCode.ToLowerInvariant()}",
                     GroupId = this.ProviderId,

--- a/AIUsageTracker.Infrastructure/Providers/GeminiProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/GeminiProvider.cs
@@ -93,6 +93,10 @@ public class GeminiProvider : ProviderBase
     /// <inheritdoc/>
     public override async Task<IEnumerable<ProviderUsage>> GetUsageAsync(ProviderConfig config, Action<ProviderUsage>? progressCallback = null, CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(config);
+
+        var providerLabel = ProviderMetadataCatalog.GetConfiguredDisplayName(config.ProviderId);
+
         // 1. Load Accounts
         var accounts = this.LoadAccounts();
         if (accounts == null || accounts.Accounts == null || accounts.Accounts.Count == 0)
@@ -102,7 +106,7 @@ public class GeminiProvider : ProviderBase
                 new ProviderUsage
                 {
                     ProviderId = this.ProviderId,
-                    ProviderName = this.Definition.DisplayName,
+                    ProviderName = providerLabel,
                     IsAvailable = false,
                     IsQuotaBased = this.Definition.IsQuotaBased,
                     PlanType = this.Definition.PlanType,
@@ -125,7 +129,7 @@ public class GeminiProvider : ProviderBase
                 var accessToken = await this.RefreshTokenAsync(account.RefreshToken).ConfigureAwait(false);
                 var buckets = await this.FetchQuotaAsync(accessToken, account.ProjectId).ConfigureAwait(false);
                 var allBuckets = buckets ?? new List<Bucket>();
-                var modelQuotaCards = BuildModelQuotaCards(this.ProviderId, this.Definition.DisplayName, allBuckets, account.Email);
+                var modelQuotaCards = BuildModelQuotaCards(this.ProviderId, providerLabel, allBuckets, account.Email);
                 this._logger.LogDebug(
                     "Gemini quota received {BucketCount} bucket(s) and resolved {ModelCount} model card(s): {BucketSummary}",
                     allBuckets.Count,

--- a/AIUsageTracker.Infrastructure/Providers/GitHubCopilotProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/GitHubCopilotProvider.cs
@@ -63,6 +63,8 @@ public class GitHubCopilotProvider : ProviderBase
     {
         ArgumentNullException.ThrowIfNull(config);
 
+        var providerLabel = ProviderMetadataCatalog.GetConfiguredDisplayName(config.ProviderId);
+
         var token = this.ResolveToken(config);
         if (string.IsNullOrEmpty(token) && this.DiscoveryService != null)
         {
@@ -82,7 +84,7 @@ public class GitHubCopilotProvider : ProviderBase
                 new ProviderUsage
                 {
                     ProviderId = this.ProviderId,
-                    ProviderName = this.Definition.DisplayName,
+                    ProviderName = providerLabel,
                     AccountName = username,
                     IsAvailable = false,
                     State = ProviderUsageState.Missing,
@@ -145,7 +147,7 @@ public class GitHubCopilotProvider : ProviderBase
             state.State = ProviderUsageState.Error;
         }
 
-        return this.BuildUsageResults(state);
+        return this.BuildUsageResults(state, providerLabel);
     }
 
     private static HttpRequestMessage CreateBearerRequest(string url, string token)
@@ -478,7 +480,7 @@ public class GitHubCopilotProvider : ProviderBase
         }
     }
 
-    private IEnumerable<ProviderUsage> BuildUsageResults(CopilotUsageState state)
+    private IEnumerable<ProviderUsage> BuildUsageResults(CopilotUsageState state, string providerLabel)
     {
         var accountName = HasMeaningfulUsername(state.Username) ? state.Username : string.Empty;
         var authSource = string.IsNullOrEmpty(state.PlanName) ? AuthSource.Unknown : state.PlanName;
@@ -486,7 +488,7 @@ public class GitHubCopilotProvider : ProviderBase
         var baseUsage = new ProviderUsage
         {
             ProviderId = this.ProviderId,
-            ProviderName = ProviderDisplayName,
+            ProviderName = providerLabel,
             AccountName = accountName,
             IsAvailable = state.IsAvailable,
             State = state.State,
@@ -517,7 +519,7 @@ public class GitHubCopilotProvider : ProviderBase
             results.Add(new ProviderUsage
             {
                 ProviderId = this.ProviderId,
-                ProviderName = ProviderDisplayName,
+                ProviderName = providerLabel,
                 CardId = "weekly",
                 GroupId = this.ProviderId,
                 Name = "Weekly Quota",
@@ -544,7 +546,7 @@ public class GitHubCopilotProvider : ProviderBase
             results.Add(new ProviderUsage
             {
                 ProviderId = this.ProviderId,
-                ProviderName = ProviderDisplayName,
+                ProviderName = providerLabel,
                 CardId = "burst",
                 GroupId = this.ProviderId,
                 Name = "5-Hour Window",

--- a/AIUsageTracker.Infrastructure/Providers/KimiProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/KimiProvider.cs
@@ -90,7 +90,7 @@ public class KimiProvider : ProviderBase
                 return new[] { this.CreateUnavailableUsage("Response missing usage data", authSource: config.AuthSource) };
             }
 
-            return this.BuildUsageCards(data, content, (int)response.StatusCode, config.AuthSource);
+            return this.BuildUsageCards(data, content, (int)response.StatusCode, config.AuthSource, ProviderMetadataCatalog.GetConfiguredDisplayName(config.ProviderId));
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
@@ -99,7 +99,7 @@ public class KimiProvider : ProviderBase
         }
     }
 
-    private IEnumerable<ProviderUsage> BuildUsageCards(KimiUsageResponse data, string content, int statusCode, string? authSource)
+    private IEnumerable<ProviderUsage> BuildUsageCards(KimiUsageResponse data, string content, int statusCode, string? authSource, string providerLabel)
     {
         var flatCards = new List<ProviderUsage>();
         var usedCardIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -107,7 +107,7 @@ public class KimiProvider : ProviderBase
         var hasRollingFromLimits = data.Limits?.Any(l =>
             l.Window != null && DetermineWindowKind(l.Window.Duration, l.Window.TimeUnit) == WindowKind.Rolling) ?? false;
 
-        var weeklyCard = this.TryBuildWeeklyCard(data.Usage!, hasRollingFromLimits, content, statusCode, authSource);
+        var weeklyCard = this.TryBuildWeeklyCard(data.Usage!, hasRollingFromLimits, content, statusCode, authSource, providerLabel);
         if (weeklyCard != null)
         {
             flatCards.Add(weeklyCard);
@@ -116,7 +116,7 @@ public class KimiProvider : ProviderBase
 
         if (data.Limits != null)
         {
-            this.AddLimitCards(data.Limits, flatCards, usedCardIds, content, statusCode, authSource);
+            this.AddLimitCards(data.Limits, flatCards, usedCardIds, content, statusCode, authSource, providerLabel);
         }
 
         if (flatCards.Count == 0)
@@ -126,7 +126,7 @@ public class KimiProvider : ProviderBase
                 new ProviderUsage
                 {
                     ProviderId = this.ProviderId,
-                    ProviderName = this.Definition.DisplayName,
+                    ProviderName = providerLabel,
                     UsedPercent = data.Usage!.Limit > 0 ? UsageMath.CalculateUsedPercent(data.Usage!.Used, data.Usage!.Limit) : 0,
                     RequestsUsed = data.Usage!.Used,
                     RequestsAvailable = data.Usage!.Limit,
@@ -144,7 +144,7 @@ public class KimiProvider : ProviderBase
         return flatCards;
     }
 
-    private ProviderUsage? TryBuildWeeklyCard(KimiUsageData usage, bool hasRollingFromLimits, string content, int statusCode, string? authSource)
+    private ProviderUsage? TryBuildWeeklyCard(KimiUsageData usage, bool hasRollingFromLimits, string content, int statusCode, string? authSource, string providerLabel)
     {
         if (usage.Limit <= 0 || usage.Remaining < 0 || hasRollingFromLimits)
         {
@@ -162,7 +162,7 @@ public class KimiProvider : ProviderBase
         return new ProviderUsage
         {
             ProviderId = this.ProviderId,
-            ProviderName = this.Definition.DisplayName,
+            ProviderName = providerLabel,
             CardId = "weekly",
             GroupId = this.ProviderId,
             Name = "Weekly Limit",
@@ -182,11 +182,11 @@ public class KimiProvider : ProviderBase
         };
     }
 
-    private void AddLimitCards(List<KimiLimitItem> limits, List<ProviderUsage> flatCards, HashSet<string> usedCardIds, string content, int statusCode, string? authSource)
+    private void AddLimitCards(List<KimiLimitItem> limits, List<ProviderUsage> flatCards, HashSet<string> usedCardIds, string content, int statusCode, string? authSource, string providerLabel)
     {
         foreach (var limitItem in limits)
         {
-            var card = this.TryBuildLimitCard(limitItem, usedCardIds, content, statusCode, authSource);
+            var card = this.TryBuildLimitCard(limitItem, usedCardIds, content, statusCode, authSource, providerLabel);
             if (card != null)
             {
                 flatCards.Add(card);
@@ -194,7 +194,7 @@ public class KimiProvider : ProviderBase
         }
     }
 
-    private ProviderUsage? TryBuildLimitCard(KimiLimitItem limitItem, HashSet<string> usedCardIds, string content, int statusCode, string? authSource)
+    private ProviderUsage? TryBuildLimitCard(KimiLimitItem limitItem, HashSet<string> usedCardIds, string content, int statusCode, string? authSource, string providerLabel)
     {
         if (limitItem.Detail == null || limitItem.Window == null)
         {
@@ -227,7 +227,7 @@ public class KimiProvider : ProviderBase
         return new ProviderUsage
         {
             ProviderId = this.ProviderId,
-            ProviderName = this.Definition.DisplayName,
+            ProviderName = providerLabel,
             CardId = cardId,
             GroupId = this.ProviderId,
             Name = name,

--- a/AIUsageTracker.Infrastructure/Providers/MinimaxProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/MinimaxProvider.cs
@@ -31,7 +31,7 @@ public class MinimaxProvider : ProviderBase
 
     public static ProviderDefinition StaticDefinition { get; } = new(
         ChinaProviderId,
-        "MiniMax.chat",
+        "MiniMax.com",
         PlanType.Coding,
         isQuotaBased: true)
     {

--- a/AIUsageTracker.Infrastructure/Providers/MistralProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/MistralProvider.cs
@@ -51,6 +51,8 @@ public class MistralProvider : ProviderBase
     {
         ArgumentNullException.ThrowIfNull(config);
 
+        var providerLabel = ProviderMetadataCatalog.GetConfiguredDisplayName(config.ProviderId);
+
         var apiKey = config.ApiKey;
 
         if (string.IsNullOrEmpty(apiKey) && this.DiscoveryService != null)
@@ -78,7 +80,7 @@ public class MistralProvider : ProviderBase
                     new ProviderUsage
                     {
                         ProviderId = this.ProviderId,
-                        ProviderName = this.Definition.DisplayName,
+                        ProviderName = providerLabel,
                         IsAvailable = true,
                         UsedPercent = 0,
                         IsQuotaBased = this.Definition.IsQuotaBased,

--- a/AIUsageTracker.Infrastructure/Providers/OpenAIProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/OpenAIProvider.cs
@@ -93,9 +93,11 @@ public class OpenAIProvider : ProviderBase
     {
         ArgumentNullException.ThrowIfNull(config);
 
+        var providerLabel = ProviderMetadataCatalog.GetConfiguredDisplayName(config.ProviderId);
+
         if (!string.IsNullOrWhiteSpace(config.ApiKey) && IsApiKey(config.ApiKey))
         {
-            return await this.GetApiKeyUsageAsync(config.ApiKey).ConfigureAwait(false);
+            return await this.GetApiKeyUsageAsync(config.ApiKey, providerLabel).ConfigureAwait(false);
         }
 
         var accessToken = config.ApiKey;
@@ -118,7 +120,7 @@ public class OpenAIProvider : ProviderBase
 
         try
         {
-            return await this.GetNativeUsageAsync(accessToken, accountId).ConfigureAwait(false);
+            return await this.GetNativeUsageAsync(accessToken, accountId, providerLabel).ConfigureAwait(false);
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or JsonException)
         {
@@ -237,7 +239,7 @@ public class OpenAIProvider : ProviderBase
         return null;
     }
 
-    private async Task<IEnumerable<ProviderUsage>> GetApiKeyUsageAsync(string apiKey)
+    private async Task<IEnumerable<ProviderUsage>> GetApiKeyUsageAsync(string apiKey, string providerLabel)
     {
         if (apiKey.StartsWith("sk-proj", StringComparison.OrdinalIgnoreCase))
         {
@@ -246,7 +248,7 @@ public class OpenAIProvider : ProviderBase
                 new ProviderUsage
                 {
                     ProviderId = this.ProviderId,
-                    ProviderName = this.Definition.DisplayName,
+                    ProviderName = providerLabel,
                     IsAvailable = false,
                     State = ProviderUsageState.Missing,
                     Description = "Project keys (sk-proj-...) not supported yet. Use a standard user API key.",
@@ -269,7 +271,7 @@ public class OpenAIProvider : ProviderBase
                     new ProviderUsage
                     {
                         ProviderId = this.ProviderId,
-                        ProviderName = this.Definition.DisplayName,
+                        ProviderName = providerLabel,
                         IsAvailable = true,
                         UsedPercent = 0,
                         IsQuotaBased = this.Definition.IsQuotaBased,
@@ -285,10 +287,10 @@ public class OpenAIProvider : ProviderBase
                 new ProviderUsage
                 {
                     ProviderId = this.ProviderId,
-                    ProviderName = this.Definition.DisplayName,
-                    IsAvailable = false,
-                    State = ProviderUsageState.Error,
-                    Description = $"Invalid Key ({response.StatusCode})",
+                        ProviderName = providerLabel,
+                        IsAvailable = false,
+                        State = ProviderUsageState.Error,
+                        Description = $"Invalid Key ({response.StatusCode})",
                     IsQuotaBased = this.Definition.IsQuotaBased,
                     PlanType = this.Definition.PlanType,
                 },
@@ -302,7 +304,7 @@ public class OpenAIProvider : ProviderBase
                 new ProviderUsage
                 {
                     ProviderId = this.ProviderId,
-                    ProviderName = this.Definition.DisplayName,
+                    ProviderName = providerLabel,
                     IsAvailable = false,
                     State = ProviderUsageState.Error,
                     Description = "Connection Failed",
@@ -313,7 +315,7 @@ public class OpenAIProvider : ProviderBase
         }
     }
 
-    private async Task<IEnumerable<ProviderUsage>> GetNativeUsageAsync(string accessToken, string? accountId)
+    private async Task<IEnumerable<ProviderUsage>> GetNativeUsageAsync(string accessToken, string? accountId, string providerLabel)
     {
         using var request = new HttpRequestMessage(HttpMethod.Get, WhamUsageEndpoint);
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
@@ -358,7 +360,7 @@ public class OpenAIProvider : ProviderBase
             results.Add(new ProviderUsage
             {
                 ProviderId = this.ProviderId,
-                ProviderName = this.Definition.DisplayName,
+                ProviderName = providerLabel,
                 CardId = "burst",
                 GroupId = this.ProviderId,
                 Name = "5-hour quota",
@@ -385,7 +387,7 @@ public class OpenAIProvider : ProviderBase
             results.Add(new ProviderUsage
             {
                 ProviderId = this.ProviderId,
-                ProviderName = this.Definition.DisplayName,
+                ProviderName = providerLabel,
                 CardId = "weekly",
                 GroupId = this.ProviderId,
                 Name = "Weekly quota",
@@ -415,7 +417,7 @@ public class OpenAIProvider : ProviderBase
             results.Add(new ProviderUsage
             {
                 ProviderId = this.ProviderId,
-                ProviderName = this.Definition.DisplayName,
+                ProviderName = providerLabel,
                 AccountName = accountIdentity,
                 IsAvailable = true,
                 IsQuotaBased = this.Definition.IsQuotaBased,

--- a/AIUsageTracker.Infrastructure/Providers/OpenCodeZenProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/OpenCodeZenProvider.cs
@@ -96,6 +96,8 @@ public class OpenCodeZenProvider : ProviderBase
     {
         ArgumentNullException.ThrowIfNull(config);
 
+        var providerLabel = ProviderMetadataCatalog.GetConfiguredDisplayName(config.ProviderId);
+
         var cliPath = await this.ResolveCliPathAsync().ConfigureAwait(false);
         if (cliPath == null)
         {
@@ -107,14 +109,15 @@ public class OpenCodeZenProvider : ProviderBase
                     config.AuthSource,
                     "Searched: PATH, fallback paths: " + string.Join(", ", FallbackPaths),
                     404,
-                    ProviderUsageState.Missing),
+                    ProviderUsageState.Missing,
+                    providerLabel),
             };
         }
 
         try
         {
             var output = await this.RunCliAsync(cliPath).ConfigureAwait(false);
-            return new[] { this.ParseOutput(output, config) };
+            return new[] { this.ParseOutput(output, config, providerLabel) };
         }
         catch (Exception ex) when (ex is InvalidOperationException or System.ComponentModel.Win32Exception or IOException or TimeoutException)
         {
@@ -126,7 +129,9 @@ public class OpenCodeZenProvider : ProviderBase
                     $"CLI Error: {ex.Message} (Check log or clear storage if JSON error)",
                     config.AuthSource,
                     ex.ToString(),
-                    500),
+                    500,
+                    ProviderUsageState.Error,
+                    providerLabel),
             };
         }
     }
@@ -137,12 +142,13 @@ public class OpenCodeZenProvider : ProviderBase
         string? authSource,
         string rawJson,
         int httpStatus,
-        ProviderUsageState state = ProviderUsageState.Error)
+        ProviderUsageState state,
+        string? providerLabel = null)
     {
         return new ProviderUsage
         {
             ProviderId = providerId,
-            ProviderName = ProviderDisplayName,
+            ProviderName = providerLabel ?? ProviderDisplayName,
             IsAvailable = false,
             Description = description,
             State = state,
@@ -534,7 +540,7 @@ public class OpenCodeZenProvider : ProviderBase
         return await standardOutputTask.ConfigureAwait(false);
     }
 
-    private ProviderUsage ParseOutput(string output, ProviderConfig config)
+    private ProviderUsage ParseOutput(string output, ProviderConfig config, string providerLabel)
     {
         var cleaned = CleanAnsiOutput(output);
 
@@ -563,7 +569,7 @@ public class OpenCodeZenProvider : ProviderBase
         return new ProviderUsage
         {
             ProviderId = this.ProviderId,
-            ProviderName = ProviderDisplayName,
+            ProviderName = providerLabel ?? ProviderDisplayName,
             UsedPercent = 0.0,
             RequestsUsed = totalCost,
             RequestsAvailable = 0.0,

--- a/AIUsageTracker.Infrastructure/Providers/ProviderMetadataCatalog.cs
+++ b/AIUsageTracker.Infrastructure/Providers/ProviderMetadataCatalog.cs
@@ -54,30 +54,6 @@ public static class ProviderMetadataCatalog
         return !string.IsNullOrWhiteSpace(mapped) ? mapped : definition.DisplayName;
     }
 
-    public static string ResolveDisplayLabel(ProviderUsage usage)
-    {
-        ArgumentNullException.ThrowIfNull(usage);
-        return ResolveDisplayLabel(usage.ProviderId ?? string.Empty, usage.ProviderName);
-    }
-
-    public static string ResolveDisplayLabel(string providerId, string? runtimeLabel = null)
-    {
-        var definition = Find(providerId);
-        if (definition == null)
-        {
-            return !string.IsNullOrWhiteSpace(runtimeLabel) ? runtimeLabel : (providerId ?? string.Empty);
-        }
-
-        var isDerived = !string.Equals(providerId, definition.ProviderId, StringComparison.OrdinalIgnoreCase);
-        if (isDerived && !string.IsNullOrWhiteSpace(runtimeLabel))
-        {
-            return runtimeLabel;
-        }
-
-        var mapped = definition.ResolveDisplayName(providerId);
-        return !string.IsNullOrWhiteSpace(mapped) ? mapped : definition.DisplayName;
-    }
-
     public static string GetDerivedModelDisplayName(string providerId, string modelName)
     {
         if (string.IsNullOrWhiteSpace(modelName))

--- a/AIUsageTracker.Infrastructure/Providers/SyntheticProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/SyntheticProvider.cs
@@ -47,6 +47,8 @@ public sealed class SyntheticProvider : ProviderBase
     {
         ArgumentNullException.ThrowIfNull(config);
 
+        var providerLabel = ProviderMetadataCatalog.GetConfiguredDisplayName(config.ProviderId);
+
         if (string.IsNullOrWhiteSpace(config.ApiKey))
         {
             return new[] { this.CreateUnavailableUsage("API Key missing", 401, config.AuthSource, state: ProviderUsageState.Missing) };
@@ -100,7 +102,7 @@ public sealed class SyntheticProvider : ProviderBase
                 new ProviderUsage
                 {
                     ProviderId = this.ProviderId,
-                    ProviderName = this.Definition.DisplayName,
+                    ProviderName = providerLabel,
                     UsedPercent = Math.Clamp(used / total * 100.0, 0, 100),
                     RequestsUsed = used,
                     RequestsAvailable = total,

--- a/AIUsageTracker.Infrastructure/Providers/XiaomiProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/XiaomiProvider.cs
@@ -45,6 +45,8 @@ public class XiaomiProvider : ProviderBase
     {
         ArgumentNullException.ThrowIfNull(config);
 
+        var providerLabel = ProviderMetadataCatalog.GetConfiguredDisplayName(config.ProviderId);
+
         if (string.IsNullOrEmpty(config.ApiKey))
         {
             return new[]
@@ -52,7 +54,7 @@ public class XiaomiProvider : ProviderBase
                 new ProviderUsage
             {
                 ProviderId = config.ProviderId,
-                ProviderName = this.Definition.DisplayName,
+                ProviderName = providerLabel,
                 IsAvailable = false,
                 IsQuotaBased = this.Definition.IsQuotaBased,
                 PlanType = this.Definition.PlanType,
@@ -92,7 +94,7 @@ public class XiaomiProvider : ProviderBase
                 new ProviderUsage
             {
                 ProviderId = config.ProviderId,
-                ProviderName = this.Definition.DisplayName,
+                ProviderName = providerLabel,
                 UsedPercent = usedPercent,
                 RequestsUsed = used,
                 RequestsAvailable = quota > 0 ? quota : balance,
@@ -115,7 +117,7 @@ public class XiaomiProvider : ProviderBase
                 new ProviderUsage
             {
                 ProviderId = config.ProviderId,
-                ProviderName = this.Definition.DisplayName,
+                ProviderName = providerLabel,
                 IsAvailable = false,
                 IsQuotaBased = this.Definition.IsQuotaBased,
                 PlanType = this.Definition.PlanType,

--- a/AIUsageTracker.Infrastructure/Providers/ZaiProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/ZaiProvider.cs
@@ -58,7 +58,7 @@ public class ZaiProvider : ProviderBase
             throw new ArgumentException("API Key not found for Z.AI provider.", nameof(config));
         }
 
-        var providerLabel = this.Definition.DisplayName;
+        var providerLabel = ProviderMetadataCatalog.GetConfiguredDisplayName(config.ProviderId);
 
         using var request = new HttpRequestMessage(HttpMethod.Get, QuotaLimitEndpoint);
 

--- a/AIUsageTracker.Monitor/Services/ProviderRefreshCircuitBreakerService.cs
+++ b/AIUsageTracker.Monitor/Services/ProviderRefreshCircuitBreakerService.cs
@@ -173,7 +173,7 @@ public class ProviderRefreshCircuitBreakerService
                     ? $"Temporarily paused after repeated failures — next check at {retryLocal:HH:mm}"
                     : $"Temporarily paused — next check at {retryLocal:HH:mm} (last error: {state.LastError})";
 
-                var displayName = ProviderMetadataCatalog.ResolveDisplayLabel(config.ProviderId, config.ProviderId);
+                var displayName = ProviderMetadataCatalog.GetConfiguredDisplayName(config.ProviderId);
                 result.Add(new ProviderUsage
                 {
                     ProviderId = config.ProviderId,

--- a/AIUsageTracker.Monitor/Services/UsageDatabase.cs
+++ b/AIUsageTracker.Monitor/Services/UsageDatabase.cs
@@ -688,8 +688,6 @@ public class UsageDatabase : IUsageDatabase
                 }
             }
 
-            usage.ProviderName = ProviderMetadataCatalog.ResolveDisplayLabel(usage.ProviderId ?? string.Empty, usage.ProviderName);
-
             ApplyUpstreamResponseValidity(usage);
             MarkStaleIfOutdated(usage, now);
         }

--- a/AIUsageTracker.Tests/Core/AllProvidersWorkingTests.cs
+++ b/AIUsageTracker.Tests/Core/AllProvidersWorkingTests.cs
@@ -45,7 +45,7 @@ public class AllProvidersWorkingTests
         mockMinimax.Setup(p => p.ProviderId).Returns("minimax");
         mockMinimax.Setup(p => p.Definition).Returns(new ProviderDefinition(
             "minimax",
-            "MiniMax.chat",
+            "MiniMax.com",
             PlanType.Coding,
             isQuotaBased: true)
         {

--- a/AIUsageTracker.Tests/Infrastructure/ProviderMetadataCatalogTests.cs
+++ b/AIUsageTracker.Tests/Infrastructure/ProviderMetadataCatalogTests.cs
@@ -52,7 +52,7 @@ public class ProviderMetadataCatalogTests
 
         Assert.NotNull(definition);
         Assert.Equal(expectedDefinitionId, definition!.ProviderId);
-        Assert.Equal(expectedDisplayName, ProviderMetadataCatalog.ResolveDisplayLabel(providerId));
+        Assert.Equal(expectedDisplayName, ProviderMetadataCatalog.GetConfiguredDisplayName(providerId));
     }
 
     [Theory]
@@ -63,14 +63,14 @@ public class ProviderMetadataCatalogTests
         string expectedDisplayName,
         string expectedSessionLabel)
     {
-        Assert.Equal(expectedDisplayName, ProviderMetadataCatalog.ResolveDisplayLabel(providerId));
+        Assert.Equal(expectedDisplayName, ProviderMetadataCatalog.GetConfiguredDisplayName(providerId));
         Assert.Equal(expectedSessionLabel, ProviderMetadataCatalog.Find(providerId)?.SessionStatusLabel);
     }
 
     [Theory]
     [InlineData("codex.spark", "OpenAI (GPT-5.3 Codex Spark)")]
     [InlineData("antigravity.gpt-oss", "Google Antigravity")]
-    [InlineData("minimax", "MiniMax.chat")]
+    [InlineData("minimax", "MiniMax.com")]
     [InlineData("minimax-io", "MiniMax.io")]
     [InlineData("minimax-global", "MiniMax.io")]
     [InlineData("minimax-coding-plan", "Minimax.io Coding Plan")]
@@ -80,14 +80,13 @@ public class ProviderMetadataCatalogTests
     }
 
     [Theory]
-    [InlineData("antigravity.gpt-oss", "GPT OSS (Anti-Gravity)", "GPT OSS (Anti-Gravity)")]
-    [InlineData("gemini-cli.minute", "Gemini 2.5 Flash Lite [Gemini CLI]", "Gemini 2.5 Flash Lite [Gemini CLI]")]
-    public void ResolveDisplayLabel_PreservesIntentionalRuntimeLabels_ForDynamicChildren(
+    [InlineData("antigravity.gpt-oss", "Google Antigravity")]
+    [InlineData("gemini-cli.minute", "Gemini CLI (Minute)")]
+    public void GetConfiguredDisplayName_ResolvesDerivedProviderIds(
         string providerId,
-        string runtimeLabel,
         string expectedDisplayLabel)
     {
-        Assert.Equal(expectedDisplayLabel, ProviderMetadataCatalog.ResolveDisplayLabel(providerId, runtimeLabel));
+        Assert.Equal(expectedDisplayLabel, ProviderMetadataCatalog.GetConfiguredDisplayName(providerId));
     }
 
     [Fact]

--- a/AIUsageTracker.Tests/Infrastructure/Providers/AntigravityProviderTests.cs
+++ b/AIUsageTracker.Tests/Infrastructure/Providers/AntigravityProviderTests.cs
@@ -151,7 +151,8 @@ public class AntigravityProviderTests : HttpProviderTestBase<AntigravityProvider
         var method = typeof(AntigravityProvider).GetMethod("FetchUsageAsync", BindingFlags.Instance | BindingFlags.NonPublic);
         Assert.NotNull(method);
 
-        var task = (Task<List<ProviderUsage>>)method!.Invoke(provider, new object[] { port, csrfToken, config })!;
+        var providerLabel = ProviderMetadataCatalog.GetConfiguredDisplayName("antigravity");
+        var task = (Task<List<ProviderUsage>>)method!.Invoke(provider, new object[] { port, csrfToken, config, providerLabel })!;
         return await task.ConfigureAwait(false);
     }
 }

--- a/AIUsageTracker.Tests/Infrastructure/Providers/ClaudeCodeProviderTests.cs
+++ b/AIUsageTracker.Tests/Infrastructure/Providers/ClaudeCodeProviderTests.cs
@@ -59,7 +59,7 @@ public class ClaudeCodeProviderTests : HttpProviderTestBase<ClaudeCodeProvider>
         this.SetupOAuthResponse(HttpStatusCode.OK, responseJson);
 
         // Act
-        var results = await this._provider.GetUsageFromOAuthAsync("test-token");
+        var results = await this._provider.GetUsageFromOAuthAsync("test-token", "Claude Code");
 
         // Assert — flat cards returned
         Assert.NotNull(results);
@@ -121,7 +121,7 @@ public class ClaudeCodeProviderTests : HttpProviderTestBase<ClaudeCodeProvider>
         this.SetupOAuthResponse(HttpStatusCode.OK, responseJson);
 
         // Act
-        var results = await this._provider.GetUsageFromOAuthAsync("test-token");
+        var results = await this._provider.GetUsageFromOAuthAsync("test-token", "Claude Code");
 
         // Assert
         Assert.NotNull(results);
@@ -166,7 +166,7 @@ public class ClaudeCodeProviderTests : HttpProviderTestBase<ClaudeCodeProvider>
         this.SetupOAuthResponse(HttpStatusCode.OK, responseJson);
 
         // Act
-        var results = await this._provider.GetUsageFromOAuthAsync("test-token");
+        var results = await this._provider.GetUsageFromOAuthAsync("test-token", "Claude Code");
 
         // Assert
         Assert.NotNull(results);
@@ -212,7 +212,7 @@ public class ClaudeCodeProviderTests : HttpProviderTestBase<ClaudeCodeProvider>
         this.SetupOAuthResponse(HttpStatusCode.OK, responseJson);
 
         // Act
-        var results = await this._provider.GetUsageFromOAuthAsync("test-token");
+        var results = await this._provider.GetUsageFromOAuthAsync("test-token", "Claude Code");
 
         // Assert
         Assert.NotNull(results);
@@ -256,7 +256,7 @@ public class ClaudeCodeProviderTests : HttpProviderTestBase<ClaudeCodeProvider>
         this.SetupOAuthResponse(HttpStatusCode.OK, responseJson);
 
         // Act
-        var results = await this._provider.GetUsageFromOAuthAsync("test-token");
+        var results = await this._provider.GetUsageFromOAuthAsync("test-token", "Claude Code");
 
         // Assert
         Assert.NotNull(results);
@@ -295,7 +295,7 @@ public class ClaudeCodeProviderTests : HttpProviderTestBase<ClaudeCodeProvider>
         this.SetupOAuthResponse(HttpStatusCode.OK, responseJson);
 
         // Act
-        var results = await this._provider.GetUsageFromOAuthAsync("test-token");
+        var results = await this._provider.GetUsageFromOAuthAsync("test-token", "Claude Code");
 
         // Assert
         Assert.NotNull(results);
@@ -330,7 +330,7 @@ public class ClaudeCodeProviderTests : HttpProviderTestBase<ClaudeCodeProvider>
         this.SetupOAuthResponse(HttpStatusCode.OK, responseJson);
 
         // Act
-        var results = await this._provider.GetUsageFromOAuthAsync("test-token");
+        var results = await this._provider.GetUsageFromOAuthAsync("test-token", "Claude Code");
 
         // Assert
         Assert.NotNull(results);
@@ -347,7 +347,7 @@ public class ClaudeCodeProviderTests : HttpProviderTestBase<ClaudeCodeProvider>
         this.SetupOAuthResponse(HttpStatusCode.Unauthorized, """{"error": "invalid_token"}""");
 
         // Act
-        var result = await this._provider.GetUsageFromOAuthAsync("invalid-token");
+        var result = await this._provider.GetUsageFromOAuthAsync("invalid-token", "Claude Code");
 
         // Assert
         Assert.Null(result);
@@ -360,7 +360,7 @@ public class ClaudeCodeProviderTests : HttpProviderTestBase<ClaudeCodeProvider>
         this.SetupOAuthResponse(HttpStatusCode.InternalServerError, """{"error": "internal_error"}""");
 
         // Act
-        var result = await this._provider.GetUsageFromOAuthAsync("test-token");
+        var result = await this._provider.GetUsageFromOAuthAsync("test-token", "Claude Code");
 
         // Assert
         Assert.Null(result);
@@ -373,7 +373,7 @@ public class ClaudeCodeProviderTests : HttpProviderTestBase<ClaudeCodeProvider>
         this.SetupOAuthResponse(HttpStatusCode.OK, "not valid json");
 
         // Act
-        var result = await this._provider.GetUsageFromOAuthAsync("test-token");
+        var result = await this._provider.GetUsageFromOAuthAsync("test-token", "Claude Code");
 
         // Assert
         Assert.Null(result);
@@ -394,7 +394,7 @@ public class ClaudeCodeProviderTests : HttpProviderTestBase<ClaudeCodeProvider>
             }));
 
         // Act
-        var result = await this._provider.GetUsageFromOAuthAsync("test-token");
+        var result = await this._provider.GetUsageFromOAuthAsync("test-token", "Claude Code");
 
         // Assert — returns null after retry
         Assert.Null(result);

--- a/AIUsageTracker.Tests/Infrastructure/Providers/MinimaxProviderTests.cs
+++ b/AIUsageTracker.Tests/Infrastructure/Providers/MinimaxProviderTests.cs
@@ -216,7 +216,7 @@ public class MinimaxProviderTests : HttpProviderTestBase<MinimaxProvider>
         var definition = MinimaxProvider.StaticDefinition;
 
         Assert.Equal("minimax", definition.ProviderId); // provider-id-guardrail-allow: test assertion
-        Assert.Equal("MiniMax.chat", definition.DisplayName);
+        Assert.Equal("MiniMax.com", definition.DisplayName);
         Assert.True(definition.IsQuotaBased);
         Assert.Contains("MINIMAX_API_KEY", definition.DiscoveryEnvironmentVariables);
     }
@@ -243,7 +243,7 @@ public class MinimaxProviderTests : HttpProviderTestBase<MinimaxProvider>
         // Assert
         var usage = result.Single();
         Assert.Equal("minimax", usage.ProviderId); // provider-id-guardrail-allow: test assertion
-        Assert.Equal("MiniMax.chat", usage.ProviderName);
+        Assert.Equal("MiniMax.com", usage.ProviderName);
     }
 
     [Fact]

--- a/AIUsageTracker.Tests/Infrastructure/Providers/OpenCodeZenProviderTests.cs
+++ b/AIUsageTracker.Tests/Infrastructure/Providers/OpenCodeZenProviderTests.cs
@@ -428,7 +428,8 @@ public class OpenCodeZenProviderTests : HttpProviderTestBase<OpenCodeZenProvider
         var parseOutput = typeof(OpenCodeZenProvider).GetMethod(
             "ParseOutput", BindingFlags.NonPublic | BindingFlags.Instance);
         Assert.NotNull(parseOutput);
-        return (ProviderUsage)parseOutput.Invoke(this._provider, new object[] { output, this.Config })!;
+        var providerLabel = ProviderMetadataCatalog.GetConfiguredDisplayName("opencode-zen");
+        return (ProviderUsage)parseOutput.Invoke(this._provider, new object[] { output, this.Config, providerLabel })!;
     }
 
     private static (string ScriptPath, string TempDir) CreateMockCliScript(string output)

--- a/AIUsageTracker.Tests/Integration/ProviderResponseDeserializationTests.cs
+++ b/AIUsageTracker.Tests/Integration/ProviderResponseDeserializationTests.cs
@@ -235,7 +235,7 @@ public class ProviderResponseDeserializationTests
         var provider = new ClaudeCodeProvider(NullLogger<ClaudeCodeProvider>.Instance, httpClient);
 
         // Act — GetUsageFromOAuthAsync returns IEnumerable<ProviderUsage>?
-        var results = await provider.GetUsageFromOAuthAsync("test-oauth-token");
+        var results = await provider.GetUsageFromOAuthAsync("test-oauth-token", "Claude Code");
 
         // Assert — flat cards: current-session, sonnet, opus, all-models
         Assert.NotNull(results);
@@ -286,7 +286,7 @@ public class ProviderResponseDeserializationTests
         var httpClient = CreateMockHttpClient(responseJson, HttpStatusCode.OK);
         var provider = new ClaudeCodeProvider(NullLogger<ClaudeCodeProvider>.Instance, httpClient);
 
-        var results = await provider.GetUsageFromOAuthAsync("test-token");
+        var results = await provider.GetUsageFromOAuthAsync("test-token", "Claude Code");
 
         Assert.NotNull(results);
         var cards = results!.ToList();
@@ -333,7 +333,7 @@ public class ProviderResponseDeserializationTests
         var httpClient = CreateMockHttpClient("{\"error\": \"unauthorized\"}", HttpStatusCode.Unauthorized);
         var provider = new ClaudeCodeProvider(NullLogger<ClaudeCodeProvider>.Instance, httpClient);
 
-        var usage = await provider.GetUsageFromOAuthAsync("bad-token");
+        var usage = await provider.GetUsageFromOAuthAsync("bad-token", "Claude Code");
 
         Assert.Null(usage);
     }

--- a/AIUsageTracker.Tests/Services/CachedGroupedUsageProjectionServiceTests.cs
+++ b/AIUsageTracker.Tests/Services/CachedGroupedUsageProjectionServiceTests.cs
@@ -107,7 +107,7 @@ public sealed class CachedGroupedUsageProjectionServiceTests
         // "API Key not found" data from the unconfigured minimax entry.
         var dbUsages = new List<ProviderUsage>
         {
-            new() { ProviderId = "minimax", ProviderName = "MiniMax.chat", IsAvailable = false, Description = "API Key not found." },
+            new() { ProviderId = "minimax", ProviderName = "MiniMax.com", IsAvailable = false, Description = "API Key not found." },
             new() { ProviderId = "minimax-io", ProviderName = "MiniMax.io", IsAvailable = true, UsedPercent = 30 },
         };
 

--- a/AIUsageTracker.Tests/UI/MainWindowDeterministicFixtureTests.cs
+++ b/AIUsageTracker.Tests/UI/MainWindowDeterministicFixtureTests.cs
@@ -25,7 +25,7 @@ public class MainWindowDeterministicFixtureTests
             var definition = Assert.Single(
                 ProviderMetadataCatalog.Definitions,
                 d => d.HandlesProviderId(usage.ProviderId));
-            Assert.Equal(ProviderMetadataCatalog.ResolveDisplayLabel(usage.ProviderId), usage.ProviderName);
+            Assert.Equal(ProviderMetadataCatalog.GetConfiguredDisplayName(usage.ProviderId), usage.ProviderName);
             Assert.Equal(definition.PlanType, usage.PlanType);
             Assert.Equal(definition.IsQuotaBased, usage.IsQuotaBased);
         }

--- a/AIUsageTracker.Tests/UI/SettingsWindowDeterministicFixtureTests.cs
+++ b/AIUsageTracker.Tests/UI/SettingsWindowDeterministicFixtureTests.cs
@@ -34,7 +34,7 @@ public class SettingsWindowDeterministicFixtureTests
             var definition = Assert.Single(
                 ProviderMetadataCatalog.Definitions,
                 d => d.HandlesProviderId(usage.ProviderId));
-            Assert.Equal(ProviderMetadataCatalog.ResolveDisplayLabel(usage.ProviderId), usage.ProviderName);
+            Assert.Equal(ProviderMetadataCatalog.GetConfiguredDisplayName(usage.ProviderId), usage.ProviderName);
             Assert.Equal(definition.PlanType, usage.PlanType);
             Assert.Equal(definition.IsQuotaBased, usage.IsQuotaBased);
         }

--- a/AIUsageTracker.UI.Slim/App.TrayIcon.cs
+++ b/AIUsageTracker.UI.Slim/App.TrayIcon.cs
@@ -78,7 +78,7 @@ public partial class App
                         dualQuotaSingleBarMode);
                 }
 
-                var providerLabel = ProviderMetadataCatalog.ResolveDisplayLabel(usage);
+                var providerLabel = usage.ProviderName ?? ProviderMetadataCatalog.GetConfiguredDisplayName(usage.ProviderId ?? string.Empty);
                 var paceColor = UsageMath.ComputePaceColor(
                     usage.UsedPercent,
                     usage.NextResetTime,

--- a/AIUsageTracker.UI.Slim/MainWindow.Rendering.cs
+++ b/AIUsageTracker.UI.Slim/MainWindow.Rendering.cs
@@ -291,7 +291,7 @@ public partial class MainWindow : Window
             this.AddProviderCard(groupCards[0], container, cardRenderer, isChild: false);
 
             var (groupHeader, groupContainer) = this.CreateCollapsibleHeader(
-                $"{ProviderMetadataCatalog.ResolveDisplayLabel(groupCards[0])} Details",
+                $"{groupCards[0].ProviderName ?? ProviderMetadataCatalog.GetConfiguredDisplayName(groupCards[0].ProviderId ?? string.Empty)} Details",
                 System.Windows.Media.Brushes.DeepSkyBlue,
                 isGroupHeader: false,
                 groupKey: null,

--- a/AIUsageTracker.UI.Slim/MainWindowDeterministicFixture.cs
+++ b/AIUsageTracker.UI.Slim/MainWindowDeterministicFixture.cs
@@ -165,7 +165,7 @@ internal static class MainWindowDeterministicFixture
         return new ProviderUsage
         {
             ProviderId = scenario.ProviderId,
-            ProviderName = ProviderMetadataCatalog.ResolveDisplayLabel(scenario.ProviderId),
+            ProviderName = ProviderMetadataCatalog.GetConfiguredDisplayName(scenario.ProviderId),
             IsAvailable = isAvailable,
             IsQuotaBased = isQuotaBased,
             PlanType = planType,

--- a/AIUsageTracker.UI.Slim/ProviderCardRenderer.cs
+++ b/AIUsageTracker.UI.Slim/ProviderCardRenderer.cs
@@ -52,7 +52,7 @@ internal sealed class ProviderCardRenderer
     public FrameworkElement CreateProviderCard(ProviderUsage usage, bool showUsed, bool isChild = false, ProviderDefinition? definition = null)
     {
         var providerId = usage.ProviderId ?? string.Empty;
-        var friendlyName = ResolveFriendlyName(usage, definition, providerId);
+        var friendlyName = usage.ProviderName ?? providerId;
 
         var presentation = MainWindowRuntimeLogic.Create(usage, showUsed, this._preferences.EnablePaceAdjustment);
 
@@ -171,21 +171,6 @@ internal sealed class ProviderCardRenderer
         providerIcon.Height = iconSize;
         providerIcon.VerticalAlignment = VerticalAlignment.Center;
         AddDockedElement(contentPanel, providerIcon, Dock.Left);
-    }
-
-    private static string ResolveFriendlyName(ProviderUsage usage, ProviderDefinition? definition, string providerId)
-    {
-        if (!string.IsNullOrEmpty(usage.CardId))
-        {
-            return usage.ProviderName ?? string.Empty;
-        }
-
-        if (definition != null)
-        {
-            return definition.ResolveDisplayName(providerId) ?? usage.ProviderName;
-        }
-
-        return ProviderMetadataCatalog.ResolveDisplayLabel(usage);
     }
 
     private void AddCardBackground(Grid grid, Grid pGrid, ProviderCardPresentation presentation, PaceColorResult cardPaceColor)

--- a/AIUsageTracker.UI.Slim/SettingsWindow.Providers.cs
+++ b/AIUsageTracker.UI.Slim/SettingsWindow.Providers.cs
@@ -132,7 +132,7 @@ public partial class SettingsWindow
         displayItems.AddRange(derivedItems);
 
         return displayItems
-            .OrderBy(item => ProviderMetadataCatalog.ResolveDisplayLabel(item.Config.ProviderId), StringComparer.OrdinalIgnoreCase)
+            .OrderBy(item => ProviderMetadataCatalog.GetConfiguredDisplayName(item.Config.ProviderId), StringComparer.OrdinalIgnoreCase)
             .ThenBy(item => item.Config.ProviderId, StringComparer.OrdinalIgnoreCase)
             .ToList();
     }

--- a/AIUsageTracker.UI.Slim/SettingsWindowDeterministicFixture.cs
+++ b/AIUsageTracker.UI.Slim/SettingsWindowDeterministicFixture.cs
@@ -68,7 +68,7 @@ internal static class SettingsWindowDeterministicFixture
         return new ProviderUsage
         {
             ProviderId = scenario.ProviderId,
-            ProviderName = ProviderMetadataCatalog.ResolveDisplayLabel(scenario.ProviderId),
+            ProviderName = ProviderMetadataCatalog.GetConfiguredDisplayName(scenario.ProviderId),
             IsAvailable = isAvailable,
             IsQuotaBased = isQuotaBased,
             PlanType = planType,
@@ -90,7 +90,7 @@ internal static class SettingsWindowDeterministicFixture
 
         return new SettingsWindowHistoryRow
         {
-            ProviderName = ProviderMetadataCatalog.ResolveDisplayLabel(providerId),
+            ProviderName = ProviderMetadataCatalog.GetConfiguredDisplayName(providerId),
             UsagePercentage = scenario.UsagePercentage,
             Used = scenario.Used,
             Limit = scenario.Limit,

--- a/AIUsageTracker.Web/Services/WebProviderDisplayNameMapper.cs
+++ b/AIUsageTracker.Web/Services/WebProviderDisplayNameMapper.cs
@@ -29,7 +29,7 @@ internal static class WebProviderDisplayNameMapper
     {
         foreach (var provider in providers)
         {
-            provider.ProviderName = ProviderMetadataCatalog.ResolveDisplayLabel(provider.ProviderId, provider.ProviderName);
+            provider.ProviderName = provider.ProviderName ?? ProviderMetadataCatalog.GetConfiguredDisplayName(provider.ProviderId ?? string.Empty);
         }
     }
 
@@ -37,7 +37,7 @@ internal static class WebProviderDisplayNameMapper
     {
         foreach (var point in points)
         {
-            point.ProviderName = ProviderMetadataCatalog.ResolveDisplayLabel(point.ProviderId, point.ProviderName);
+            point.ProviderName = point.ProviderName ?? ProviderMetadataCatalog.GetConfiguredDisplayName(point.ProviderId ?? string.Empty);
         }
     }
 
@@ -45,7 +45,7 @@ internal static class WebProviderDisplayNameMapper
     {
         foreach (var resetEvent in resetEvents)
         {
-            resetEvent.ProviderName = ProviderMetadataCatalog.ResolveDisplayLabel(resetEvent.ProviderId, resetEvent.ProviderName);
+            resetEvent.ProviderName = resetEvent.ProviderName ?? ProviderMetadataCatalog.GetConfiguredDisplayName(resetEvent.ProviderId ?? string.Empty);
         }
     }
 }


### PR DESCRIPTION
## Summary

Centralizes all provider display name resolution into a single method: `ProviderMetadataCatalog.GetConfiguredDisplayName(providerId)`.

### Before (broken)
Display names were resolved in 4+ different places with inconsistent results:
- `ProviderCardRenderer.ResolveFriendlyName` — re-resolved from definition, overriding `usage.ProviderName`
- `ProviderMetadataCatalog.ResolveDisplayLabel` — re-resolved from providerId + runtime label
- `UsageDatabase` — overrode `ProviderName` on persist
- Individual providers used `this.Definition.DisplayName` directly — **bypassing `DisplayNameOverrides`**

This caused bugs like MiniMax international users seeing "MiniMax.chat" instead of "MiniMax.io" because providers used `this.Definition.DisplayName` (always the base name) instead of `GetConfiguredDisplayName` (respects overrides).

### After (fixed)
- **Single source of truth**: `GetConfiguredDisplayName(providerId)` checks `DisplayNameOverrides` then falls back to `definition.DisplayName`
- All 15 providers now use `GetConfiguredDisplayName(config.ProviderId)` for `providerLabel`
- Removed `ResolveDisplayLabel` (2 overloads) and `ResolveFriendlyName` — no longer needed
- Removed `UsageDatabase` display name override on persist — providers already set correct names
- UI card renderer uses `usage.ProviderName` directly

### Also included
- Renamed China provider display name from "MiniMax.chat" to "MiniMax.com"

## Files changed
- 36 files, +164/-177 lines (net reduction)
- 15 providers updated
- 6 consumer sites updated (CLI, SettingsWindow, UsageDatabase, TokenDiscoveryService, Web, TrayIcon)
- Tests updated for new signatures and expected values

## Test plan
- [x] `dotnet build` - 0 errors, 0 warnings
- [x] 1,487 tests pass (1 flaky WPF test excluded)
- [ ] Manual: Verify provider display names correct in UI
- [ ] Manual: MiniMax international shows "MiniMax.io", China shows "MiniMax.com"