### PR TITLE
feat: provider health indicators showing last refresh time

### DIFF
--- a/AIUsageTracker.UI.Slim/MainWindowRuntimeLogic.Presentation.cs
+++ b/AIUsageTracker.UI.Slim/MainWindowRuntimeLogic.Presentation.cs
@@ -86,7 +86,8 @@ internal static partial class MainWindowRuntimeLogic
                 StatusText: rateLimitText,
                 StatusTone: ProviderCardStatusTone.Warning,
                 PaceColor: paceColor,
-                IsStale: isStale);
+                IsStale: isStale,
+                FetchedAt: usage.FetchedAt);
         }
 
         if (TryCreateSpecialPresentation(
@@ -123,7 +124,8 @@ internal static partial class MainWindowRuntimeLogic
             StatusTone: ProviderCardStatusTone.Secondary,
             PaceColor: paceColor,
             DualBar: dualBar,
-            IsStale: isStale);
+            IsStale: isStale,
+            FetchedAt: usage.FetchedAt);
     }
 
 #pragma warning disable S107
@@ -474,7 +476,8 @@ internal sealed record ProviderCardPresentation(
     PaceColorResult PaceColor,
     DualBarData? DualBar = null,
     bool IsExpired = false,
-    bool IsStale = false)
+    bool IsStale = false,
+    DateTime FetchedAt = default)
 {
     public bool HasDualBuckets => this.DualBar != null;
 }

--- a/AIUsageTracker.UI.Slim/ProviderCardRenderer.cs
+++ b/AIUsageTracker.UI.Slim/ProviderCardRenderer.cs
@@ -143,6 +143,39 @@ internal sealed class ProviderCardRenderer
                     margin: new Thickness(6, 0, 0, 0)),
                 Dock.Right);
         }
+
+        if (presentation.FetchedAt != default)
+        {
+            var fetchedUtc = UsageMath.AsUtc(presentation.FetchedAt);
+            var ago = DateTime.UtcNow - fetchedUtc;
+            string freshnessText;
+            if (ago.TotalMinutes < 1)
+            {
+                freshnessText = "just now";
+            }
+            else if (ago.TotalHours < 1)
+            {
+                freshnessText = $"{(int)ago.TotalMinutes}m ago";
+            }
+            else if (ago.TotalDays < 1)
+            {
+                freshnessText = $"{(int)ago.TotalHours}h ago";
+            }
+            else
+            {
+                freshnessText = fetchedUtc.ToLocalTime().ToString("MMM d", CultureInfo.InvariantCulture);
+            }
+
+            var tertiaryBrush = this._getResourceBrush(ResourceKeyTertiaryText, Brushes.Gray);
+            AddDockedElement(
+                contentPanel,
+                this.CreateDockedTextBlock(
+                    freshnessText,
+                    fontSize: 8,
+                    foreground: tertiaryBrush,
+                    margin: new Thickness(6, 0, 0, 0)),
+                Dock.Right);
+        }
     }
 
     private void AttachTooltip(Grid grid, ProviderUsage usage, string friendlyName)


### PR DESCRIPTION
## Changes

### Task 43: Provider Health Indicators (P2)
- Adds relative timestamp badge to each provider card showing last refresh time
- Uses existing FetchedAt from Monitor database - no API or schema changes
- Shows: just now, 5m ago, 2h ago, or date for older data
- Badge appears in gray tertiary text next to Stale/Expired badges

## Files Changed
- MainWindowRuntimeLogic.Presentation.cs - add FetchedAt to ProviderCardPresentation
- ProviderCardRenderer.cs - render relative timestamp badge in AddStatusBadges

## Testing
- Build: 0 errors
- Tests: 1362 passed, 1 pre-existing failure (version comparison of -develop suffix)
- All 57 presentation/renderer tests pass
