### PR TITLE
Add Web Analytics page with per-model breakdown, latency trends, HTTP status history, and details panel

### DIFF
--- a/AIUsageTracker.Core/Models/DetailsJsonEntry.cs
+++ b/AIUsageTracker.Core/Models/DetailsJsonEntry.cs
@@ -1,0 +1,16 @@
+// <copyright file="DetailsJsonEntry.cs" company="AIUsageTracker">
+// Copyright (c) AIUsageTracker. All rights reserved.
+// </copyright>
+
+namespace AIUsageTracker.Core.Models;
+
+public class DetailsJsonEntry
+{
+    public string ProviderId { get; set; } = string.Empty;
+
+    public string ProviderName { get; set; } = string.Empty;
+
+    public string DetailsJson { get; set; } = string.Empty;
+
+    public DateTime FetchedAt { get; set; }
+}

--- a/AIUsageTracker.Core/Models/HttpStatusHistoryPoint.cs
+++ b/AIUsageTracker.Core/Models/HttpStatusHistoryPoint.cs
@@ -1,0 +1,20 @@
+// <copyright file="HttpStatusHistoryPoint.cs" company="AIUsageTracker">
+// Copyright (c) AIUsageTracker. All rights reserved.
+// </copyright>
+
+namespace AIUsageTracker.Core.Models;
+
+public class HttpStatusHistoryPoint
+{
+    public string ProviderId { get; set; } = string.Empty;
+
+    public string ProviderName { get; set; } = string.Empty;
+
+    public DateTime Timestamp { get; set; }
+
+    public int SuccessCount { get; set; }
+
+    public int ErrorCount { get; set; }
+
+    public int TotalCount { get; set; }
+}

--- a/AIUsageTracker.Core/Models/LatencyDataPoint.cs
+++ b/AIUsageTracker.Core/Models/LatencyDataPoint.cs
@@ -1,0 +1,18 @@
+// <copyright file="LatencyDataPoint.cs" company="AIUsageTracker">
+// Copyright (c) AIUsageTracker. All rights reserved.
+// </copyright>
+
+namespace AIUsageTracker.Core.Models;
+
+public class LatencyDataPoint
+{
+    public string ProviderId { get; set; } = string.Empty;
+
+    public string ProviderName { get; set; } = string.Empty;
+
+    public DateTime Timestamp { get; set; }
+
+    public double AvgLatencyMs { get; set; }
+
+    public double MaxLatencyMs { get; set; }
+}

--- a/AIUsageTracker.Core/Models/ModelUsageBreakdown.cs
+++ b/AIUsageTracker.Core/Models/ModelUsageBreakdown.cs
@@ -1,0 +1,18 @@
+// <copyright file="ModelUsageBreakdown.cs" company="AIUsageTracker">
+// Copyright (c) AIUsageTracker. All rights reserved.
+// </copyright>
+
+namespace AIUsageTracker.Core.Models;
+
+public class ModelUsageBreakdown
+{
+    public string ModelName { get; set; } = string.Empty;
+
+    public string ProviderName { get; set; } = string.Empty;
+
+    public int SampleCount { get; set; }
+
+    public double TotalUsed { get; set; }
+
+    public double AvgUsedPercent { get; set; }
+}

