### PR TITLE
refactor: consolidate auto-start settings and fix stale appcast

### DIFF
--- a/AIUsageTracker.Core/Models/AppPreferences.cs
+++ b/AIUsageTracker.Core/Models/AppPreferences.cs
@@ -72,8 +72,6 @@ public class AppPreferences
 
     public string QuietHoursEnd { get; set; } = "07:00";
 
-    public bool StartMonitorWithWindows { get; set; } = false;
-
     public bool StartUiWithWindows { get; set; } = false;
 
     public AppTheme Theme { get; set; } = AppTheme.Dark;

--- a/AIUsageTracker.UI.Slim/SettingsWindow.xaml
+++ b/AIUsageTracker.UI.Slim/SettingsWindow.xaml
@@ -526,16 +526,12 @@
 
                         <Border Height="1" Background="{DynamicResource BorderColor}" Margin="0,12,0,12"/>
 
-                        <!-- Windows Startup -->
-                        <TextBlock Text="Windows Startup" FontWeight="Bold" FontSize="12"
+                        <!-- Startup -->
+                        <TextBlock Text="Startup" FontWeight="Bold" FontSize="12"
                                    Foreground="{DynamicResource PrimaryText}" Margin="0,0,0,10"/>
-                        <CheckBox x:Name="StartMonitorWithWindowsCheck" Content="Start Monitor with Windows"
+                        <CheckBox x:Name="StartUiWithWindowsCheck" Content="Start with Windows"
                                   Margin="0,4" Foreground="{DynamicResource SecondaryText}"
-                                  ToolTip="Automatically start the background Monitor service when Windows starts."
-                                  Checked="LayoutSetting_Changed" Unchecked="LayoutSetting_Changed"/>
-                        <CheckBox x:Name="StartUiWithWindowsCheck" Content="Start UI with Windows"
-                                  Margin="0,4" Foreground="{DynamicResource SecondaryText}"
-                                  ToolTip="Automatically start the UI when Windows starts."
+                                  ToolTip="Automatically start the application when Windows starts. The Monitor will start automatically with the UI."
                                   Checked="LayoutSetting_Changed" Unchecked="LayoutSetting_Changed"/>
 
                         <Grid Margin="0,10,0,0">
@@ -825,9 +821,8 @@
                                         <TextBlock x:Name="MonitorPortText" Text="5000" Grid.Row="1" Grid.Column="1"
                                                    Foreground="{DynamicResource PrimaryText}"/>
                                     </Grid>
-                                    <CheckBox x:Name="AutoStartMonitorCheck" Content="Auto-start Monitor"
-                                              IsChecked="True" Margin="0,8,0,0"
-                                              Foreground="{DynamicResource SecondaryText}"/>
+
+
                                 </StackPanel>
 
                                 <!-- Right: Actions -->

--- a/AIUsageTracker.UI.Slim/SettingsWindow.xaml.cs
+++ b/AIUsageTracker.UI.Slim/SettingsWindow.xaml.cs
@@ -475,9 +475,7 @@ public partial class SettingsWindow : Window
         this.AlwaysOnTopCheck.IsChecked = this._preferences.AlwaysOnTop;
         this.AggressiveTopmostCheck.IsChecked = this._preferences.AggressiveAlwaysOnTop;
         this.ForceWin32TopmostCheck.IsChecked = this._preferences.ForceWin32Topmost;
-        var (monitorAutoStart, uiAutoStart) = WindowsStartupService.Read();
-        this.StartMonitorWithWindowsCheck.IsChecked = monitorAutoStart;
-        this.StartUiWithWindowsCheck.IsChecked = uiAutoStart;
+        this.StartUiWithWindowsCheck.IsChecked = WindowsStartupService.IsUiStartupEnabled();
         this.PopulateDualQuotaBarWindowCombo();
         this.ApplyDisplayModePreference();
         this.ThemeCombo.DisplayMemberPath = nameof(ThemeOption.Label);
@@ -785,11 +783,9 @@ public partial class SettingsWindow : Window
             this._preferences.AlwaysOnTop = this.AlwaysOnTopCheck.IsChecked ?? true;
             this._preferences.AggressiveAlwaysOnTop = this.AggressiveTopmostCheck.IsChecked ?? false;
             this._preferences.ForceWin32Topmost = this.ForceWin32TopmostCheck.IsChecked ?? false;
