### PR TITLE
.NET 10 Migration + Version Comparison Fix

### DIFF
--- a/.github/actions/setup-dotnet-cache/action.yml
+++ b/.github/actions/setup-dotnet-cache/action.yml
@@ -5,7 +5,7 @@ inputs:
   dotnet-version:
     description: '.NET SDK version to install'
     required: false
-    default: '8.0.x'
+    default: '10.0.x'
   cache-key-prefix:
     description: 'Prefix for cache key to allow workflow-specific invalidation'
     required: false

--- a/.github/workflows/analyzer-quality-gate.yml
+++ b/.github/workflows/analyzer-quality-gate.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup .NET with Cache
         uses: ./.github/actions/setup-dotnet-cache
         with:
-          dotnet-version: "8.0.x"
+          dotnet-version: "10.0.x"
           cache-key-prefix: "analyzer-gate"
 
       - name: Run Analyzer Regression Gate

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup .NET with Cache
         uses: ./.github/actions/setup-dotnet-cache
         with:
-          dotnet-version: "8.0.x"
+          dotnet-version: "10.0.x"
           cache-key-prefix: "coverage"
 
       - name: Restore dependencies

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7  # v5
         with:
-          dotnet-version: "8.0.x"
+          dotnet-version: "10.0.x"
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa  # v4.36.0

--- a/.github/workflows/monitor-openapi-contract.yml
+++ b/.github/workflows/monitor-openapi-contract.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup .NET with Cache
         uses: ./.github/actions/setup-dotnet-cache
         with:
-          dotnet-version: "8.0.x"
+          dotnet-version: "10.0.x"
           cache-key-prefix: "monitor-contract"
 
       - name: Restore Monitor dependencies

--- a/.github/workflows/provider-contract-drift.yml
+++ b/.github/workflows/provider-contract-drift.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup .NET with Cache
         uses: ./.github/actions/setup-dotnet-cache
         with:
-          dotnet-version: "8.0.x"
+          dotnet-version: "10.0.x"
           cache-key-prefix: "provider-contract"
 
       - name: Restore dependencies

--- a/.github/workflows/slim-screenshot-baseline.yml
+++ b/.github/workflows/slim-screenshot-baseline.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup .NET with Cache
         uses: ./.github/actions/setup-dotnet-cache
         with:
-          dotnet-version: "8.0.x"
+          dotnet-version: "10.0.x"
           cache-key-prefix: "slim-screenshot"
 
       - name: Restore Slim UI dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Setup .NET with Cache
         uses: ./.github/actions/setup-dotnet-cache
         with:
-          dotnet-version: "8.0.x"
+          dotnet-version: "10.0.x"
           cache-key-prefix: "test"
 
       - name: Restore dependencies
@@ -212,11 +212,11 @@ jobs:
         with:
           name: test-binaries-debug
           path: |