--- a/AIUsageTracker.Web/Pages/Analytics.cshtml
+++ b/AIUsageTracker.Web/Pages/Analytics.cshtml
@@ -1,0 +1,345 @@
+@page "/analytics"
+@model AnalyticsModel
+@{
+    ViewData["Title"] = "Analytics";
+}
+
+<h1 class="page-title">Analytics</h1>
+
+@if (!Model.IsDatabaseAvailable)
+{
+    <div class="alert alert-warning">
+        <strong>Database not found!</strong> The Monitor database is not available.
+        Ensure the Monitor has run at least once to initialize the database.
+    </div>
+}
+else
+{
+    <div class="chart-controls mb-2">
+        <select id="timeRange"
+                name="hours"
+                class="theme-select"
+                style="width: auto;"
+                hx-get="/analytics?handler=AnalyticsPayload"
+                hx-trigger="change"
+                hx-include="this"
+                hx-target="#analytics-chart-loader"
+                hx-swap="none">
+            <option value="6" selected="@(Model.SelectedHours == 6)">Last 6 hours</option>
+            <option value="12" selected="@(Model.SelectedHours == 12)">Last 12 hours</option>
+            <option value="24" selected="@(Model.SelectedHours == 24)">Last 24 hours</option>
+            <option value="48" selected="@(Model.SelectedHours == 48)">Last 48 hours</option>
+            <option value="168" selected="@(Model.SelectedHours == 168)">Last 7 days</option>
+        </select>
+    </div>
+    <div id="analytics-chart-loader"
+         hx-get="/analytics?handler=AnalyticsPayload&hours=@Model.SelectedHours"
+         hx-trigger="load"
+         hx-swap="none"></div>
+
+    @* Section 1: Per-Model Usage Breakdown *@
+    <div class="section-header">
+        <h2 class="mb-2">Model Usage Breakdown</h2>
+    </div>
+    @if (Model.ModelBreakdown.Count > 0)
+    {
+        var maxTotal = Model.ModelBreakdown.Max(m => m.TotalUsed);
+        <div class="analytics-table-container">
+            <table class="analytics-table">
+                <thead>
+                    <tr>
+                        <th>Model</th>
+                        <th>Provider</th>
+                        <th>Total Used</th>
+                        <th>Avg Usage %</th>
+                        <th>Samples</th>
+                        <th>Distribution</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var item in Model.ModelBreakdown)
+                    {
+                        var barWidth = maxTotal > 0 ? (item.TotalUsed / maxTotal * 100) : 0;
+                        <tr>
+                            <td class="model-name">@item.ModelName</td>
+                            <td class="provider-label">@item.ProviderName</td>
+                            <td>@item.TotalUsed.ToString("N0")</td>
+                            <td>@item.AvgUsedPercent.ToString("F1")%</td>
+                            <td>@item.SampleCount</td>
+                            <td class="distribution-cell">
+                                <div class="distribution-bar">
+                                    <div class="distribution-fill" style="width: @barWidth.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)%"></div>
+                                </div>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    }
+    else
+    {
+        <div class="alert alert-info">No per-model data available. Providers with model_name or card names will appear here.</div>
+    }
+
+    @* Section 2: Latency Trend Chart *@
+    <div class="section-header">
+        <h2 class="mb-2">Latency Trends</h2>
+    </div>
+    <div class="chart-container">
+        <canvas id="latencyChart"></canvas>
+    </div>
+    @if (Model.LatencyData.Count == 0)
+    {
+        <div class="alert alert-info">No latency data available yet.</div>
+    }
+
+    @* Section 3: HTTP Status History *@
+    <div class="section-header">
+        <h2 class="mb-2">HTTP Status History</h2>
+    </div>
+    <div class="chart-container">
+        <canvas id="httpStatusChart"></canvas>
+    </div>
+    @if (Model.HttpStatusData.Count == 0)
+    {
+        <div class="alert alert-info">No HTTP status history available yet.</div>
+    }
+
+    @* Section 4: Details JSON Panel *@
+    <div class="section-header">
+        <h2 class="mb-2">Provider Details (Latest)</h2>
+    </div>
+    @if (Model.DetailsEntries.Count > 0)
+    {
+        <div class="details-grid">
+            @foreach (var entry in Model.DetailsEntries)
+            {
+                <div class="details-card">
+                    <div class="details-header">
+                        <span class="provider-name">@entry.ProviderName</span>
+                        <span class="details-timestamp">@entry.FetchedAt.ToLocalTime().ToString("g")</span>
+                    </div>
+                    <div class="details-json-container">
+                        <pre class="details-json"><code>@FormatDetailsJson(entry.DetailsJson)</code></pre>
+                    </div>
+                </div>
+            }
+        </div>
+    }
+    else
+    {
+        <div class="alert alert-info">No details_json data available from recent provider snapshots.</div>
+    }
+}
+
+@functions {
+    static string FormatDetailsJson(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return "{}";
+        }
+
+        try
+        {
+            var doc = System.Text.Json.JsonDocument.Parse(json);
+            return System.Text.Json.JsonSerializer.Serialize(doc, new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
+        }
+        catch
+        {
+            return json;
+        }
+    }
+}
+
+@section Scripts {
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script>
+        const latencyData = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.LatencyData ?? new List<AIUsageTracker.Core.Models.LatencyDataPoint>()));
+        const httpStatusData = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.HttpStatusData ?? new List<AIUsageTracker.Core.Models.HttpStatusHistoryPoint>()));
+
+        let currentLatencyData = latencyData;
+        let currentHttpStatusData = httpStatusData;
+        let latencyChartInstance = null;
+        let httpStatusChartInstance = null;
+
+        const providerChartColors = {
+            'Antigravity': '#ef4444',
+            'Anthropic': '#ec4899',
+            'OpenAI': '#22c55e',
+            'GitHub Copilot': '#3b82f6',
+            'OpenCode': '#eab308'
+        };
+        const fallbackColors = ['#06b6d4', '#8b5cf6', '#f97316', '#64748b', '#14b8a6', '#f43f5e'];
+
+        function getProviderColor(name, index) {
+            for (const key in providerChartColors) {
+                if (name.includes(key)) return providerChartColors[key];
+            }
+            return fallbackColors[index % fallbackColors.length];
+        }
+
+        function buildLatencyChart() {
+            const ctx = document.getElementById('latencyChart');
+            if (!ctx || currentLatencyData.length === 0) return;
+
+            const providers = [...new Set(currentLatencyData.map(d => d.ProviderName))].sort();
+            const allTimestamps = [...new Set(currentLatencyData.map(d => d.Timestamp))].sort();
+
+            const labels = allTimestamps.map(ts => {
+                const date = new Date(ts);
+                return date.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' });
+            });
+
+            const datasets = providers.map((name, i) => {
+                const providerData = currentLatencyData.filter(d => d.ProviderName === name);
+                const color = getProviderColor(name, i);
+                return {
+                    label: name,
+                    data: allTimestamps.map(ts => {
+                        const point = providerData.find(d => d.Timestamp === ts);
+                        return point ? Math.round(point.AvgLatencyMs) : null;
+                    }),
+                    borderColor: color,
+                    backgroundColor: color + '20',
+                    fill: false,
+                    tension: 0.2,
+                    pointRadius: 2,
+                    pointHoverRadius: 5,
+                    spanGaps: true
+                };
+            });
+
+            if (latencyChartInstance) {
+                latencyChartInstance.data.labels = labels;
+                latencyChartInstance.data.datasets = datasets;
+                latencyChartInstance.update('none');
+                return;
+            }
+
+            latencyChartInstance = new Chart(ctx, {
+                type: 'line',
+                data: { labels, datasets },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    interaction: { intersect: false, mode: 'index' },
+                    animation: false,
+                    scales: {
+                        x: { ticks: { maxRotation: 45, minRotation: 45, maxTicksLimit: 20 } },
+                        y: { beginAtZero: true, title: { display: true, text: 'Latency (ms)' } }
+                    },
+                    plugins: {
+                        legend: { position: 'bottom', labels: { boxWidth: 12, padding: 15 } },
+                        tooltip: {
+                            callbacks: {
+                                label: c => `${c.dataset.label}: ${c.parsed.y?.toLocaleString() ?? '-'}ms`
+                            }
+                        }
+                    }
+                }
+            });
+        }
+
+        function buildHttpStatusChart() {
+            const ctx = document.getElementById('httpStatusChart');
+            if (!ctx || currentHttpStatusData.length === 0) return;
+
+            const providers = [...new Set(currentHttpStatusData.map(d => d.ProviderName))].sort();
+            const allTimestamps = [...new Set(currentHttpStatusData.map(d => d.Timestamp))].sort();
+
+            const labels = allTimestamps.map(ts => {
+                const date = new Date(ts);
+                return date.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' });
+            });
+
+            const successDatasets = providers.map((name, i) => {
+                const providerData = currentHttpStatusData.filter(d => d.ProviderName === name);
+                const color = getProviderColor(name, i);
+                return {
+                    label: name + ' (2xx)',
+                    data: allTimestamps.map(ts => {
+                        const point = providerData.find(d => d.Timestamp === ts);
+                        return point ? point.SuccessCount : null;
+                    }),
+                    borderColor: color,
+                    backgroundColor: color + '40',
+                    fill: true,
+                    tension: 0.1,
+                    pointRadius: 1,
+                    spanGaps: true
+                };
+            });
+
+            const errorDatasets = providers.map((name, i) => {
+                const providerData = currentHttpStatusData.filter(d => d.ProviderName === name);
+                const color = getProviderColor(name, i);
+                return {
+                    label: name + ' (4xx/5xx)',
+                    data: allTimestamps.map(ts => {
+                        const point = providerData.find(d => d.Timestamp === ts);
+                        return point && point.ErrorCount > 0 ? point.ErrorCount : null;
+                    }),
+                    borderColor: '#ef4444',
+                    backgroundColor: '#ef444440',
+                    borderDash: [5, 3],
+                    fill: false,
+                    tension: 0.1,
+                    pointRadius: 2,
+                    pointBackgroundColor: '#ef4444',
+                    spanGaps: true
+                };
+            });
+
+            const datasets = [...successDatasets, ...errorDatasets];
+
+            if (httpStatusChartInstance) {
+                httpStatusChartInstance.data.labels = labels;
+                httpStatusChartInstance.data.datasets = datasets;
+                httpStatusChartInstance.update('none');
+                return;
+            }
+
+            httpStatusChartInstance = new Chart(ctx, {
+                type: 'line',
+                data: { labels, datasets },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    interaction: { intersect: false, mode: 'index' },
+                    animation: false,
+                    scales: {
+                        x: { ticks: { maxRotation: 45, minRotation: 45, maxTicksLimit: 20 } },
+                        y: { beginAtZero: true, title: { display: true, text: 'Request Count' } }
+                    },
+                    plugins: {
+                        legend: { position: 'bottom', labels: { boxWidth: 12, padding: 10 } },
+                        tooltip: {
+                            callbacks: {
+                                label: c => `${c.dataset.label}: ${c.parsed.y ?? '-'}`
+                            }
+                        }
+                    }
+                }
+            });
+        }
+
+        document.body.addEventListener('htmx:afterRequest', event => {
+            const sourceId = event.detail?.elt?.id;
+            if (sourceId !== 'timeRange' && sourceId !== 'analytics-chart-loader') return;
+            if (!event.detail?.successful) return;
+
+            try {
+                const payload = JSON.parse(event.detail.xhr.responseText);
+                currentLatencyData = payload.latencyData ?? [];
+                currentHttpStatusData = payload.httpStatusData ?? [];
+                buildLatencyChart();
+                buildHttpStatusChart();
+            } catch { }
+        });
+
+        buildLatencyChart();
+        buildHttpStatusChart();
+    </script>
+}

