### PR TITLE
Fix ShowUsed migration and add workflow_dispatch to Publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,12 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'           # Stable releases: v2.2.25
       - 'v[0-9]+.[0-9]+.[0-9]+-beta.*'    # Beta releases: v2.3.0-beta.1
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build (e.g., v2.3.4-beta.33)'
+        required: true
+        type: string
 
 jobs:
   publish:
@@ -19,13 +25,15 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
+          ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0
           persist-credentials: false
 
       - name: Extract Version and Channel
         id: extract
         run: |
-          $version = $env:GITHUB_REF -replace 'refs/tags/v', ''
+          $ref = if ('${{ inputs.tag }}') { '${{ inputs.tag }}' } else { $env:GITHUB_REF }
+          $version = $ref -replace 'refs/tags/v', '' -replace '^v', ''
           $channel = if ($version -match '-beta') { 'beta' } else { 'stable' }
           
           echo "VERSION=$version" >> $env:GITHUB_ENV

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,8 +31,10 @@ jobs:
 
       - name: Extract Version and Channel
         id: extract
+        env:
+          INPUT_TAG: ${{ inputs.tag || '' }}
         run: |
-          $ref = if ('${{ inputs.tag }}') { '${{ inputs.tag }}' } else { $env:GITHUB_REF }
+          $ref = if ($env:INPUT_TAG) { $env:INPUT_TAG } else { $env:GITHUB_REF }
           $version = $ref -replace 'refs/tags/v', '' -replace '^v', ''
           $channel = if ($version -match '-beta') { 'beta' } else { 'stable' }
           

--- a/AIUsageTracker.Tests/UI/AppStartupTests.cs
+++ b/AIUsageTracker.Tests/UI/AppStartupTests.cs
@@ -111,6 +111,59 @@ public class AppStartupTests : IDisposable
     }
 
     [Fact]
+    public async Task LoadPreferencesAsync_WithLegacyPercentageDisplayModeUsed_MapsToShowUsedPercentagesAsync()
+    {
+        var legacyJson = /*lang=json,strict*/ """
+            {
+              "PercentageDisplayMode": "Used",
+              "SchemaVersion": 2
+            }
+            """;
+        await File.WriteAllTextAsync(this._testPreferencesPath, legacyJson);
+
+        var loaded = await this._store.LoadAsync();
+
+        Assert.True(loaded.ShowUsedPercentages);
+    }
+
+    [Fact]
+    public async Task LoadPreferencesAsync_WithLegacyPercentageDisplayModeRemaining_MapsToShowUsedPercentagesFalseAsync()
+    {
+        var legacyJson = /*lang=json,strict*/ """
+            {
+              "PercentageDisplayMode": "Remaining",
+              "SchemaVersion": 2
+            }
+            """;
+        await File.WriteAllTextAsync(this._testPreferencesPath, legacyJson);
+
+        var loaded = await this._store.LoadAsync();
+
+        Assert.False(loaded.ShowUsedPercentages);
+    }
+
+    [Fact]
+    public async Task LoadPreferencesAsync_WithLegacyPercentageDisplayMode_SavesShowUsedPercentagesOnNextWriteAsync()
+    {
+        var legacyJson = /*lang=json,strict*/ """
+            {
+              "PercentageDisplayMode": "Used",
+              "SchemaVersion": 2
+            }
+            """;
+        await File.WriteAllTextAsync(this._testPreferencesPath, legacyJson);
+
+        var loaded = await this._store.LoadAsync();
+        Assert.True(loaded.ShowUsedPercentages);
+
+        await this._store.SaveAsync(loaded);
+        var savedJson = await File.ReadAllTextAsync(this._testPreferencesPath);
+
+        Assert.Contains("ShowUsedPercentages", savedJson, StringComparison.Ordinal);
+        Assert.DoesNotContain("PercentageDisplayMode", savedJson, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task LoadPreferencesAsync_WithLegacyInvertCalculations_MapsToShowUsedPercentagesAsync()
     {
         await File.WriteAllTextAsync(this._testPreferencesPath, "{\"InvertCalculations\":true}");

--- a/AIUsageTracker.UI.Slim/App.xaml.cs
+++ b/AIUsageTracker.UI.Slim/App.xaml.cs
@@ -108,6 +108,10 @@ public partial class App : Application
         try
         {
             Preferences = await preferencesStore.LoadAsync().ConfigureAwait(true);
+            if (Preferences.SchemaVersion < AppPreferences.CurrentSchemaVersion)
+            {
+                _ = preferencesStore.SaveAsync(Preferences);
+            }
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {

--- a/AIUsageTracker.UI.Slim/MainWindow.xaml
+++ b/AIUsageTracker.UI.Slim/MainWindow.xaml
@@ -89,8 +89,7 @@
                          
                           <CheckBox x:Name="ShowUsedToggle" 
                                     Content="Show Used"
-                                    IsChecked="False"
-                                    Foreground="{DynamicResource SecondaryText}" 
+                                     Foreground="{DynamicResource SecondaryText}"
                                     VerticalAlignment="Center"
                                     FontSize="11"
                                     Margin="0,0,8,0"


### PR DESCRIPTION
## Summary
- Fix ShowUsedPercentages migration: auto-save after schema upgrade, remove hardcoded IsChecked from XAML, add migration tests
- Add workflow_dispatch trigger to Publish workflow so releases can be manually triggered when tag push bypasses branch protection

## Test plan
- [x] 3 new migration tests pass
- [x] All 1308 existing tests pass
- [ ] Verify Publish and Distribute can be manually triggered after merge