### PR TITLE
chore(release): prepare 2.3.4-beta.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+## [2.3.4-beta.31] - 2026-04-17
+
+### Added
+- **Copilot monthly quota model**: GitHub Copilot now reports a monthly quota window and no longer renders the previous weekly/burst split.
+
+### Fixed
+- **Privacy and settings persistence hardening**: preferences/config writes now use atomic write semantics with retry behavior, and preferences loading can recover from backup when the primary file is unreadable.
+- **Secret Scanning false positives on push**: Gitleaks push-mode baseline scan is now deterministic by removing `--redact` from the baseline-path execution path.
+
+### Changed
+- **Display-name resolution centralized**: provider naming now consistently resolves through a single catalog path across UI and web surfaces.
+
 ## [2.3.4-beta.30] - 2026-04-12
 
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TrackerVersion>2.3.4-beta.30</TrackerVersion>
+    <TrackerVersion>2.3.4-beta.31</TrackerVersion>
     <TrackerAssemblyVersion>2.3.4</TrackerAssemblyVersion>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(MSBuildProjectDirectory)\artifacts\**\*</DefaultItemExcludes>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="AIUsageTracker.Web/wwwroot/favicon.png" width="32" height="32" valign="middle"> AI Usage Tracker
 
-![Version](https://img.shields.io/badge/version-2.3.4--beta.30-orange)
+![Version](https://img.shields.io/badge/version-2.3.4--beta.31-orange)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Platforms](https://img.shields.io/badge/platforms-Windows%20|%20Linux%20-blue)
 ![Language](https://img.shields.io/badge/language-C%23%20|%20.NET-purple)

--- a/scripts/publish-app.ps1
+++ b/scripts/publish-app.ps1
@@ -6,7 +6,7 @@ param(
 )
 
 # AI Usage Tracker - Distribution Packaging Script
-# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.3.4-beta.30 -InstallerCompression balanced
+# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.3.4-beta.31 -InstallerCompression balanced
 
 $isWinPlatform = $Runtime.StartsWith("win-")
 $projectName = if ($isWinPlatform) { "AIUsageTracker" } else { "AIUsageTracker.CLI" }
@@ -214,6 +214,5 @@ Write-Host "--------------------------------------------------" -ForegroundColor
 Write-Host "Distribution ready at: $zipPath" -ForegroundColor Green
 Write-Host "Size: $((Get-Item $zipPath).Length / 1MB) MB" -ForegroundColor Gray
 Write-Host "--------------------------------------------------" -ForegroundColor Yellow
-
 
 

--- a/scripts/setup.iss
+++ b/scripts/setup.iss
@@ -1,7 +1,7 @@
 ; AI Usage Tracker - Inno Setup Script
 
 #ifndef MyAppVersion
-  #define MyAppVersion "2.3.4-beta.30"
+  #define MyAppVersion "2.3.4-beta.31"
 #endif
 #ifndef SourcePath
   #define SourcePath "..\dist\publish-win-x64"
@@ -254,4 +254,3 @@ Root: HKCU; Subkey: "Software\Microsoft\Windows\CurrentVersion\Run"; ValueType: 
 
 [Run]
 Filename: "{app}\AIUsageTracker.exe"; Description: "{cm:LaunchProgram,AI Usage Tracker UI}"; Flags: nowait postinstall skipifsilent; Components: apps\tracker; Check: ShouldRunApplication
-


### PR DESCRIPTION
## Summary
Prepare beta release metadata for 2.3.4-beta.31 after recent fixes landed on develop.

## Changes
- bump tracker version to 2.3.4-beta.31
- add changelog entry for beta.31 (copilot quota model, persistence hardening, CI baseline fix, display-name cleanup)
- update README version badge
- update installer version
- update publish script example version

## Validation
- bash scripts/validate-release-consistency.sh "2.3.4-beta.31"
- dotnet build AIUsageTracker.sln --configuration Debug
- dotnet test AIUsageTracker.Tests/AIUsageTracker.Tests.csproj --configuration Debug --no-build
- ./scripts/pre-commit-check.sh
