### PR TITLE
chore: update stable appcast files to v2.3.4

### DIFF
--- a/appcast/appcast.xml
+++ b/appcast/appcast.xml
@@ -6,13 +6,14 @@
         <description>Most recent changes with links to updates.</description>
         <language>en</language>
         <item>
-            <title>Version 2.2.19</title>
-            <sparkle:releaseNotesLink>https://github.com/rygel/AIUsageTracker/releases/tag/v2.2.19</sparkle:releaseNotesLink>
-            <pubDate>Fri, 27 Feb 2026 12:00:00 +0000</pubDate>
-            <enclosure url="https://github.com/rygel/AIUsageTracker/releases/download/v2.2.19/AIUsageTracker_Setup_v2.2.19_win-x64.exe"
-                       sparkle:version="2.2.19"
+            <title>Version 2.3.4</title>
+            <sparkle:releaseNotesLink>https://github.com/rygel/AIUsageTracker/releases/tag/v2.3.4</sparkle:releaseNotesLink>
+            <pubDate>Sun, 26 Apr 2026 12:00:00 +0000</pubDate>
+            <enclosure url="https://github.com/rygel/AIUsageTracker/releases/download/v2.3.4/AIUsageTracker_Setup_v2.3.4_win-x64.exe"
+                       sparkle:version="2.3.4"
+                       sparkle:shortVersionString="2.3.4"
                        sparkle:os="windows"
-                       length="0"
+                       length="19521279"
                        type="application/octet-stream" />
         </item>
     </channel>

--- a/appcast/appcast_arm64.xml
+++ b/appcast/appcast_arm64.xml
@@ -6,13 +6,14 @@
         <description>Most recent changes with links to updates.</description>
         <language>en</language>
         <item>
-            <title>Version 2.2.19</title>
-            <sparkle:releaseNotesLink>https://github.com/rygel/AIUsageTracker/releases/tag/v2.2.19</sparkle:releaseNotesLink>
-            <pubDate>Fri, 27 Feb 2026 12:00:00 +0000</pubDate>
-            <enclosure url="https://github.com/rygel/AIUsageTracker/releases/download/v2.2.19/AIUsageTracker_Setup_v2.2.19_win-arm64.exe"
-                       sparkle:version="2.2.19"
+            <title>Version 2.3.4</title>
+            <sparkle:releaseNotesLink>https://github.com/rygel/AIUsageTracker/releases/tag/v2.3.4</sparkle:releaseNotesLink>
+            <pubDate>Sun, 26 Apr 2026 12:00:00 +0000</pubDate>
+            <enclosure url="https://github.com/rygel/AIUsageTracker/releases/download/v2.3.4/AIUsageTracker_Setup_v2.3.4_win-arm64.exe"
+                       sparkle:version="2.3.4"
+                       sparkle:shortVersionString="2.3.4"
                        sparkle:os="windows"
-                       length="0"
+                       length="18872206"
                        type="application/octet-stream" />
         </item>
     </channel>

--- a/appcast/appcast_x64.xml
+++ b/appcast/appcast_x64.xml
@@ -6,13 +6,14 @@
         <description>Most recent changes with links to updates.</description>
         <language>en</language>
         <item>
-            <title>Version 2.2.19</title>
-            <sparkle:releaseNotesLink>https://github.com/rygel/AIUsageTracker/releases/tag/v2.2.19</sparkle:releaseNotesLink>
-            <pubDate>Fri, 27 Feb 2026 12:00:00 +0000</pubDate>
-            <enclosure url="https://github.com/rygel/AIUsageTracker/releases/download/v2.2.19/AIUsageTracker_Setup_v2.2.19_win-x64.exe"
-                       sparkle:version="2.2.19"
+            <title>Version 2.3.4</title>
+            <sparkle:releaseNotesLink>https://github.com/rygel/AIUsageTracker/releases/tag/v2.3.4</sparkle:releaseNotesLink>
+            <pubDate>Sun, 26 Apr 2026 12:00:00 +0000</pubDate>
+            <enclosure url="https://github.com/rygel/AIUsageTracker/releases/download/v2.3.4/AIUsageTracker_Setup_v2.3.4_win-x64.exe"
+                       sparkle:version="2.3.4"
+                       sparkle:shortVersionString="2.3.4"
                        sparkle:os="windows"
-                       length="0"
+                       length="19521279"
                        type="application/octet-stream" />
         </item>
     </channel>

--- a/appcast/appcast_x86.xml
+++ b/appcast/appcast_x86.xml
@@ -6,13 +6,14 @@
         <description>Most recent changes with links to updates.</description>
         <language>en</language>
         <item>
-            <title>Version 2.2.19</title>
-            <sparkle:releaseNotesLink>https://github.com/rygel/AIUsageTracker/releases/tag/v2.2.19</sparkle:releaseNotesLink>
-            <pubDate>Fri, 27 Feb 2026 12:00:00 +0000</pubDate>
-            <enclosure url="https://github.com/rygel/AIUsageTracker/releases/download/v2.2.19/AIUsageTracker_Setup_v2.2.19_win-x86.exe"
-                       sparkle:version="2.2.19"
+            <title>Version 2.3.4</title>
+            <sparkle:releaseNotesLink>https://github.com/rygel/AIUsageTracker/releases/tag/v2.3.4</sparkle:releaseNotesLink>
+            <pubDate>Sun, 26 Apr 2026 12:00:00 +0000</pubDate>
+            <enclosure url="https://github.com/rygel/AIUsageTracker/releases/download/v2.3.4/AIUsageTracker_Setup_v2.3.4_win-x86.exe"
+                       sparkle:version="2.3.4"
+                       sparkle:shortVersionString="2.3.4"
                        sparkle:os="windows"
-                       length="0"
+                       length="18901923"
                        type="application/octet-stream" />
         </item>
     </channel>


### PR DESCRIPTION
## Summary
Update stable appcast files from v2.2.19 to v2.3.4 with correct asset sizes from the release.

## Test plan
- [x] Appcast URLs point to v2.3.4 release assets
- [x] Asset sizes match actual release binaries