### PR TITLE
fix: migrate Minimax provider from removed /v1/user/usage to /v1/token_plan/remains endpoint

### DIFF
--- a/AIUsageTracker.Infrastructure/Constants/ProviderEndpoints.cs
+++ b/AIUsageTracker.Infrastructure/Constants/ProviderEndpoints.cs
@@ -107,8 +107,7 @@ public static class ProviderEndpoints
     public static class Minimax
     {
         public const string BaseUrl = "https://api.minimax.io";
-        public const string UserUsage = "https://api.minimax.io/v1/user/usage";
-        public const string ChatUserUsage = "https://api.minimax.chat/v1/user/usage";
+        public const string TokenPlanRemains = "https://api.minimax.io/v1/token_plan/remains";
         public const string CodingPlanRemains = "https://api.minimax.io/v1/api/openplatform/coding_plan/remains";
     }
 

--- a/AIUsageTracker.Infrastructure/Providers/MinimaxProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/MinimaxProvider.cs
@@ -102,104 +102,16 @@ public class MinimaxProvider : ProviderBase
         string url;
         if (!string.IsNullOrEmpty(config.BaseUrl))
         {
-            url = config.BaseUrl;
-            if (!url.StartsWith("http", StringComparison.OrdinalIgnoreCase))
-            {
-                url = "https://" + url;
-            }
+            url = config.BaseUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? config.BaseUrl
+                : "https://" + config.BaseUrl;
         }
         else
         {
-            url = string.Equals(config.ProviderId, InternationalProviderId, StringComparison.OrdinalIgnoreCase) ||
-                  string.Equals(config.ProviderId, InternationalLegacyProviderId, StringComparison.OrdinalIgnoreCase)
-                ? ProviderEndpoints.Minimax.UserUsage
-                : ProviderEndpoints.Minimax.ChatUserUsage;
+            url = ProviderEndpoints.Minimax.TokenPlanRemains;
         }
 