--- a/AIUsageTracker.Web/Pages/Analytics.cshtml.cs
+++ b/AIUsageTracker.Web/Pages/Analytics.cshtml.cs
@@ -1,0 +1,78 @@
+// <copyright file="Analytics.cshtml.cs" company="AIUsageTracker">
+// Copyright (c) AIUsageTracker. All rights reserved.
+// </copyright>
+
+using AIUsageTracker.Core.Models;
+using AIUsageTracker.Web.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.OutputCaching;
+
+namespace AIUsageTracker.Web.Pages;
+
+[OutputCache(PolicyName = "AnalyticsCache")]
+public class AnalyticsModel : PageModel
+{
+    private readonly WebDatabaseService _dbService;
+
+    public AnalyticsModel(WebDatabaseService dbService)
+    {
+        this._dbService = dbService;
+    }
+
+    public IReadOnlyList<ModelUsageBreakdown> ModelBreakdown { get; private set; } = [];
+
+    public IReadOnlyList<LatencyDataPoint> LatencyData { get; private set; } = [];
+
+    public IReadOnlyList<HttpStatusHistoryPoint> HttpStatusData { get; private set; } = [];
+
+    public IReadOnlyList<DetailsJsonEntry> DetailsEntries { get; private set; } = [];
+
+    public bool IsDatabaseAvailable => this._dbService.IsDatabaseAvailable();
+
+    public int SelectedHours { get; set; } = 24;
+
+    public async Task OnGetAsync(int hours = 24)
+    {
+        this.SelectedHours = hours;
+
+        if (!this.IsDatabaseAvailable)
+        {
+            return;
+        }
+
+        var modelTask = this._dbService.GetModelUsageBreakdownAsync(168);
+        var latencyTask = this._dbService.GetLatencyTrendAsync(hours);
+        var httpTask = this._dbService.GetHttpStatusHistoryAsync(hours);
+        var detailsTask = this._dbService.GetRecentDetailsJsonAsync(20);
+
+        await Task.WhenAll(modelTask, latencyTask, httpTask, detailsTask).ConfigureAwait(false);
+
+        this.ModelBreakdown = await modelTask.ConfigureAwait(false);
+        this.LatencyData = await latencyTask.ConfigureAwait(false);
+        this.HttpStatusData = await httpTask.ConfigureAwait(false);
+        this.DetailsEntries = await detailsTask.ConfigureAwait(false);
+    }
+
+    public async Task<IActionResult> OnGetAnalyticsPayloadAsync(int hours = 24)
+    {
+        if (!this.IsDatabaseAvailable)
+        {
+            return new JsonResult(new
+            {
+                latencyData = Array.Empty<LatencyDataPoint>(),
+                httpStatusData = Array.Empty<HttpStatusHistoryPoint>(),
+            });
+        }
+
+        var latencyTask = this._dbService.GetLatencyTrendAsync(hours);
+        var httpTask = this._dbService.GetHttpStatusHistoryAsync(hours);
+        await Task.WhenAll(latencyTask, httpTask).ConfigureAwait(false);
+
+        return new JsonResult(new
+        {
+            latencyData = await latencyTask.ConfigureAwait(false),
+            httpStatusData = await httpTask.ConfigureAwait(false),
+        });
+    }
+}

