### PR TITLE
fix(ci): avoid false positives in push gitleaks baseline scan

### DIFF
--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -62,5 +62,4 @@ jobs:
           ./gitleaks detect \
             --source . \
             --baseline-path .gitleaksbaseline.json \
-            --redact \
             --exit-code 1


### PR DESCRIPTION
## Summary
- remove \--redact\ from the push-mode gitleaks scan that uses \--baseline-path\
- keep PR-mode scan unchanged (still redacted)

## Why
The failing Secret Scanning job (run 24560532192, job 71807756409) was caused by a mismatch between baseline mode and redacted output in gitleaks 8.21.2. The same commit passes baseline mode when redaction is not applied.

## Validation
- Reproduced failure at commit \ca5933204b9c868350bc542e67bb5f817153dd18\ with current workflow command (10 leaks reported).
- Ran equivalent baseline scan without \--redact\ on the same commit: no leaks found.