### PR TITLE
feat: ProviderDefinition value-based equality (task-36)

### DIFF
--- a/AIUsageTracker.Core/Models/ProviderDefinition.cs
+++ b/AIUsageTracker.Core/Models/ProviderDefinition.cs
@@ -4,7 +4,7 @@
 
 namespace AIUsageTracker.Core.Models;
 
-public sealed class ProviderDefinition
+public sealed class ProviderDefinition : IEquatable<ProviderDefinition>
 {
     private HashSet<string>? _handledProviderIdsSet;
 
@@ -191,4 +191,35 @@ public sealed class ProviderDefinition
             Description = description,
         };
     }
+
+    public bool Equals(ProviderDefinition? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        return string.Equals(this.ProviderId, other.ProviderId, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public override bool Equals(object? obj) => this.Equals(obj as ProviderDefinition);
+
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(this.ProviderId);
+
+    public static bool operator ==(ProviderDefinition? left, ProviderDefinition? right)
+    {
+        if (left is null)
+        {
+            return right is null;
+        }
+
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(ProviderDefinition? left, ProviderDefinition? right) => !(left == right);
 }


### PR DESCRIPTION
Cycle 16 task-36: Add IEquatable<ProviderDefinition> with value-based equality keyed on ProviderId.

- Properties were already immutable (constructor-required + init-only)
- Lazy cache field (_handledProviderIdsSet) ruled out record conversion
- Equality based on ProviderId per AGENTS.md: provider definitions are immutable per provider ID
- 1360 tests pass (1 pre-existing failure unrelated)