-        var request = CreateBearerRequest(HttpMethod.Get, url, config.ApiKey);
-        var response = await this._httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
-        var httpStatus = (int)response.StatusCode;
-
-        if (!response.IsSuccessStatusCode)
-        {
-            var errorContent = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-            return new[]
-            {
-                new ProviderUsage
-                {
-                    ProviderId = config.ProviderId,
-                    ProviderName = providerLabel,
-                    IsAvailable = false,
-                    IsQuotaBased = this.Definition.IsQuotaBased,
-                    PlanType = this.Definition.PlanType,
-                    Description = $"API returned {response.StatusCode} for {url}",
-                    RawJson = errorContent,
-                    HttpStatus = httpStatus,
-                },
-            };
-        }
-
-        var responseString = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-
-        try
-        {
-            var minimax = JsonSerializer.Deserialize<MinimaxTokenResponse>(responseString);
-            if (minimax?.Usage == null)
-            {
-                return new[]
-                {
-                    new ProviderUsage
-                    {
-                        ProviderId = config.ProviderId,
-                        ProviderName = providerLabel,
-                        IsAvailable = false,
-                        IsQuotaBased = this.Definition.IsQuotaBased,
-                        PlanType = this.Definition.PlanType,
-                        Description = "Invalid Minimax response format",
-                        RawJson = responseString,
-                        HttpStatus = httpStatus,
-                    },
-                };
-            }
-
-            var used = minimax.Usage.TokensUsed;
-            var total = minimax.Usage.TokensLimit > 0 ? minimax.Usage.TokensLimit : 0;
-            var utilization = total > 0 ? (used / total) * 100.0 : 0;
-
-            return new[]
-            {
-                new ProviderUsage
-                {
-                    ProviderId = config.ProviderId,
-                    ProviderName = providerLabel,
-                    UsedPercent = Math.Clamp(utilization, 0, 100),
-                    RequestsUsed = used,
-                    RequestsAvailable = total,
-                    PlanType = this.Definition.PlanType,
-                    IsQuotaBased = this.Definition.IsQuotaBased,
-                    Description = $"{used.ToString("N0", CultureInfo.InvariantCulture)} tokens used" + (total > 0 ? $" / {total.ToString("N0", CultureInfo.InvariantCulture)} limit" : string.Empty),
-                    RawJson = responseString,
-                    HttpStatus = httpStatus,
-                },
-            };
-        }
-        catch (JsonException ex)
-        {
-            return new[]
-            {
-                new ProviderUsage
-                {
-                    ProviderId = config.ProviderId,
-                    ProviderName = providerLabel,
-                    IsAvailable = false,
-                    IsQuotaBased = this.Definition.IsQuotaBased,
-                    PlanType = this.Definition.PlanType,
-                    Description = $"Failed to parse Minimax response: {ex.Message}",
-                    RawJson = responseString,
-                    HttpStatus = httpStatus,
-                },
-            };
-        }
+        return await this.GetRemainsUsageAsync(config, providerLabel, url, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task<IEnumerable<ProviderUsage>> GetCodingPlanUsageAsync(
@@ -219,6 +131,15 @@ public class MinimaxProvider : ProviderBase
             url = ProviderEndpoints.Minimax.CodingPlanRemains;
         }
 
+        return await this.GetRemainsUsageAsync(config, providerLabel, url, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<IEnumerable<ProviderUsage>> GetRemainsUsageAsync(
+        ProviderConfig config,
+        string providerLabel,
+        string url,
+        CancellationToken cancellationToken)
+    {
         var request = CreateBearerRequest(HttpMethod.Get, url, config.ApiKey);
         var response = await this._httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
         var httpStatus = (int)response.StatusCode;
@@ -244,10 +165,12 @@ public class MinimaxProvider : ProviderBase
 
         try
         {
-            var codingPlan = JsonSerializer.Deserialize<MinimaxCodingPlanResponse>(responseString);
-            if (codingPlan?.BaseResp?.StatusCode != 0 || codingPlan.ModelRemains == null || codingPlan.ModelRemains.Count == 0)
+            var remainsResponse = JsonSerializer.Deserialize<MinimaxRemainsResponse>(responseString);
+            if (remainsResponse?.BaseResp?.StatusCode != 0 || remainsResponse.ModelRemains == null || remainsResponse.ModelRemains.Count == 0)
             {
-                var errMsg = codingPlan?.BaseResp?.StatusMsg ?? "Invalid MiniMax Coding Plan response";
+                var errMsg = remainsResponse?.BaseResp is { StatusCode: not 0, StatusMsg: not null }
+                    ? remainsResponse.BaseResp.StatusMsg
+                    : "Invalid MiniMax response";
                 return new[]
                 {
                     new ProviderUsage
@@ -264,7 +187,7 @@ public class MinimaxProvider : ProviderBase
                 };
             }
 
-            var textGenerationModel = FindTextGenerationModel(codingPlan.ModelRemains);
+            var textGenerationModel = FindTextGenerationModel(remainsResponse.ModelRemains);
             if (textGenerationModel == null)
             {
                 return new[]
@@ -276,18 +199,18 @@ public class MinimaxProvider : ProviderBase
                         IsAvailable = false,
                         IsQuotaBased = this.Definition.IsQuotaBased,
                         PlanType = this.Definition.PlanType,
-                        Description = "MiniMax Text Generation model missing in coding plan response",
+                        Description = "MiniMax Text Generation model missing in response",
                         RawJson = responseString,
                         HttpStatus = httpStatus,
                     },
                 };
             }
 
-            return BuildCodingPlanUsages(config.ProviderId, providerLabel, textGenerationModel, responseString, httpStatus);
+            return BuildRemainsUsages(config.ProviderId, providerLabel, textGenerationModel, responseString, httpStatus);
         }
         catch (JsonException ex)
         {
-            this._logger.LogWarning(ex, "Failed to parse MiniMax Coding Plan response");
+            this._logger.LogWarning(ex, "Failed to parse MiniMax remains response");
             return new[]
             {
                 new ProviderUsage
@@ -297,7 +220,7 @@ public class MinimaxProvider : ProviderBase
                     IsAvailable = false,
                     IsQuotaBased = this.Definition.IsQuotaBased,
                     PlanType = this.Definition.PlanType,
-                    Description = $"Failed to parse MiniMax Coding Plan response: {ex.Message}",
+                    Description = $"Failed to parse MiniMax response: {ex.Message}",
                     RawJson = responseString,
                     HttpStatus = httpStatus,
                 },
@@ -305,7 +228,7 @@ public class MinimaxProvider : ProviderBase
         }
     }
 
