### PR TITLE
Release v2.3.6-beta.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+## [2.3.6-beta.4] - 2026-06-11
+
+### Added
+- **Web Analytics page** (`/analytics`): new page with 4 analytics sections — Model Usage Breakdown (per-model distribution table), Latency Trend Chart (response_latency_ms over time), HTTP Status History (2xx vs 4xx/5xx over time), and Provider Details Panel (pretty-printed details_json from latest snapshots).
+- **Test Connection button**: Settings UI now has a Test button that calls `POST /api/providers/{providerId}/test` to verify API key connectivity.
+- **Descriptive error states**: `ProviderBase` auto-attaches `HttpFailureContext` in all error paths; UI reads `FailureContext.Classification` for actionable messages (rate-limited, auth-failed, unreachable, etc.).
+- **Provider health indicators**: `FetchedAt` relative time badge on provider cards showing data freshness.
+- **Minimax API provider**: new provider with credit-based quota windows.
+
+### Changed
+- **Migrated to .NET 10**: all projects now target `net10.0`. CI/CD workflows, PowerShell scripts, and `global.json` updated for SDK 10.0.300.
+- **Fixed `IsNewerVersion` for `-develop` suffix**: `ParseAppVersion` now strips non-numeric suffix from beta number before parsing.
+- **Added `/api/providers/{providerId}/test` to OpenAPI contract**: pre-existing endpoint gap.
+
 ## [2.3.6-beta.1] - 2026-06-06
 
 ### Fixed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TrackerVersion>2.3.6-beta.1</TrackerVersion>
+    <TrackerVersion>2.3.6-beta.4</TrackerVersion>
     <TrackerAssemblyVersion>2.3.6</TrackerAssemblyVersion>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(MSBuildProjectDirectory)\artifacts\**\*</DefaultItemExcludes>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="AIUsageTracker.Web/wwwroot/favicon.png" width="32" height="32" valign="middle"> AI Usage Tracker
 
-![Version](https://img.shields.io/badge/version-2.3.6--beta.1-orange)
+![Version](https://img.shields.io/badge/version-2.3.6--beta.4-orange)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Platforms](https://img.shields.io/badge/platforms-Windows%20|%20Linux%20-blue)
 ![Language](https://img.shields.io/badge/language-C%23%20|%20.NET-purple)

--- a/scripts/publish-app.ps1
+++ b/scripts/publish-app.ps1
@@ -6,7 +6,7 @@ param(
 )
 
 # AI Usage Tracker - Distribution Packaging Script
-# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.3.6-beta.1 -InstallerCompression balanced
+# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.3.6-beta.4 -InstallerCompression balanced
 
 $isWinPlatform = $Runtime.StartsWith("win-")
 $projectName = if ($isWinPlatform) { "AIUsageTracker" } else { "AIUsageTracker.CLI" }

--- a/scripts/setup.iss
+++ b/scripts/setup.iss
@@ -1,7 +1,7 @@
 ; AI Usage Tracker - Inno Setup Script
 
 #ifndef MyAppVersion
-  #define MyAppVersion "2.3.6-beta.1"
+  #define MyAppVersion "2.3.6-beta.4"
 #endif
 #ifndef SourcePath
   #define SourcePath "..\dist\publish-win-x64"


### PR DESCRIPTION
Beta release for .NET 10 migration testing.

## Changes since v2.3.6-beta.3
- Web Analytics page with per-model breakdown, latency trends, HTTP status history, details panel
- Test Connection button in Settings UI
- Descriptive error states with actionable failure context
- Provider health indicators (FetchedAt freshness badges)
- Minimax API provider
- .NET 10 migration (all projects, CI/CD, scripts)
- IsNewerVersion fix for -develop suffix
- OpenAPI contract gap fix

## Version
- Directory.Build.props: 2.3.6-beta.4
- Target framework: net10.0