### PR TITLE
docs(preferences): clarify numeric UpdateChannel persistence

### DIFF
--- a/AIUsageTracker.Core/Models/AppPreferences.cs
+++ b/AIUsageTracker.Core/Models/AppPreferences.cs
@@ -107,7 +107,8 @@ public class AppPreferences
     // Per-group collapse state for flat card groups (keyed by GroupId).
     public IDictionary<string, bool> CollapsedGroupIds { get; set; } = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
 
-    // Update channel (Stable or Beta)
+    // Update channel (Stable or Beta).
+    // Intentionally persisted as a numeric enum value (0=Stable, 1=Beta).
     public UpdateChannel UpdateChannel { get; set; } = UpdateChannel.Stable;
 
     // Display Options

--- a/AIUsageTracker.Tests/UI/AppStartupTests.cs
+++ b/AIUsageTracker.Tests/UI/AppStartupTests.cs
@@ -173,6 +173,18 @@ public class AppStartupTests : IDisposable
     }
 
     [Fact]
+    public async Task SavePreferencesAsync_WritesNumericUpdateChannelValueAsync()
+    {
+        var preferences = new AppPreferences { UpdateChannel = UpdateChannel.Beta };
+
+        var saved = await this._store.SaveAsync(preferences);
+        var json = await File.ReadAllTextAsync(this._testPreferencesPath);
+
+        Assert.True(saved);
+        Assert.Contains("\"UpdateChannel\": 1", json, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task LoadPreferencesAsync_WhenPrimaryCorrupted_UsesBackupAsync()
     {
         var original = new AppPreferences


### PR DESCRIPTION
## Summary
- document in AppPreferences that UpdateChannel is intentionally persisted as numeric enum values (