### PR TITLE
Fix Copilot raw snapshot and ShowUsed migration

### DIFF
--- a/AIUsageTracker.Infrastructure/Providers/GitHubCopilotProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/GitHubCopilotProvider.cs
@@ -422,6 +422,7 @@ public class GitHubCopilotProvider : ProviderBase
             }
 
             var quotaJson = await quotaResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+            state.RawJson = quotaJson;
             using var quotaDoc = System.Text.Json.JsonDocument.Parse(quotaJson);
             var root = quotaDoc.RootElement;
 


### PR DESCRIPTION
## Summary
- Fix Copilot raw snapshot to store quota API response (premium_interactions, quota_snapshots) instead of GitHub profile response
- Fix ShowUsedPercentages migration: auto-save after schema upgrade, remove hardcoded IsChecked from XAML, add migration tests
- Add workflow_dispatch to Publish workflow for manual release triggering
- Fix Semgrep script injection warning in publish workflow

## Test plan
- [x] 3 new migration tests pass
- [x] All 1308 existing tests pass
- [ ] Copilot raw snapshots contain quota data after Monitor restart