-            var startMonitor = this.StartMonitorWithWindowsCheck.IsChecked ?? false;
             var startUi = this.StartUiWithWindowsCheck.IsChecked ?? false;
-            this._preferences.StartMonitorWithWindows = startMonitor;
             this._preferences.StartUiWithWindows = startUi;
-            WindowsStartupService.Apply(startMonitor, startUi);
+            WindowsStartupService.Apply(startUi);
             this.ApplyDisplayPreferencesFromControls();
             if (this.ThemeCombo.SelectedValue is AppTheme appTheme)
             {

--- a/AIUsageTracker.UI.Slim/WindowsStartupService.cs
+++ b/AIUsageTracker.UI.Slim/WindowsStartupService.cs
@@ -11,23 +11,15 @@ namespace AIUsageTracker.UI.Slim;
 internal static class WindowsStartupService
 {
     private const string RunKeyPath = @"Software\Microsoft\Windows\CurrentVersion\Run";
-    private const string MonitorValueName = "AI Usage Tracker Monitor";
     private const string UiValueName = "AI Usage Tracker";
 
-    public static (bool MonitorEnabled, bool UiEnabled) Read()
+    public static bool IsUiStartupEnabled()
     {
         using var key = Registry.CurrentUser.OpenSubKey(RunKeyPath, writable: false);
-        if (key == null)
-        {
-            return (false, false);
-        }
-
-        return (
-            key.GetValue(MonitorValueName) != null,
-            key.GetValue(UiValueName) != null);
+        return key?.GetValue(UiValueName) != null;
     }
 
-    public static void Apply(bool startMonitor, bool startUi)
+    public static void Apply(bool startUi)
     {
         using var key = Registry.CurrentUser.OpenSubKey(RunKeyPath, writable: true);
         if (key == null)
@@ -35,25 +27,15 @@ internal static class WindowsStartupService
             return;
         }
 
-        ApplyEntry(key, MonitorValueName, startMonitor, GetMonitorExePath());
-        ApplyEntry(key, UiValueName, startUi, GetUiExePath());
-    }
+        var exePath = Path.Combine(AppContext.BaseDirectory, "AIUsageTracker.exe");
 
-    private static void ApplyEntry(RegistryKey key, string valueName, bool enable, string exePath)
-    {
-        if (enable && File.Exists(exePath))
+        if (startUi && File.Exists(exePath))
         {
-            key.SetValue(valueName, $"\"{exePath}\"");
+            key.SetValue(UiValueName, $"\"{exePath}\"");
         }
         else
         {
-            key.DeleteValue(valueName, throwOnMissingValue: false);
+            key.DeleteValue(UiValueName, throwOnMissingValue: false);
         }
     }
-
-    private static string GetMonitorExePath() =>
-        Path.Combine(AppContext.BaseDirectory, "AIUsageTracker.Monitor.exe");
-
-    private static string GetUiExePath() =>
-        Path.Combine(AppContext.BaseDirectory, "AIUsageTracker.exe");
 }

--- a/appcast/appcast_beta.xml
+++ b/appcast/appcast_beta.xml
@@ -6,14 +6,14 @@
         <description>Beta releases with latest features and improvements.</description>
         <language>en</language>
         <item>
-            <title>Version 2.3.4-beta.11</title>
-            <sparkle:releaseNotesLink>https://github.com/rygel/AIUsageTracker/releases/tag/v2.3.4-beta.11</sparkle:releaseNotesLink>
-            <pubDate>Mon, 30 Mar 2026 00:14:52 +0000</pubDate>
-            <enclosure url="https://github.com/rygel/AIUsageTracker/releases/download/v2.3.4-beta.11/AIUsageTracker_Setup_v2.3.4-beta.11_win-x64.exe"
-                       sparkle:version="2.3.4.11"
-                       sparkle:shortVersionString="2.3.4-beta.11"
+            <title>Version 2.3.4-beta.33</title>
+            <sparkle:releaseNotesLink>https://github.com/rygel/AIUsageTracker/releases/tag/v2.3.4-beta.33</sparkle:releaseNotesLink>
+            <pubDate>Tue, 22 Apr 2026 05:11:41 +0000</pubDate>
+            <enclosure url="https://github.com/rygel/AIUsageTracker/releases/download/v2.3.4-beta.33/AIUsageTracker_Setup_v2.3.4-beta.33_win-x64.exe"
+                       sparkle:version="2.3.4.33"
+                       sparkle:shortVersionString="2.3.4-beta.33"
                        sparkle:os="windows"
