### PR TITLE
release: v2.3.4-beta.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+## [2.3.4-beta.34] - 2026-04-26
+
+### Fixed
+- **Always-on-top leaking when disabled**: window no longer stays topmost after unchecking "Always On Top". Root cause was hardcoded `Topmost="True"` in XAML and asymmetric Win32 flag management.
+- **Stale beta appcast files**: beta appcast now points to v2.3.4-beta.33 instead of v2.3.4-beta.11.
+- **Copilot raw snapshot**: stored quota API response instead of profile response.
+
+### Changed
+- **Consolidated auto-start settings**: removed redundant "Start Monitor with Windows" checkbox (Monitor always auto-starts with the UI). Single "Start with Windows" checkbox controls startup behavior.
+- **Removed Monitor startup task from installer**: the installer no longer offers a separate Monitor startup option.
+
 ## [2.3.4-beta.32] - 2026-04-21
 
 ### Fixed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TrackerVersion>2.3.4-beta.32</TrackerVersion>
+    <TrackerVersion>2.3.4-beta.34</TrackerVersion>
     <TrackerAssemblyVersion>2.3.4</TrackerAssemblyVersion>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(MSBuildProjectDirectory)\artifacts\**\*</DefaultItemExcludes>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="AIUsageTracker.Web/wwwroot/favicon.png" width="32" height="32" valign="middle"> AI Usage Tracker
 
-![Version](https://img.shields.io/badge/version-2.3.4--beta.32-orange)
+![Version](https://img.shields.io/badge/version-2.3.4--beta.34-orange)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Platforms](https://img.shields.io/badge/platforms-Windows%20|%20Linux%20-blue)
 ![Language](https://img.shields.io/badge/language-C%23%20|%20.NET-purple)

--- a/scripts/publish-app.ps1
+++ b/scripts/publish-app.ps1
@@ -6,7 +6,7 @@ param(
 )
 
 # AI Usage Tracker - Distribution Packaging Script
-# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.3.4-beta.32 -InstallerCompression balanced
+# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.3.4-beta.34 -InstallerCompression balanced
 
 $isWinPlatform = $Runtime.StartsWith("win-")
 $projectName = if ($isWinPlatform) { "AIUsageTracker" } else { "AIUsageTracker.CLI" }

--- a/scripts/setup.iss
+++ b/scripts/setup.iss
@@ -1,7 +1,7 @@
 ; AI Usage Tracker - Inno Setup Script
 
 #ifndef MyAppVersion
-  #define MyAppVersion "2.3.4-beta.32"
+  #define MyAppVersion "2.3.4-beta.34"
 #endif
 #ifndef SourcePath
   #define SourcePath "..\dist\publish-win-x64"


### PR DESCRIPTION
## Summary
Bump version to 2.3.4-beta.34 for beta release.

### Changes since v2.3.4-beta.32
- Fix always-on-top leaking when disabled (PR #583)
- Consolidate auto-start settings into single startup checkbox (PR #582)
- Fix stale beta appcast files pointing to beta.11 instead of beta.33
- Fix Copilot raw snapshot storing profile response instead of quota response (PR #581)

## Test plan
- [x] Build succeeds (0 errors)
- [x] All 1311 tests pass
- [x] Version bumped in all required files
- [x] CHANGELOG.md updated