### PR TITLE
fix: stable channel version comparison for beta users

### DIFF
--- a/AIUsageTracker.Infrastructure/Services/GitHubUpdateChecker.cs
+++ b/AIUsageTracker.Infrastructure/Services/GitHubUpdateChecker.cs
@@ -98,23 +98,23 @@ public class GitHubUpdateChecker
             if (updateInfo?.Updates?.Count > 0)
             {
                 var latest = updateInfo.Updates[0];
-                var currentVersion = System.Reflection.Assembly.GetEntryAssembly()?.GetName()?.Version ?? new Version(1, 0, 0);
 
                 var latestVersionStr = latest.Version?.TrimStart('v') ?? "0.0.0";
+                var currentVersionStr = GetCurrentInformationalVersion();
 
-                if (Version.TryParse(latestVersionStr, out var latestVersion) && latestVersion > currentVersion)
+                if (IsNewerVersion(latestVersionStr, currentVersionStr))
                 {
                     this._logger.LogInformation(
                         "New version available: {LatestVersion} (Current: {CurrentVersion})",
-                        latestVersion,
-                        currentVersion);
+                        latestVersionStr,
+                        currentVersionStr);
 
                     var releaseNotes = await this.FetchReleaseNotesFromGitHubAsync(latestVersionStr).ConfigureAwait(false);
 
                     return new AIUsageTracker.Core.Interfaces.UpdateInfo
                     {
-                        Version = latest.Version ?? latestVersion.ToString(),
-                        ReleaseUrl = latest.ReleaseNotesLink ?? GetReleaseTagUrl(latestVersion.ToString()),
+                        Version = latest.Version ?? latestVersionStr,
+                        ReleaseUrl = latest.ReleaseNotesLink ?? GetReleaseTagUrl(latestVersionStr),
                         DownloadUrl = latest.DownloadLink ?? string.Empty,
                         ReleaseNotes = releaseNotes,
                         PublishedAt = latest.PublicationDate,


### PR DESCRIPTION
## Summary
- Fix stable channel not detecting v2.3.4 stable as an update for users on v2.3.4-beta.34
- Replaced System.Version comparison (assembly version 2.3.4.0 == 2.3.4.0) with IsNewerVersion using informational version (2.3.4-beta.34 < 2.3.4)

## Root cause
The stable channel used Assembly.GetEntryAssembly().GetName().Version which returns the assembly version 2.3.4.0 for all v2.3.4-beta builds. The appcast sparkle:version is also 2.3.4. So 2.3.4.0 > 2.3.4.0 = false, no update detected.

## Fix
Use GetCurrentInformationalVersion() (returns 2.3.4-beta.34) with IsNewerVersion() which correctly ranks 2.3.4 (PreRelease=int.MaxValue) > 2.3.4-beta.34 (PreRelease=34).

## Test plan
- [x] Build succeeds (0 errors)
- [x] All 1311 tests pass
- [x] 51 update-channel tests pass
- [ ] Verify stable channel user on v2.3.4-beta.34 gets offered v2.3.4 stable