-                       length="19451188"
+                       length="19521848"
                        type="application/octet-stream" />
         </item>
     </channel>

--- a/appcast/appcast_beta_arm64.xml
+++ b/appcast/appcast_beta_arm64.xml
@@ -6,14 +6,14 @@
         <description>Beta releases with latest features and improvements for ARM64 architecture.</description>
         <language>en</language>
         <item>
-            <title>Version 2.3.4-beta.11</title>
-            <sparkle:releaseNotesLink>https://github.com/rygel/AIUsageTracker/releases/tag/v2.3.4-beta.11</sparkle:releaseNotesLink>
-            <pubDate>Mon, 30 Mar 2026 00:14:52 +0000</pubDate>
-            <enclosure url="https://github.com/rygel/AIUsageTracker/releases/download/v2.3.4-beta.11/AIUsageTracker_Setup_v2.3.4-beta.11_win-arm64.exe"
-                       sparkle:version="2.3.4.11"
-                       sparkle:shortVersionString="2.3.4-beta.11"
+            <title>Version 2.3.4-beta.33</title>
+            <sparkle:releaseNotesLink>https://github.com/rygel/AIUsageTracker/releases/tag/v2.3.4-beta.33</sparkle:releaseNotesLink>
+            <pubDate>Tue, 22 Apr 2026 05:11:41 +0000</pubDate>
+            <enclosure url="https://github.com/rygel/AIUsageTracker/releases/download/v2.3.4-beta.33/AIUsageTracker_Setup_v2.3.4-beta.33_win-arm64.exe"
+                       sparkle:version="2.3.4.33"
+                       sparkle:shortVersionString="2.3.4-beta.33"
                        sparkle:os="windows"
-                       length="18802141"
+                       length="18872587"
                        type="application/octet-stream" />
         </item>
     </channel>

--- a/appcast/appcast_beta_x64.xml
+++ b/appcast/appcast_beta_x64.xml
@@ -6,14 +6,14 @@
         <description>Beta releases with latest features and improvements.</description>
         <language>en</language>
         <item>
-            <title>Version 2.3.4-beta.11</title>
-            <sparkle:releaseNotesLink>https://github.com/rygel/AIUsageTracker/releases/tag/v2.3.4-beta.11</sparkle:releaseNotesLink>
-            <pubDate>Mon, 30 Mar 2026 00:14:52 +0000</pubDate>
-            <enclosure url="https://github.com/rygel/AIUsageTracker/releases/download/v2.3.4-beta.11/AIUsageTracker_Setup_v2.3.4-beta.11_win-x64.exe"
-                       sparkle:version="2.3.4.11"
-                       sparkle:shortVersionString="2.3.4-beta.11"
+            <title>Version 2.3.4-beta.33</title>
+            <sparkle:releaseNotesLink>https://github.com/rygel/AIUsageTracker/releases/tag/v2.3.4-beta.33</sparkle:releaseNotesLink>
+            <pubDate>Tue, 22 Apr 2026 05:11:41 +0000</pubDate>
+            <enclosure url="https://github.com/rygel/AIUsageTracker/releases/download/v2.3.4-beta.33/AIUsageTracker_Setup_v2.3.4-beta.33_win-x64.exe"
+                       sparkle:version="2.3.4.33"
+                       sparkle:shortVersionString="2.3.4-beta.33"
                        sparkle:os="windows"
-                       length="19451188"
+                       length="19521848"
                        type="application/octet-stream" />
         </item>
     </channel>

