### PR TITLE
chore: prepare v2.3.5-beta.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [2.3.5-beta.1] - 2026-05-03
+
+### Changed
+- updater diagnostics correlation (attempt ID) and installer artifact diagnostics (path/size/SHA-256).
+- persisted `update-last-attempt.json` for post-failure triage context.
+
+### Fixed
+- update failure triage gap with stage-specific context and native error codes.
 ## [2.3.4-beta.35] - 2026-05-03
 
 ### Changed
@@ -457,4 +465,5 @@
 
 ### CI/CD
 - Updated all GitHub Actions to latest major versions (checkout v6, setup-dotnet v5, upload-artifact v7, download-artifact v8, github-script v8, cache v5, codecov v5, create-pull-request v8, paths-filter v4) to eliminate Node.js 20 deprecation warnings.
+
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <TrackerVersion>2.3.4-beta.35</TrackerVersion>
-    <TrackerAssemblyVersion>2.3.4</TrackerAssemblyVersion>
+    <TrackerVersion>2.3.5-beta.1</TrackerVersion>
+    <TrackerAssemblyVersion>2.3.5</TrackerAssemblyVersion>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(MSBuildProjectDirectory)\artifacts\**\*</DefaultItemExcludes>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest</AnalysisLevel>
@@ -16,3 +16,5 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="all" />
   </ItemGroup>
 </Project>
+
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="AIUsageTracker.Web/wwwroot/favicon.png" width="32" height="32" valign="middle"> AI Usage Tracker
 
-![Version](https://img.shields.io/badge/version-2.3.4--beta.35-orange)
+![Version](https://img.shields.io/badge/version-2.3.5--beta.1-orange)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Platforms](https://img.shields.io/badge/platforms-Windows%20|%20Linux%20-blue)
 ![Language](https://img.shields.io/badge/language-C%23%20|%20.NET-purple)
@@ -120,3 +120,5 @@ Configuration is stored in `auth.json` in the application data directory.
 
 ## License
 MIT
+
+

--- a/scripts/publish-app.ps1
+++ b/scripts/publish-app.ps1
@@ -6,7 +6,7 @@ param(
 )
 
 # AI Usage Tracker - Distribution Packaging Script
-# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.3.4-beta.35 -InstallerCompression balanced
+# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.3.5-beta.1 -InstallerCompression balanced
 
 $isWinPlatform = $Runtime.StartsWith("win-")
 $projectName = if ($isWinPlatform) { "AIUsageTracker" } else { "AIUsageTracker.CLI" }
@@ -214,5 +214,7 @@ Write-Host "--------------------------------------------------" -ForegroundColor
 Write-Host "Distribution ready at: $zipPath" -ForegroundColor Green
 Write-Host "Size: $((Get-Item $zipPath).Length / 1MB) MB" -ForegroundColor Gray
 Write-Host "--------------------------------------------------" -ForegroundColor Yellow
+
+
 
 

--- a/scripts/setup.iss
+++ b/scripts/setup.iss
@@ -1,7 +1,7 @@
 ; AI Usage Tracker - Inno Setup Script
 
 #ifndef MyAppVersion
-  #define MyAppVersion "2.3.4-beta.35"
+    #define MyAppVersion "2.3.5-beta.1"
 #endif
 #ifndef SourcePath
   #define SourcePath "..\dist\publish-win-x64"
@@ -254,3 +254,5 @@ Root: HKCU; Subkey: "Software\Microsoft\Windows\CurrentVersion\Run"; ValueType: 
 
 [Run]
 Filename: "{app}\AIUsageTracker.exe"; Description: "{cm:LaunchProgram,AI Usage Tracker UI}"; Flags: nowait postinstall skipifsilent; Components: apps\tracker; Check: ShouldRunApplication
+
+


### PR DESCRIPTION
## Summary
- bump tracker version to `2.3.5-beta.1` (assembly version `2.3.5`)
- update README badge and publish/setup version references
- add changelog section for `2.3.5-beta.1`

## Validation
- `bash scripts/validate-release-consistency.sh "2.3.5-beta.1"`
- `dotnet build AIUsageTracker.sln --configuration Release`
- `dotnet test AIUsageTracker.Tests/AIUsageTracker.Tests.csproj --configuration Release --no-build`

## Why this beta
- users on stable `2.3.4` are not offered `2.3.4-beta.35` due version ordering (stable of same core is considered higher)
- `2.3.5-beta.1` advances core version so update is discoverable on beta channel