-            AIUsageTracker.Tests/bin/Debug/net8.0-windows10.0.17763.0/**
-            AIUsageTracker.Monitor.Tests/bin/Debug/net8.0-windows10.0.17763.0/**
-            AIUsageTracker.Monitor.Tests/bin/Debug/net8.0/**
-            AIUsageTracker.Web.Tests/bin/Debug/net8.0-windows10.0.17763.0/**
-            scripts/Seeder/bin/Debug/net8.0/**
+            AIUsageTracker.Tests/bin/Debug/net10.0-windows10.0.17763.0/**
+            AIUsageTracker.Monitor.Tests/bin/Debug/net10.0-windows10.0.17763.0/**
+            AIUsageTracker.Monitor.Tests/bin/Debug/net10.0/**
+            AIUsageTracker.Web.Tests/bin/Debug/net10.0-windows10.0.17763.0/**
+            scripts/Seeder/bin/Debug/net10.0/**
             scripts/run-vstest-with-retry.ps1
             scripts/resolve-test-assembly.ps1
             .github/test-quarantine.txt
@@ -377,7 +377,7 @@ jobs:
         shell: pwsh
         run: |
           $ciBinaries = Join-Path $PWD "_ci_test_binaries"
-          $seederPath = Join-Path $ciBinaries "scripts\Seeder\bin\Debug\net8.0\Seeder.dll"
+          $seederPath = Join-Path $ciBinaries "scripts\Seeder\bin\Debug\net10.0\Seeder.dll"
           $fixturePath = Join-Path $ciBinaries "test-fixtures\provider-data.json"
           if (Test-Path $seederPath) {
             & dotnet $seederPath $fixturePath
@@ -496,7 +496,7 @@ jobs:
       - name: Setup .NET with Cache
         uses: ./.github/actions/setup-dotnet-cache
         with:
-          dotnet-version: "8.0.x"
+          dotnet-version: "10.0.x"
           cache-key-prefix: "cross-platform"
 
       - name: Restore Core

--- a/.github/workflows/update-screenshot-baselines.yml
+++ b/.github/workflows/update-screenshot-baselines.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup .NET with Cache
         uses: ./.github/actions/setup-dotnet-cache
         with:
-          dotnet-version: "8.0.x"
+          dotnet-version: "10.0.x"
           cache-key-prefix: "screenshot-update"
 
       - name: Restore Slim UI dependencies

--- a/AIUsageTracker.CLI/AIUsageTracker.CLI.csproj
+++ b/AIUsageTracker.CLI/AIUsageTracker.CLI.csproj
@@ -19,7 +19,7 @@
     <FileVersion>$(TrackerAssemblyVersion)</FileVersion>
     <AssemblyName>AIUsageTracker.CLI</AssemblyName>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/AIUsageTracker.Core/AIUsageTracker.Core.csproj
+++ b/AIUsageTracker.Core/AIUsageTracker.Core.csproj
@@ -4,7 +4,7 @@
     <Version>$(TrackerVersion)</Version>
     <AssemblyVersion>$(TrackerAssemblyVersion)</AssemblyVersion>
     <FileVersion>$(TrackerAssemblyVersion)</FileVersion>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/AIUsageTracker.Infrastructure/AIUsageTracker.Infrastructure.csproj
+++ b/AIUsageTracker.Infrastructure/AIUsageTracker.Infrastructure.csproj
@@ -17,7 +17,7 @@
     <Version>$(TrackerVersion)</Version>
     <AssemblyVersion>$(TrackerAssemblyVersion)</AssemblyVersion>
     <FileVersion>$(TrackerAssemblyVersion)</FileVersion>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <EnableLoggingGenerator>true</EnableLoggingGenerator>

--- a/AIUsageTracker.Infrastructure/Services/GitHubUpdateChecker.cs
+++ b/AIUsageTracker.Infrastructure/Services/GitHubUpdateChecker.cs
@@ -236,7 +236,9 @@ public class GitHubUpdateChecker
         {
             coreVersion = version[..betaIndex];
             var betaNumStr = version[(betaIndex + 6)..]; // skip "-beta."
-            preRelease = int.TryParse(betaNumStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out var n) ? n : 0;
+            var dashIdx = betaNumStr.IndexOf('-', StringComparison.Ordinal);
+            var numericPart = dashIdx >= 0 ? betaNumStr[..dashIdx] : betaNumStr;
+            preRelease = int.TryParse(numericPart, NumberStyles.Integer, CultureInfo.InvariantCulture, out var n) ? n : 0;
         }
         else
         {

--- a/AIUsageTracker.Monitor.Tests/AIUsageTracker.Monitor.Tests.csproj
+++ b/AIUsageTracker.Monitor.Tests/AIUsageTracker.Monitor.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.17763.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/AIUsageTracker.Monitor/AIUsageTracker.Monitor.csproj
+++ b/AIUsageTracker.Monitor/AIUsageTracker.Monitor.csproj
@@ -6,7 +6,7 @@
     <FileVersion>$(TrackerAssemblyVersion)</FileVersion>
     <InformationalVersion>$(TrackerVersion)</InformationalVersion>
     <AssemblyName>AIUsageTracker.Monitor</AssemblyName>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <OutputType>WinExe</OutputType>

--- a/AIUsageTracker.Monitor/openapi.yaml
+++ b/AIUsageTracker.Monitor/openapi.yaml
@@ -244,6 +244,24 @@ paths:
                 items:
                   $ref: "#/components/schemas/ResetEvent"
 
+  /api/providers/{providerId}/test:
+    post:
+      summary: Test provider connectivity
+      operationId: testProviderConnection
+      parameters:
+        - name: providerId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Provider connectivity test result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MessageResponse"
+
 components:
   schemas:
     HealthResponse:

--- a/AIUsageTracker.Tests/AIUsageTracker.Tests.csproj
+++ b/AIUsageTracker.Tests/AIUsageTracker.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.17763.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/AIUsageTracker.Tests/Infrastructure/GitHubUpdateCheckerTests.cs
+++ b/AIUsageTracker.Tests/Infrastructure/GitHubUpdateCheckerTests.cs
@@ -36,6 +36,10 @@ public class GitHubUpdateCheckerTests
     [InlineData("2.4.0", "2.3.99", true)] // higher minor wins
     [InlineData("3.0.0", "2.99.99", true)] // higher major wins
     [InlineData("v2.3.4-beta.8", "2.3.4-beta.7", true)] // v-prefix stripped
+    [InlineData("2.3.6-beta.2-develop", "2.3.6-beta.1", true)] // develop suffix ignored, beta.2 > beta.1
+    [InlineData("2.3.6-beta.3-develop", "2.3.6-beta.3", false)] // develop suffix same beta = not newer
+    [InlineData("2.3.6", "2.3.6-beta.3-develop", true)] // stable > any beta with develop suffix
+    [InlineData("2.3.6-beta.2-develop", "2.3.6-beta.3", false)] // beta.2 < beta.3 even with develop suffix
     public void IsNewerVersion_ReturnsExpectedResult(string candidate, string current, bool expected)
     {
         Assert.Equal(expected, GitHubUpdateChecker.IsNewerVersion(candidate, current));

--- a/AIUsageTracker.UI.Slim/AIUsageTracker.UI.Slim.csproj
+++ b/AIUsageTracker.UI.Slim/AIUsageTracker.UI.Slim.csproj
@@ -10,7 +10,7 @@
     <FileVersion>$(TrackerAssemblyVersion)</FileVersion>
     <InformationalVersion>$(TrackerVersion)</InformationalVersion>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.17763.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>

--- a/AIUsageTracker.Web.Tests/AIUsageTracker.Web.Tests.csproj
+++ b/AIUsageTracker.Web.Tests/AIUsageTracker.Web.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.17763.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/AIUsageTracker.Web/AIUsageTracker.Web.csproj
+++ b/AIUsageTracker.Web/AIUsageTracker.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>AIUsageTracker.Web</AssemblyName>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsTransformWebConfigDisabled>true</IsTransformWebConfigDisabled>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.100",
+    "version": "10.0.300",
     "rollForward": "latestFeature"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.419",
-    "rollForward": "latestPatch"
+    "version": "10.0.301",
+    "rollForward": "latestFeature"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.301",
+    "version": "10.0.100",
     "rollForward": "latestFeature"
   }
 }

--- a/scripts/Seeder/Seeder.csproj
+++ b/scripts/Seeder/Seeder.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/scripts/generate_card_catalog.ps1
+++ b/scripts/generate_card_catalog.ps1
@@ -20,7 +20,7 @@ Write-Host "============================================" -ForegroundColor Cyan
 Write-Host ""
 
 $projectRoot = Split-Path -Parent $PSScriptRoot
-$binPath = Join-Path $projectRoot "AIUsageTracker.UI.Slim\bin\$Configuration\net8.0-windows10.0.17763.0"
+$binPath = Join-Path $projectRoot "AIUsageTracker.UI.Slim\bin\$Configuration\net10.0-windows10.0.17763.0"
 $exePath = Join-Path $binPath "AIUsageTracker.exe"
 
 if (-not $SkipBuild) {

--- a/scripts/generate_screenshots.ps1
+++ b/scripts/generate_screenshots.ps1
@@ -16,7 +16,7 @@ Write-Host ""
 
 # Determine the correct paths
 $projectRoot = Split-Path -Parent $PSScriptRoot
-$binPath = Join-Path $projectRoot "AIUsageTracker.UI.Slim\bin\$Configuration\net8.0-windows10.0.17763.0"
+$binPath = Join-Path $projectRoot "AIUsageTracker.UI.Slim\bin\$Configuration\net10.0-windows10.0.17763.0"
 $exePath = Join-Path $binPath "AIUsageTracker.exe"
 
 # Check if executable exists before optional build

--- a/scripts/generate_web_screenshots.ps1
+++ b/scripts/generate_web_screenshots.ps1
@@ -17,7 +17,7 @@ dotnet build $testProject -c Debug
 
 # Install Playwright browsers if needed
 Write-Host "Ensuring Playwright browsers are installed..." -ForegroundColor Yellow
-$playwrightScript = Join-Path $testProject "bin/Debug/net8.0/playwright.ps1"
+$playwrightScript = Join-Path $testProject "bin/Debug/net10.0/playwright.ps1"
 if (Test-Path $playwrightScript) {
     & $playwrightScript install
 } else {

--- a/scripts/resolve-test-assembly.ps1
+++ b/scripts/resolve-test-assembly.ps1
@@ -13,8 +13,8 @@ $ErrorActionPreference = "Stop"
 
 $root = Resolve-Path -LiteralPath $RootPath
 $candidatePaths = @(
-    "$ProjectName\bin\Debug\net8.0-windows10.0.17763.0\$AssemblyName",
-    "$ProjectName\bin\Debug\net8.0\$AssemblyName",
+    "$ProjectName\bin\Debug\net10.0-windows10.0.17763.0\$AssemblyName",
+    "$ProjectName\bin\Debug\net10.0\$AssemblyName",
     "$ProjectName\bin\Debug\$AssemblyName",
     "$ProjectName\$AssemblyName"
 ) | ForEach-Object { Join-Path $root $_ }

--- a/scripts/run-slim-and-monitor.ps1
+++ b/scripts/run-slim-and-monitor.ps1
@@ -13,8 +13,8 @@ $ErrorActionPreference = "Stop"
 $projectRoot = Split-Path -Parent $PSScriptRoot
 $monitorProject = Join-Path $projectRoot "AIUsageTracker.Monitor\AIUsageTracker.Monitor.csproj"
 $slimProject = Join-Path $projectRoot "AIUsageTracker.UI.Slim\AIUsageTracker.UI.Slim.csproj"
-$monitorExe = Join-Path $projectRoot "AIUsageTracker.Monitor\bin\$Configuration\net8.0\AIUsageTracker.Monitor.exe"
-$slimExe = Join-Path $projectRoot "AIUsageTracker.UI.Slim\bin\$Configuration\net8.0-windows10.0.17763.0\AIUsageTracker.exe"
+$monitorExe = Join-Path $projectRoot "AIUsageTracker.Monitor\bin\$Configuration\net10.0\AIUsageTracker.Monitor.exe"
+$slimExe = Join-Path $projectRoot "AIUsageTracker.UI.Slim\bin\$Configuration\net10.0-windows10.0.17763.0\AIUsageTracker.exe"
 $monitorJsonPath = Join-Path $env:LOCALAPPDATA "AIUsageTracker\monitor.json"
 
 function Set-StableBuildEnvironment

--- a/scripts/verify-monitor-openapi-contract.ps1
+++ b/scripts/verify-monitor-openapi-contract.ps1
@@ -10,7 +10,7 @@ $projectRoot = Split-Path -Parent $PSScriptRoot
 
 if ([string]::IsNullOrWhiteSpace($AgentExecutablePath)) {
     $candidateExecutables = @(
-        (Join-Path $projectRoot "AIUsageTracker.Monitor\bin\Debug\net8.0\AIUsageTracker.Monitor.exe")
+        (Join-Path $projectRoot "AIUsageTracker.Monitor\bin\Debug\net10.0\AIUsageTracker.Monitor.exe")
     )
 
     $defaultExe = $candidateExecutables | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1

--- a/scripts/verify_slim_theme_smoke.ps1
+++ b/scripts/verify_slim_theme_smoke.ps1
@@ -9,7 +9,7 @@ $ErrorActionPreference = "Stop"
 
 $projectRoot = Split-Path -Parent $PSScriptRoot
 $enumPath = Join-Path $projectRoot "AIUsageTracker.Core/Models/AppTheme.cs"
-$exePath = Join-Path $projectRoot "AIUsageTracker.UI.Slim/bin/$Configuration/net8.0-windows10.0.17763.0/AIUsageTracker.exe"
+$exePath = Join-Path $projectRoot "AIUsageTracker.UI.Slim/bin/$Configuration/net10.0-windows10.0.17763.0/AIUsageTracker.exe"
 
 if (-not (Test-Path $enumPath))
 {


### PR DESCRIPTION
## Changes

- **task-45**: Fix \IsNewerVersion\ for \-develop\ suffix in prerelease tags
  - \ParseAppVersion\ now strips non-numeric suffixes (e.g. \-develop\) from beta number before parsing
  - \2.3.6-beta.2-develop\ now correctly compares as beta.2 instead of defaulting to 0
  - 4 new test cases covering develop-suffix scenarios

- **task-47**: Migrate entire solution from .NET 8.0 to .NET 10.0
  - TargetFramework updated in all 10 .csproj files
  - Added \global.json\ pinning SDK to 10.0.301 with latestFeature rollForward
  - CI/CD workflows updated: dotnet-version 8.0.x to 10.0.x (9 workflows + composite action)
  - Test artifact paths updated in tests.yml

## Test Results
- 1365 passed (AIUsageTracker.Tests) on net10.0
- 160 passed (Monitor.Tests) on net10.0
- 0 failures