--- a/appcast/appcast_beta_x86.xml
+++ b/appcast/appcast_beta_x86.xml
@@ -6,14 +6,14 @@
         <description>Beta releases with latest features and improvements for x86 architecture.</description>
         <language>en</language>
         <item>
-            <title>Version 2.3.4-beta.11</title>
-            <sparkle:releaseNotesLink>https://github.com/rygel/AIUsageTracker/releases/tag/v2.3.4-beta.11</sparkle:releaseNotesLink>
-            <pubDate>Mon, 30 Mar 2026 00:14:52 +0000</pubDate>
-            <enclosure url="https://github.com/rygel/AIUsageTracker/releases/download/v2.3.4-beta.11/AIUsageTracker_Setup_v2.3.4-beta.11_win-x86.exe"
-                       sparkle:version="2.3.4.11"
-                       sparkle:shortVersionString="2.3.4-beta.11"
+            <title>Version 2.3.4-beta.33</title>
+            <sparkle:releaseNotesLink>https://github.com/rygel/AIUsageTracker/releases/tag/v2.3.4-beta.33</sparkle:releaseNotesLink>
+            <pubDate>Tue, 22 Apr 2026 05:11:41 +0000</pubDate>
+            <enclosure url="https://github.com/rygel/AIUsageTracker/releases/download/v2.3.4-beta.33/AIUsageTracker_Setup_v2.3.4-beta.33_win-x86.exe"
+                       sparkle:version="2.3.4.33"
+                       sparkle:shortVersionString="2.3.4-beta.33"
                        sparkle:os="windows"
-                       length="18831779"
+                       length="18902383"
                        type="application/octet-stream" />
         </item>
     </channel>

--- a/scripts/setup.iss
+++ b/scripts/setup.iss
@@ -227,7 +227,7 @@ Name: "apps\cli"; Description: "AI Usage Tracker CLI"; Types: full compact custo
 
 [Tasks]
 Name: "desktopicontracker"; Description: "Create AI Usage Tracker UI desktop icon"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked; Components: apps\tracker
-Name: "startupmonitor"; Description: "Run AI Usage Tracker Monitor at Windows Startup"; GroupDescription: "Additional options:"; Flags: unchecked; Components: apps\monitor
+
 Name: "startuptracker"; Description: "Run AI Usage Tracker UI at Windows Startup"; GroupDescription: "Additional options:"; Flags: unchecked; Components: apps\tracker
 
 [Files]
@@ -249,7 +249,7 @@ Name: "{group}\{cm:UninstallProgram,AI Usage Tracker}"; Filename: "{uninstallexe
 Name: "{autodesktop}\AI Usage Tracker"; Filename: "{app}\AIUsageTracker.exe"; Tasks: desktopicontracker; Components: apps\tracker
 
 [Registry]
-Root: HKCU; Subkey: "Software\Microsoft\Windows\CurrentVersion\Run"; ValueType: string; ValueName: "AI Usage Tracker Monitor"; ValueData: """{app}\AIUsageTracker.Monitor.exe"""; Tasks: startupmonitor; Flags: uninsdeletevalue
+
 Root: HKCU; Subkey: "Software\Microsoft\Windows\CurrentVersion\Run"; ValueType: string; ValueName: "AI Usage Tracker"; ValueData: """{app}\AIUsageTracker.exe"""; Tasks: startuptracker; Flags: uninsdeletevalue
 
 [Run]


### PR DESCRIPTION
## Summary
- Remove redundant Monitor auto-start checkbox from Monitor tab (was dead code, never wired)
- Remove "Start Monitor with Windows" from Layout tab; simplify to single "Start with Windows" checkbox
- Simplify WindowsStartupService to manage only the UI registry entry (Monitor always auto-starts with UI)
- Remove StartMonitorWithWindows from AppPreferences
- Remove Monitor startup task from installer (setup.iss)
- Update beta appcast files from stale v2.3.4-beta.11 to current v2.3.4-beta.33

## Test plan
- [x] Build succeeds (dotnet build)
- [x] All 1307 tests pass (4 previously failing appcast tests now pass)
- [ ] Verify Settings > Layout tab shows single "Start with Windows" checkbox
- [ ] Verify Monitor tab no longer shows dead "Auto-start Monitor" checkbox