--- a/AIUsageTracker.Web/Pages/Shared/_Layout.cshtml
+++ b/AIUsageTracker.Web/Pages/Shared/_Layout.cshtml
@@ -42,6 +42,11 @@
                         </a>
                     </li>
                     <li class="nav-item">
+                        <a href="/analytics" class="nav-link @(Context.Request.Path.Value?.Contains("/analytics") == true ? "active" : "")">
+                            <span class="nav-text">Analytics</span>
+                        </a>
+                    </li>
+                    <li class="nav-item">
                         <a href="/providers" class="nav-link @(Context.Request.Path.Value?.Contains("/providers") == true ? "active" : "")">
                             <span class="nav-text">Providers</span>
                         </a>

--- a/AIUsageTracker.Web/Services/WebDatabaseService.cs
+++ b/AIUsageTracker.Web/Services/WebDatabaseService.cs
@@ -313,7 +313,142 @@ public class WebDatabaseService : IWebDatabaseRepository
         return await this.GetTableRawAsync("reset_events", page, pageSize, "timestamp DESC").ConfigureAwait(false);
     }
 
+    public async Task<IReadOnlyList<ModelUsageBreakdown>> GetModelUsageBreakdownAsync(int hours = 168)
+    {
+        var cutoffUtc = DateTime.UtcNow.AddHours(-hours).ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
+
+        const string sql = @"
+            SELECT
+                COALESCE(h.model_name, h.name, h.provider_id) AS ModelName,
+                MIN(p.provider_name) AS ProviderName,
+                COUNT(*) AS SampleCount,
+                SUM(h.requests_used) AS TotalUsed,
+                AVG(h.requests_percentage) AS AvgUsedPercent
+            FROM provider_history h
+            JOIN providers p ON h.provider_id = p.provider_id
+            WHERE h.fetched_at >= @CutoffUtc
+              AND (h.model_name IS NOT NULL OR h.name IS NOT NULL)
+            GROUP BY COALESCE(h.model_name, h.name, h.provider_id)
+            ORDER BY TotalUsed DESC";
+
+        return await this.QueryIfDatabaseAvailableAsync(
+            async connection => (await connection.QueryAsync<ModelUsageBreakdown>(sql, new { CutoffUtc = cutoffUtc }).ConfigureAwait(false)).ToList(),
+            []).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<LatencyDataPoint>> GetLatencyTrendAsync(int hours = 24)
+    {
+        var cutoffUtc = DateTime.UtcNow.AddHours(-hours).ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
+        var bucketSeconds = hours <= 24 ? 60 : hours <= 72 ? 300 : 3600;
+
+        const string sql = @"
+            SELECT
+                h.provider_id AS ProviderId,
+                MIN(p.provider_name) AS ProviderName,
+                datetime((strftime('%s', h.fetched_at) / @BucketSeconds) * @BucketSeconds, 'unixepoch') AS Timestamp,
+                AVG(h.response_latency_ms) AS AvgLatencyMs,
+                MAX(h.response_latency_ms) AS MaxLatencyMs
+            FROM provider_history h
+            JOIN providers p ON h.provider_id = p.provider_id
+            WHERE h.fetched_at >= @CutoffUtc
+              AND h.response_latency_ms > 0
+            GROUP BY h.provider_id, (strftime('%s', h.fetched_at) / @BucketSeconds)
+            ORDER BY Timestamp ASC";
+
+        return await this.QueryDisplayNamedListIfDatabaseAvailableAsync(
+            connection => connection.QueryAsync<LatencyDataPoint>(sql, new { CutoffUtc = cutoffUtc, BucketSeconds = bucketSeconds }),
+            []).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<HttpStatusHistoryPoint>> GetHttpStatusHistoryAsync(int hours = 24)
+    {
+        var cutoffUtc = DateTime.UtcNow.AddHours(-hours).ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
+        var bucketSeconds = hours <= 24 ? 60 : hours <= 72 ? 300 : 3600;
+
+        const string sql = @"
+            SELECT
+                h.provider_id AS ProviderId,
+                MIN(p.provider_name) AS ProviderName,
+                datetime((strftime('%s', h.fetched_at) / @BucketSeconds) * @BucketSeconds, 'unixepoch') AS Timestamp,
+                SUM(CASE WHEN h.http_status >= 200 AND h.http_status < 300 THEN 1 ELSE 0 END) AS SuccessCount,
+                SUM(CASE WHEN h.http_status >= 400 THEN 1 ELSE 0 END) AS ErrorCount,
+                COUNT(*) AS TotalCount
+            FROM provider_history h
+            JOIN providers p ON h.provider_id = p.provider_id
+            WHERE h.fetched_at >= @CutoffUtc
+            GROUP BY h.provider_id, (strftime('%s', h.fetched_at) / @BucketSeconds)
+            ORDER BY Timestamp ASC";
+
+        return await this.QueryDisplayNamedListIfDatabaseAvailableAsync(
+            connection => connection.QueryAsync<HttpStatusHistoryPoint>(sql, new { CutoffUtc = cutoffUtc, BucketSeconds = bucketSeconds }),
+            []).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<DetailsJsonEntry>> GetRecentDetailsJsonAsync(int limit = 20)
+    {
+        const string sql = @"
+            SELECT
+                h.provider_id AS ProviderId,
+                MIN(p.provider_name) AS ProviderName,
+                h.details_json AS DetailsJson,
+                h.fetched_at AS FetchedAt
+            FROM provider_history h
+            JOIN providers p ON h.provider_id = p.provider_id
+            WHERE h.details_json IS NOT NULL
+              AND h.details_json != ''
+              AND h.details_json != '[]'
+              AND h.details_json != '{}'
+            GROUP BY h.provider_id
+            ORDER BY MAX(h.id) DESC
+            LIMIT @Limit";
+
+        return await this.QueryIfDatabaseAvailableAsync(
+            async connection =>
+            {
+                var rows = await connection.QueryAsync<dynamic>(sql, new { Limit = limit }).ConfigureAwait(false);
+                return rows.Select(r => new DetailsJsonEntry
+                {
+                    ProviderId = (string)r.ProviderId,
+                    ProviderName = (string)r.ProviderName,
+                    DetailsJson = (string?)r.DetailsJson ?? string.Empty,
+                    FetchedAt = ParseFetchedAt(r.FetchedAt),
+                }).ToList();
+            },
+            []).ConfigureAwait(false);
+    }
+
     public string GetDatabasePath() => this._connectionFactory.GetDatabasePath();
+
+    private static DateTime ParseFetchedAt(object? value)
+    {
+        if (value == null || value is DBNull)
+        {
+            return DateTime.UtcNow;
+        }
+
+        if (value is DateTime dt)
+        {
+            return dt.Kind == DateTimeKind.Utc ? dt : dt.ToUniversalTime();
+        }
+
+        if (value is long epoch)
+        {
+            return DateTimeOffset.FromUnixTimeSeconds(epoch).UtcDateTime;
+        }
+
+        if (value is double dbl && double.IsFinite(dbl))
+        {
+            return DateTimeOffset.FromUnixTimeSeconds((long)dbl).UtcDateTime;
+        }
+
+        return DateTime.TryParse(
+            Convert.ToString(value, CultureInfo.InvariantCulture),
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+            out var parsed)
+            ? parsed
+            : DateTime.UtcNow;
+    }
 
     private async Task<(IReadOnlyList<IReadOnlyDictionary<string, object?>> Rows, int TotalCount)> GetTableRawAsync(string tableName, int page, int pageSize, string? orderBy = null)
     {

--- a/AIUsageTracker.Web/Services/WebStartupServiceExtensions.cs
+++ b/AIUsageTracker.Web/Services/WebStartupServiceExtensions.cs
@@ -27,6 +27,12 @@ internal static class WebStartupServiceExtensions
                 policy.Expire(TimeSpan.FromSeconds(20));
                 policy.SetVaryByQuery("hours");
             });
+
+            options.AddPolicy("AnalyticsCache", policy =>
+            {
+                policy.Expire(TimeSpan.FromSeconds(20));
+                policy.SetVaryByQuery("hours");
+            });
         });
         services.AddResponseCompression(options =>
         {

--- a/AIUsageTracker.Web/wwwroot/css/site.css
+++ b/AIUsageTracker.Web/wwwroot/css/site.css
@@ -719,3 +719,112 @@ tr:hover { background-color: var(--bg-hover); }
     color: var(--text-secondary);
     padding: 0 0.5rem;
 }
+
+/* Analytics: Model Usage Table */
+.analytics-table-container {
+    overflow-x: auto;
+    margin-bottom: 1.5rem;
+}
+
+.analytics-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.85rem;
+}
+
+.analytics-table th {
+    text-align: left;
+    padding: 0.5rem 0.75rem;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+    color: var(--text-muted);
+    border-bottom: 1px solid var(--border-color);
+}
+
+.analytics-table td {
+    padding: 0.5rem 0.75rem;
+    border-bottom: 1px solid var(--border-color);
+    color: var(--text-secondary);
+}
+
+.analytics-table tr:hover td {
+    background-color: var(--bg-secondary);
+}
+
+.analytics-table .model-name {
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.analytics-table .provider-label {
+    color: var(--text-muted);
+}
+
+.distribution-cell {
+    width: 120px;
+}
+
+.distribution-bar {
+    height: 8px;
+    background-color: var(--bg-primary);
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+.distribution-fill {
+    height: 100%;
+    background-color: var(--accent-success);
+    border-radius: 4px;
+    transition: width 0.3s ease;
+}
+
+/* Analytics: Details JSON Panel */
+.details-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+    gap: 0.75rem;
+    margin-bottom: 1.5rem;
+}
+
+.details-card {
+    background-color: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    overflow: hidden;
+}
+
+.details-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid var(--border-color);
+    background-color: var(--bg-primary);
+}
+
+.details-header .provider-name {
+    font-weight: 600;
+    font-size: 0.9rem;
+}
+
+.details-timestamp {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+}
+
+.details-json-container {
+    max-height: 300px;
+    overflow-y: auto;
+    padding: 0.75rem 1rem;
+}
+
+.details-json {
+    margin: 0;
+    font-family: 'Cascadia Code', 'Fira Code', 'Consolas', monospace;
+    font-size: 0.75rem;
+    line-height: 1.5;
+    color: var(--text-secondary);
+    white-space: pre-wrap;
+    word-break: break-word;
+}


### PR DESCRIPTION
## Changes

New Analytics page (\/analytics) with 4 sections leveraging existing database columns:

1. **Model Usage Breakdown** — per-model usage distribution table from \model_name\/\
ame\ columns
2. **Latency Trend Chart** — Chart.js line chart of \esponse_latency_ms\ over time per provider
3. **HTTP Status History** — Chart.js chart showing 2xx success vs 4xx/5xx error counts over time
4. **Provider Details Panel** — pretty-printed \details_json\ from latest provider snapshots

## Files Changed
- 4 new Core model types (ModelUsageBreakdown, LatencyDataPoint, HttpStatusHistoryPoint, DetailsJsonEntry)
- 4 new query methods on WebDatabaseService with time-bucketed SQL aggregation
- New Analytics.cshtml + Analytics.cshtml.cs Razor page
- AnalyticsCache OutputCache policy (20s TTL, vary by hours)
- HTMX time-range selector for dynamic chart updates
- Sidebar nav link added between Charts and Providers
- CSS for analytics table, distribution bars, and details JSON panel

## Testing
- All 1573 tests pass (1363 + 160 + 46)
- Build succeeds with 0 errors

Closes: task-44 (Cycle 15)