### PR TITLE
fix: prevent always-on-top from leaking when disabled

### DIFF
--- a/AIUsageTracker.UI.Slim/MainWindow.Topmost.cs
+++ b/AIUsageTracker.UI.Slim/MainWindow.Topmost.cs
@@ -106,11 +106,7 @@ public partial class MainWindow
     private void ApplyTopmostState(bool alwaysOnTop)
     {
         this.Topmost = alwaysOnTop;
-
-        if (this._preferences.ForceWin32Topmost)
-        {
-            this.ApplyWin32Topmost(noActivate: true, alwaysOnTop);
-        }
+        this.ApplyWin32Topmost(noActivate: true, alwaysOnTop);
     }
 
     private void ScheduleTopmostRecovery(int generation, TimeSpan delay)

--- a/AIUsageTracker.UI.Slim/MainWindow.xaml
+++ b/AIUsageTracker.UI.Slim/MainWindow.xaml
@@ -12,7 +12,7 @@
         Background="{DynamicResource Background}"
         Foreground="{DynamicResource PrimaryText}"
         ShowInTaskbar="False"
-        Topmost="True"
+        Topmost="False"
         Icon="Assets/app_icon.ico"
         KeyDown="OnKeyDown">
 
@@ -77,7 +77,7 @@
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
                         <CheckBox x:Name="AlwaysOnTopCheck" 
                                   Content="Top" 
-                                  IsChecked="True"
+                                  IsChecked="False"
                                   Foreground="{DynamicResource SecondaryText}" 
                                   VerticalAlignment="Center"
                                   FontSize="11"

--- a/AIUsageTracker.UI.Slim/SettingsWindow.xaml
+++ b/AIUsageTracker.UI.Slim/SettingsWindow.xaml
@@ -512,7 +512,7 @@
                         <!-- Window Behavior -->
                         <TextBlock Text="Window Behavior" FontWeight="Bold" FontSize="12"
                                    Foreground="{DynamicResource PrimaryText}" Margin="0,0,0,10"/>
-                        <CheckBox x:Name="AlwaysOnTopCheck" Content="Always On Top" IsChecked="True"
+                         <CheckBox x:Name="AlwaysOnTopCheck" Content="Always On Top" IsChecked="False"
                                   Margin="0,4" Foreground="{DynamicResource SecondaryText}"
                                   Checked="LayoutSetting_Changed" Unchecked="LayoutSetting_Changed"/>
                         <CheckBox x:Name="AggressiveTopmostCheck" Content="Aggressive keep-on-top"


### PR DESCRIPTION
## Summary
- Fix window staying topmost when Always On Top is disabled
- Remove hardcoded Topmost="True" from MainWindow.xaml so preferences control initial state
- Fix ApplyTopmostState(false) to always call ApplyWin32Topmost(false) (was only called when ForceWin32Topmost was enabled, creating an asymmetric set-but-never-cleared Win32 flag)
- Remove hardcoded IsChecked="True" from both inline and Settings Always On Top checkboxes

## Root cause
EnsureAlwaysOnTop() always calls SetWindowPos(HWND_TOPMOST) via Win32, but ApplyTopmostState(false) only called SetWindowPos(HWND_NOTOPMOST) when ForceWin32Topmost was true (default: false). Combined with Topmost="True" hardcoded in XAML, the Win32 topmost flag was set on startup and never properly cleared when the user toggled the setting off.

## Test plan
- [x] Build succeeds (0 errors)
- [x] All 1311 tests pass
- [ ] Verify window does NOT start as topmost when Always On Top preference is false
- [ ] Verify toggling Always On Top off properly clears the Win32 topmost flag
- [ ] Verify toggling Always On Top on still works correctly