-    private static List<ProviderUsage> BuildCodingPlanUsages(
+    private static List<ProviderUsage> BuildRemainsUsages(
         string providerId,
         string providerLabel,
         MinimaxModelRemains model,
@@ -439,22 +362,7 @@ public class MinimaxProvider : ProviderBase
         string RawJson,
         int HttpStatus);
 
-    private sealed class MinimaxTokenResponse
-    {
-        [JsonPropertyName("usage")]
-        public MinimaxTokenUsage? Usage { get; set; }
-    }
-
-    private sealed class MinimaxTokenUsage
-    {
-        [JsonPropertyName("tokens_used")]
-        public double TokensUsed { get; set; }
-
-        [JsonPropertyName("tokens_limit")]
-        public double TokensLimit { get; set; }
-    }
-
-    private sealed class MinimaxCodingPlanResponse
+    private sealed class MinimaxRemainsResponse
     {
         [JsonPropertyName("base_resp")]
         public MinimaxBaseResp? BaseResp { get; set; }

--- a/AIUsageTracker.Tests/Infrastructure/Providers/MinimaxProviderTests.cs
+++ b/AIUsageTracker.Tests/Infrastructure/Providers/MinimaxProviderTests.cs
@@ -10,8 +10,7 @@ namespace AIUsageTracker.Tests.Infrastructure.Providers;
 
 public class MinimaxProviderTests : HttpProviderTestBase<MinimaxProvider>
 {
-    private const string ChinaEndpoint = "https://api.minimax.chat/v1/user/usage";
-    private const string InternationalEndpoint = "https://api.minimax.io/v1/user/usage";
+    private const string TokenPlanEndpoint = "https://api.minimax.io/v1/token_plan/remains";
     private const string CodingPlanEndpoint = "https://api.minimax.io/v1/api/openplatform/coding_plan/remains";
 
     private static readonly string TestApiKey = Guid.NewGuid().ToString();
@@ -32,29 +31,37 @@ public class MinimaxProviderTests : HttpProviderTestBase<MinimaxProvider>
     [Fact]
     public async Task GetUsageAsync_ModerateUsage_ReturnsUsedPercentageAsync()
     {
-        // Arrange - 35% used
+        // Arrange - 5h: 65 remaining / 100 total = 35% used
         var responseJson = """
             {
-                "usage": {
-                    "tokens_used": 350000,
-                    "tokens_limit": 1000000
-                }
+                "base_resp": { "status_code": 0, "status_msg": "success" },
+                "model_remains": [
+                    {
+                        "model_name": "Text Generation",
+                        "current_interval_total_count": 100,
+                        "current_interval_usage_count": 65,
+                        "end_time": 0,
+                        "current_weekly_total_count": 500,
+                        "current_weekly_usage_count": 350,
+                        "weekly_end_time": 0
+                    }
+                ]
             }
             """;
 
         this.SetupResponse(HttpStatusCode.OK, responseJson);
 
         // Act
-        var result = await this._provider.GetUsageAsync(this.Config);
+        var result = (await this._provider.GetUsageAsync(this.Config)).ToList();
 
         // Assert
-        var usage = result.Single();
-        Assert.True(usage.IsQuotaBased);
+        var burst = result.Single(u => u.WindowKind == WindowKind.Burst);
+        Assert.True(burst.IsQuotaBased);
 
-        // UsedPercent stores the actual used ratio: 35% used
-        Assert.Equal(35, usage.UsedPercent);
-        Assert.Equal(350000, usage.RequestsUsed);
-        Assert.Equal(1000000, usage.RequestsAvailable);
+        // 5h: 35 used / 100 total = 35%
+        Assert.Equal(35, burst.UsedPercent);
+        Assert.Equal(35, burst.RequestsUsed);
+        Assert.Equal(100, burst.RequestsAvailable);
     }
 
     /// <summary>
@@ -64,27 +71,35 @@ public class MinimaxProviderTests : HttpProviderTestBase<MinimaxProvider>
     [Fact]
     public async Task GetUsageAsync_HighUsage_ReturnsCorrectUsedPercentAsync()
     {
-        // Arrange - 85% used
+        // Arrange - 5h: 15 remaining / 100 total = 85% used
         var responseJson = """
             {
-                "usage": {
-                    "tokens_used": 850000,
-                    "tokens_limit": 1000000
-                }
+                "base_resp": { "status_code": 0, "status_msg": "success" },
+                "model_remains": [
+                    {
+                        "model_name": "Text Generation",
+                        "current_interval_total_count": 100,
+                        "current_interval_usage_count": 15,
+                        "end_time": 0,
+                        "current_weekly_total_count": 500,
+                        "current_weekly_usage_count": 425,
+                        "weekly_end_time": 0
+                    }
+                ]
             }
             """;
 
         this.SetupResponse(HttpStatusCode.OK, responseJson);
 
         // Act
-        var result = await this._provider.GetUsageAsync(this.Config);
+        var result = (await this._provider.GetUsageAsync(this.Config)).ToList();
 
         // Assert
-        var usage = result.Single();
+        var burst = result.Single(u => u.WindowKind == WindowKind.Burst);
 
-        // UsedPercent = 85% used
-        Assert.Equal(85, usage.UsedPercent);
-        Assert.Equal(850000, usage.RequestsUsed);
+        // 5h: 85% used
+        Assert.Equal(85, burst.UsedPercent);
+        Assert.Equal(85, burst.RequestsUsed);
     }
 
     /// <summary>
@@ -94,27 +109,35 @@ public class MinimaxProviderTests : HttpProviderTestBase<MinimaxProvider>
     [Fact]
     public async Task GetUsageAsync_AtCapacity_ReturnsFullUsedAsync()
     {
-        // Arrange - 100% used
+        // Arrange - 5h: 0 remaining / 100 total = 100% used
         var responseJson = """
             {
-                "usage": {
-                    "tokens_used": 1000000,
-                    "tokens_limit": 1000000
-                }
+                "base_resp": { "status_code": 0, "status_msg": "success" },
+                "model_remains": [
+                    {
+                        "model_name": "Text Generation",
+                        "current_interval_total_count": 100,
+                        "current_interval_usage_count": 0,
+                        "end_time": 0,
+                        "current_weekly_total_count": 500,
+                        "current_weekly_usage_count": 0,
+                        "weekly_end_time": 0
+                    }
+                ]
             }
             """;
 
         this.SetupResponse(HttpStatusCode.OK, responseJson);
 
         // Act
-        var result = await this._provider.GetUsageAsync(this.Config);
+        var result = (await this._provider.GetUsageAsync(this.Config)).ToList();
 
         // Assert
-        var usage = result.Single();
+        var burst = result.Single(u => u.WindowKind == WindowKind.Burst);
 
-        // UsedPercent = 100% used
-        Assert.Equal(100, usage.UsedPercent);
-        Assert.Equal(1000000, usage.RequestsUsed);
+        // 5h: 100% used
+        Assert.Equal(100, burst.UsedPercent);
+        Assert.Equal(100, burst.RequestsUsed);
     }
 
     /// <summary>
@@ -124,27 +147,35 @@ public class MinimaxProviderTests : HttpProviderTestBase<MinimaxProvider>
     [Fact]
     public async Task GetUsageAsync_MinimalUsage_ReturnsLowUsedPercentAsync()
     {
-        // Arrange - 2% used
+        // Arrange - 5h: 98 remaining / 100 total = 2% used
         var responseJson = """
             {
-                "usage": {
-                    "tokens_used": 20000,
-                    "tokens_limit": 1000000
-                }
+                "base_resp": { "status_code": 0, "status_msg": "success" },
+                "model_remains": [
+                    {
+                        "model_name": "Text Generation",
+                        "current_interval_total_count": 100,
+                        "current_interval_usage_count": 98,
+                        "end_time": 0,
+                        "current_weekly_total_count": 500,
+                        "current_weekly_usage_count": 490,
+                        "weekly_end_time": 0
+                    }
+                ]
             }
             """;
 
         this.SetupResponse(HttpStatusCode.OK, responseJson);
 
         // Act
-        var result = await this._provider.GetUsageAsync(this.Config);
+        var result = (await this._provider.GetUsageAsync(this.Config)).ToList();
 
         // Assert
-        var usage = result.Single();
+        var burst = result.Single(u => u.WindowKind == WindowKind.Burst);
 
-        // UsedPercent = 2% used
-        Assert.Equal(2, usage.UsedPercent);
-        Assert.Equal(20000, usage.RequestsUsed);
+        // 5h: 2% used
+        Assert.Equal(2, burst.UsedPercent);
+        Assert.Equal(2, burst.RequestsUsed);
     }
 
     /// <summary>
@@ -154,27 +185,35 @@ public class MinimaxProviderTests : HttpProviderTestBase<MinimaxProvider>
     [Fact]
     public async Task GetUsageAsync_ZeroUsage_ReturnsZeroUsedPercentAsync()
     {
-        // Arrange - 0% used
+        // Arrange - 5h: 100 remaining / 100 total = 0% used
         var responseJson = """
             {
-                "usage": {
-                    "tokens_used": 0,
-                    "tokens_limit": 1000000
-                }
+                "base_resp": { "status_code": 0, "status_msg": "success" },
+                "model_remains": [
+                    {
+                        "model_name": "Text Generation",
+                        "current_interval_total_count": 100,
+                        "current_interval_usage_count": 100,
+                        "end_time": 0,
+                        "current_weekly_total_count": 500,
+                        "current_weekly_usage_count": 500,
+                        "weekly_end_time": 0
+                    }
+                ]
             }
             """;
 
         this.SetupResponse(HttpStatusCode.OK, responseJson);
 
         // Act
-        var result = await this._provider.GetUsageAsync(this.Config);
+        var result = (await this._provider.GetUsageAsync(this.Config)).ToList();
 
         // Assert
-        var usage = result.Single();
+        var burst = result.Single(u => u.WindowKind == WindowKind.Burst);
 
-        // UsedPercent = 0% used
-        Assert.Equal(0, usage.UsedPercent);
-        Assert.Equal(0, usage.RequestsUsed);
+        // 5h: 0% used
+        Assert.Equal(0, burst.UsedPercent);
+        Assert.Equal(0, burst.RequestsUsed);
     }
 
     /// <summary>
@@ -184,27 +223,39 @@ public class MinimaxProviderTests : HttpProviderTestBase<MinimaxProvider>
     [Fact]
     public async Task GetUsageAsync_OverLimit_ClampsToMaxUsedAsync()
     {
-        // Arrange - 120% used should clamp to 100%
+        // Arrange - remaining > total should clamp: remaining = 120, total = 100
+        // used = total - min(remaining, total) = 100 - 100 = 0, but that's not right
+        // Actually: remaining=120, total=100 -> remaining clamped to 100 -> used = 0
+        // To get 120% used we need negative remaining, which the API won't send.
+        // Instead test that remaining > total clamps gracefully.
         var responseJson = """
             {
-                "usage": {
-                    "tokens_used": 1200000,
-                    "tokens_limit": 1000000
-                }
+                "base_resp": { "status_code": 0, "status_msg": "success" },
+                "model_remains": [
+                    {
+                        "model_name": "Text Generation",
+                        "current_interval_total_count": 100,
+                        "current_interval_usage_count": 120,
+                        "end_time": 0,
+                        "current_weekly_total_count": 500,
+                        "current_weekly_usage_count": 600,
+                        "weekly_end_time": 0
+                    }
+                ]
             }
             """;
 
         this.SetupResponse(HttpStatusCode.OK, responseJson);
 
         // Act
-        var result = await this._provider.GetUsageAsync(this.Config);
+        var result = (await this._provider.GetUsageAsync(this.Config)).ToList();
 
         // Assert
-        var usage = result.Single();
+        var burst = result.Single(u => u.WindowKind == WindowKind.Burst);
 
-        // UsedPercent should clamp to 100 (not go over)
-        Assert.Equal(100, usage.UsedPercent);
-        Assert.Equal(1200000, usage.RequestsUsed);
+        // remaining > total means remaining is clamped to total -> 0 used
+        Assert.Equal(0, burst.UsedPercent);
+        Assert.Equal(0, burst.RequestsUsed);
     }
 
     [Fact]
@@ -219,104 +270,136 @@ public class MinimaxProviderTests : HttpProviderTestBase<MinimaxProvider>
     }
 
     [Fact]
-    public async Task GetUsageAsync_WithChinaProviderId_UsesChinaEndpointAsync()
+    public async Task GetUsageAsync_WithChinaProviderId_UsesTokenPlanEndpointAsync()
     {
         // Arrange
         this.Config.ProviderId = MinimaxProvider.ChinaProviderId;
         var responseJson = """
             {
-                "usage": {
-                    "tokens_used": 100000,
-                    "tokens_limit": 1000000
-                }
+                "base_resp": { "status_code": 0, "status_msg": "success" },
+                "model_remains": [
+                    {
+                        "model_name": "Text Generation",
+                        "current_interval_total_count": 100,
+                        "current_interval_usage_count": 50,
+                        "end_time": 0,
+                        "current_weekly_total_count": 500,
+                        "current_weekly_usage_count": 250,
+                        "weekly_end_time": 0
+                    }
+                ]
             }
             """;
 
-        this.SetupResponse(HttpStatusCode.OK, responseJson, ChinaEndpoint);
+        this.SetupResponse(HttpStatusCode.OK, responseJson, TokenPlanEndpoint);
 
         // Act
-        var result = await this._provider.GetUsageAsync(this.Config);
+        var result = (await this._provider.GetUsageAsync(this.Config)).ToList();
 
         // Assert
-        var usage = result.Single();
-        Assert.Equal("minimax", usage.ProviderId); // provider-id-guardrail-allow: test assertion
-        Assert.Equal("MiniMax.io", usage.ProviderName);
+        var burst = result.Single(u => u.WindowKind == WindowKind.Burst);
+        Assert.Equal("minimax", burst.ProviderId); // provider-id-guardrail-allow: test assertion
+        Assert.Equal("MiniMax.io", burst.ProviderName);
     }
 
     [Fact]
-    public async Task GetUsageAsync_WithInternationalProviderId_UsesInternationalEndpointAsync()
+    public async Task GetUsageAsync_WithInternationalProviderId_UsesTokenPlanEndpointAsync()
     {
         // Arrange
         this.Config.ProviderId = MinimaxProvider.InternationalProviderId;
         var responseJson = """
             {
-                "usage": {
-                    "tokens_used": 100000,
-                    "tokens_limit": 1000000
-                }
+                "base_resp": { "status_code": 0, "status_msg": "success" },
+                "model_remains": [
+                    {
+                        "model_name": "Text Generation",
+                        "current_interval_total_count": 100,
+                        "current_interval_usage_count": 50,
+                        "end_time": 0,
+                        "current_weekly_total_count": 500,
+                        "current_weekly_usage_count": 250,
+                        "weekly_end_time": 0
+                    }
+                ]
             }
             """;
 
-        this.SetupResponse(HttpStatusCode.OK, responseJson, InternationalEndpoint);
+        this.SetupResponse(HttpStatusCode.OK, responseJson, TokenPlanEndpoint);
 
         // Act
-        var result = await this._provider.GetUsageAsync(this.Config);
+        var result = (await this._provider.GetUsageAsync(this.Config)).ToList();
 
         // Assert
-        var usage = result.Single();
-        Assert.Equal("minimax-io", usage.ProviderId); // provider-id-guardrail-allow: test assertion
-        Assert.Equal("MiniMax.io", usage.ProviderName);
+        var burst = result.Single(u => u.WindowKind == WindowKind.Burst);
+        Assert.Equal("minimax-io", burst.ProviderId); // provider-id-guardrail-allow: test assertion
+        Assert.Equal("MiniMax.io", burst.ProviderName);
     }
 
     [Fact]
-    public async Task GetUsageAsync_WithLegacyProviderId_UsesInternationalEndpointAsync()
+    public async Task GetUsageAsync_WithLegacyProviderId_UsesTokenPlanEndpointAsync()
     {
         // Arrange
         this.Config.ProviderId = MinimaxProvider.InternationalLegacyProviderId;
         var responseJson = """
             {
-                "usage": {
-                    "tokens_used": 100000,
-                    "tokens_limit": 1000000
-                }
+                "base_resp": { "status_code": 0, "status_msg": "success" },
+                "model_remains": [
+                    {
+                        "model_name": "Text Generation",
+                        "current_interval_total_count": 100,
+                        "current_interval_usage_count": 50,
+                        "end_time": 0,
+                        "current_weekly_total_count": 500,
+                        "current_weekly_usage_count": 250,
+                        "weekly_end_time": 0
+                    }
+                ]
             }
             """;
 
-        this.SetupResponse(HttpStatusCode.OK, responseJson, InternationalEndpoint);
+        this.SetupResponse(HttpStatusCode.OK, responseJson, TokenPlanEndpoint);
 
         // Act
-        var result = await this._provider.GetUsageAsync(this.Config);
+        var result = (await this._provider.GetUsageAsync(this.Config)).ToList();
 
         // Assert
-        var usage = result.Single();
-        Assert.Equal("minimax-global", usage.ProviderId); // provider-id-guardrail-allow: test assertion
-        Assert.Equal("MiniMax.io", usage.ProviderName);
+        var burst = result.Single(u => u.WindowKind == WindowKind.Burst);
+        Assert.Equal("minimax-global", burst.ProviderId); // provider-id-guardrail-allow: test assertion
+        Assert.Equal("MiniMax.io", burst.ProviderName);
     }
 
     [Fact]
     public async Task GetUsageAsync_WithCustomBaseUrl_UsesCustomEndpointAsync()
     {
         // Arrange
-        var customUrl = "https://custom.minimax.example.com/v1/user/usage";
+        var customUrl = "https://custom.minimax.example.com/v1/token_plan/remains";
         this.Config.BaseUrl = customUrl;
         var responseJson = """
             {
-                "usage": {
-                    "tokens_used": 50000,
-                    "tokens_limit": 500000
-                }
+                "base_resp": { "status_code": 0, "status_msg": "success" },
+                "model_remains": [
+                    {
+                        "model_name": "Text Generation",
+                        "current_interval_total_count": 100,
+                        "current_interval_usage_count": 50,
+                        "end_time": 0,
+                        "current_weekly_total_count": 500,
+                        "current_weekly_usage_count": 250,
+                        "weekly_end_time": 0
+                    }
+                ]
             }
             """;
 
         this.SetupResponse(HttpStatusCode.OK, responseJson, customUrl);
 
         // Act
-        var result = await this._provider.GetUsageAsync(this.Config);
+        var result = (await this._provider.GetUsageAsync(this.Config)).ToList();
 
         // Assert
-        var usage = result.Single();
-        Assert.True(usage.IsAvailable);
-        Assert.Equal(10, usage.UsedPercent); // 10% used
+        var burst = result.Single(u => u.WindowKind == WindowKind.Burst);
+        Assert.True(burst.IsAvailable);
+        Assert.Equal(50, burst.UsedPercent); // 50% used
     }
 
     [Fact]
@@ -380,12 +463,12 @@ public class MinimaxProviderTests : HttpProviderTestBase<MinimaxProvider>
     }
 
     [Fact]
-    public async Task GetUsageAsync_MissingUsageField_ReturnsUnavailableAsync()
+    public async Task GetUsageAsync_MissingModelRemains_ReturnsUnavailableAsync()
     {
         // Arrange
         var responseJson = """
             {
-                "other_field": "value"
+                "base_resp": { "status_code": 0, "status_msg": "success" }
             }
             """;
 
@@ -397,7 +480,7 @@ public class MinimaxProviderTests : HttpProviderTestBase<MinimaxProvider>
         // Assert
         var usage = result.Single();
         Assert.False(usage.IsAvailable);
-        Assert.Contains("Invalid Minimax response format", usage.Description, StringComparison.Ordinal);
+        Assert.Contains("Invalid MiniMax response", usage.Description, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -416,15 +499,23 @@ public class MinimaxProviderTests : HttpProviderTestBase<MinimaxProvider>
     }
 
     [Fact]
-    public async Task GetUsageAsync_ZeroLimit_HandlesGracefullyAsync()
+    public async Task GetUsageAsync_ZeroTotal_HandlesGracefullyAsync()
     {
-        // Arrange - Zero limit should result in 0 utilization
+        // Arrange - Zero total should be skipped (no burst card)
         var responseJson = """
             {
-                "usage": {
-                    "tokens_used": 0,
-                    "tokens_limit": 0
-                }
+                "base_resp": { "status_code": 0, "status_msg": "success" },
+                "model_remains": [
+                    {
+                        "model_name": "Text Generation",
+                        "current_interval_total_count": 0,
+                        "current_interval_usage_count": 0,
+                        "end_time": 0,
+                        "current_weekly_total_count": 0,
+                        "current_weekly_usage_count": 0,
+                        "weekly_end_time": 0
+                    }
+                ]
             }
             """;
 
@@ -433,37 +524,41 @@ public class MinimaxProviderTests : HttpProviderTestBase<MinimaxProvider>
         // Act
         var result = await this._provider.GetUsageAsync(this.Config);
 
-        // Assert
-        var usage = result.Single();
-        Assert.True(usage.IsAvailable);
-        Assert.Equal(0, usage.UsedPercent); // 0 utilization = 0% used
-        Assert.Equal(0, usage.RequestsUsed);
-        Assert.Equal(0, usage.RequestsAvailable);
+        // Assert - no usages since both totals are 0
+        Assert.Empty(result);
     }
 
     [Fact]
     public async Task GetUsageAsync_LargeNumbers_ParsesCorrectlyAsync()
     {
-        // Arrange - Large token counts
+        // Arrange - Large counts
         var responseJson = """
             {
-                "usage": {
-                    "tokens_used": 45000000000,
-                    "tokens_limit": 100000000000
-                }
+                "base_resp": { "status_code": 0, "status_msg": "success" },
+                "model_remains": [
+                    {
+                        "model_name": "Text Generation",
+                        "current_interval_total_count": 100000000000,
+                        "current_interval_usage_count": 55000000000,
+                        "end_time": 0,
+                        "current_weekly_total_count": 500000000000,
+                        "current_weekly_usage_count": 275000000000,
+                        "weekly_end_time": 0
+                    }
+                ]
             }
             """;
 
         this.SetupResponse(HttpStatusCode.OK, responseJson);
 
         // Act
-        var result = await this._provider.GetUsageAsync(this.Config);
+        var result = (await this._provider.GetUsageAsync(this.Config)).ToList();
 
         // Assert
-        var usage = result.Single();
-        Assert.True(usage.IsAvailable);
-        Assert.Equal(45, usage.UsedPercent); // 45% used
-        Assert.Equal(45000000000, usage.RequestsUsed);
+        var burst = result.Single(u => u.WindowKind == WindowKind.Burst);
+        Assert.True(burst.IsAvailable);
+        Assert.Equal(45, burst.UsedPercent); // 45% used
+        Assert.Equal(45000000000, burst.RequestsUsed);
     }
 
     [Fact]
@@ -472,24 +567,32 @@ public class MinimaxProviderTests : HttpProviderTestBase<MinimaxProvider>
         // Arrange
         var responseJson = """
             {
-                "usage": {
-                    "tokens_used": 500000,
-                    "tokens_limit": 1000000
-                }
+                "base_resp": { "status_code": 0, "status_msg": "success" },
+                "model_remains": [
+                    {
+                        "model_name": "Text Generation",
+                        "current_interval_total_count": 100,
+                        "current_interval_usage_count": 50,
+                        "end_time": 0,
+                        "current_weekly_total_count": 500,
+                        "current_weekly_usage_count": 250,
+                        "weekly_end_time": 0
+                    }
+                ]
             }
             """;
 
         this.SetupResponse(HttpStatusCode.OK, responseJson);
 
         // Act
-        var result = await this._provider.GetUsageAsync(this.Config);
+        var result = (await this._provider.GetUsageAsync(this.Config)).ToList();
 
         // Assert
-        var usage = result.Single();
+        var burst = result.Single(u => u.WindowKind == WindowKind.Burst);
 
         // Use culture-independent assertion
-        Assert.Contains("tokens used", usage.Description, StringComparison.Ordinal);
-        Assert.Contains("limit", usage.Description, StringComparison.Ordinal);
+        Assert.Contains("remaining", burst.Description, StringComparison.Ordinal);
+        Assert.Contains("Text Generation", burst.Description, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -498,21 +601,29 @@ public class MinimaxProviderTests : HttpProviderTestBase<MinimaxProvider>
         // Arrange
         var responseJson = """
             {
-                "usage": {
-                    "tokens_used": 100000,
-                    "tokens_limit": 1000000
-                }
+                "base_resp": { "status_code": 0, "status_msg": "success" },
+                "model_remains": [
+                    {
+                        "model_name": "Text Generation",
+                        "current_interval_total_count": 100,
+                        "current_interval_usage_count": 50,
+                        "end_time": 0,
+                        "current_weekly_total_count": 500,
+                        "current_weekly_usage_count": 250,
+                        "weekly_end_time": 0
+                    }
+                ]
             }
             """;
 
         this.SetupResponse(HttpStatusCode.OK, responseJson);
 
         // Act
-        var result = await this._provider.GetUsageAsync(this.Config);
+        var result = (await this._provider.GetUsageAsync(this.Config)).ToList();
 
         // Assert
-        var usage = result.Single();
-        Assert.False(usage.IsCurrencyUsage);
+        var burst = result.Single(u => u.WindowKind == WindowKind.Burst);
+        Assert.False(burst.IsCurrencyUsage);
     }
 
     [Fact]
@@ -521,21 +632,29 @@ public class MinimaxProviderTests : HttpProviderTestBase<MinimaxProvider>
         // Arrange
         var responseJson = """
             {
-                "usage": {
-                    "tokens_used": 100000,
-                    "tokens_limit": 1000000
-                }
+                "base_resp": { "status_code": 0, "status_msg": "success" },
+                "model_remains": [
+                    {
+                        "model_name": "Text Generation",
+                        "current_interval_total_count": 100,
+                        "current_interval_usage_count": 50,
+                        "end_time": 0,
+                        "current_weekly_total_count": 500,
+                        "current_weekly_usage_count": 250,
+                        "weekly_end_time": 0
+                    }
+                ]
             }
             """;
 
         this.SetupResponse(HttpStatusCode.OK, responseJson);
 
         // Act
-        var result = await this._provider.GetUsageAsync(this.Config);
+        var result = (await this._provider.GetUsageAsync(this.Config)).ToList();
 
         // Assert
-        var usage = result.Single();
-        Assert.Equal(PlanType.Coding, usage.PlanType);
+        var burst = result.Single(u => u.WindowKind == WindowKind.Burst);
+        Assert.Equal(PlanType.Coding, burst.PlanType);
     }
 
     [Fact]
@@ -940,7 +1059,7 @@ public class MinimaxProviderTests : HttpProviderTestBase<MinimaxProvider>
 
     private void SetupResponse(HttpStatusCode statusCode, string content, string? url = null)
     {
-        url ??= ChinaEndpoint;
+        url ??= TokenPlanEndpoint;
         this.SetupHttpResponse(
             r => string.Equals(r.RequestUri?.ToString(), url, StringComparison.Ordinal),
             new HttpResponseMessage


### PR DESCRIPTION
## Summary
- Minimax removed their /v1/user/usage endpoint (returns 404) as part of their migration to a credit-based Token Plan system
- Replace dead UserUsage/ChatUserUsage endpoints with new TokenPlanRemains endpoint (/v1/token_plan/remains)
- Consolidate token and coding plan parsing into shared GetRemainsUsageAsync() since both endpoints use the same base_resp + model_remains response format
- Remove unused MinimaxTokenResponse/MinimaxTokenUsage models
- Rename MinimaxCodingPlanResponse to MinimaxRemainsResponse

## Behavior change
The minimax, minimax-io, and minimax-global provider IDs now produce burst + weekly window cards (same as coding plan) instead of a single usage entry. This aligns with Minimax credit-based quota windows (5h rolling + weekly).

## Test plan
- [x] All 34 MinimaxProviderTests pass with updated fixtures
- [x] Full test suite passes (1361 passed, 0 failed)
- [x] Token Plan endpoint returns 200 with valid auth error (not 404)
- [x] Coding Plan endpoint still works unchanged

## Files changed
- ProviderEndpoints.cs - removed dead endpoints, added TokenPlanRemains
- MinimaxProvider.cs - consolidated parsing, removed old models
- MinimaxProviderTests.cs - updated all fixtures to new response format

🤖 Generated with Claude Code