### PR TITLE
refactor: add CreateBaseUsage helper and migrate 4 providers

### DIFF
--- a/AIUsageTracker.Core/Providers/ProviderBase.cs
+++ b/AIUsageTracker.Core/Providers/ProviderBase.cs
@@ -71,6 +71,23 @@ public abstract class ProviderBase : IProviderService
         return JsonSerializer.Deserialize<T>(content, JsonOptions);
     }
 
+    protected ProviderUsage CreateBaseUsage(
+        string providerLabel,
+        string? rawJson = null,
+        int httpStatus = 0)
+    {
+        return new ProviderUsage
+        {
+            ProviderId = this.ProviderId,
+            ProviderName = providerLabel,
+            IsAvailable = true,
+            PlanType = this.Definition.PlanType,
+            IsQuotaBased = this.Definition.IsQuotaBased,
+            RawJson = rawJson,
+            HttpStatus = httpStatus,
+        };
+    }
+
     protected ProviderUsage CreateUnavailableUsage(
         string description,
         int httpStatus = 0,

--- a/AIUsageTracker.Infrastructure/Providers/DeepSeekProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/DeepSeekProvider.cs
@@ -89,23 +89,12 @@ public class DeepSeekProvider : ProviderBase
 
         if (result.BalanceInfos == null || result.BalanceInfos.Count == 0)
         {
-            return new[]
-            {
-                new ProviderUsage
-                {
-                    ProviderId = this.ProviderId,
-                    ProviderName = providerLabel,
-                    IsAvailable = true,
-                    UsedPercent = 0,
-                    RequestsUsed = 0,
-                    RequestsAvailable = 0,
-                    IsQuotaBased = this.Definition.IsQuotaBased,
-                    PlanType = this.Definition.PlanType,
-                    Description = "No balance found",
-                    RawJson = content,
-                    HttpStatus = httpStatus,
-                },
-            };
+            var noBalance = this.CreateBaseUsage(providerLabel, content, httpStatus);
+            noBalance.UsedPercent = 0;
+            noBalance.RequestsUsed = 0;
+            noBalance.RequestsAvailable = 0;
+            noBalance.Description = "No balance found";
+            return new[] { noBalance };
         }
 
         var flatCards = new List<ProviderUsage>();
@@ -113,22 +102,14 @@ public class DeepSeekProvider : ProviderBase
         {
             var currencyCode = info.Currency ?? "USD";
             var currencySymbol = string.Equals(currencyCode, "CNY", StringComparison.OrdinalIgnoreCase) ? "¥" : "$";
-            flatCards.Add(new ProviderUsage
-            {
-                ProviderId = this.ProviderId,
-                ProviderName = providerLabel,
-                Name = $"Balance ({currencyCode})",
-                CardId = $"balance-{currencyCode.ToLowerInvariant()}",
-                GroupId = this.ProviderId,
-                Description = string.Format(CultureInfo.InvariantCulture, "{0}{1:F2} ({2:F2} topped-up + {3:F2} granted)", currencySymbol, info.TotalBalance, info.ToppedUpBalance, info.GrantedBalance),
-                IsAvailable = true,
-                PlanType = this.Definition.PlanType,
-                IsCurrencyUsage = true,
-                IsQuotaBased = this.Definition.IsQuotaBased,
-                UsedPercent = 0,
-                RawJson = content,
-                HttpStatus = httpStatus,
-            });
+            var card = this.CreateBaseUsage(providerLabel, content, httpStatus);
+            card.Name = $"Balance ({currencyCode})";
+            card.CardId = $"balance-{currencyCode.ToLowerInvariant()}";
+            card.GroupId = this.ProviderId;
+            card.Description = string.Format(CultureInfo.InvariantCulture, "{0}{1:F2} ({2:F2} topped-up + {3:F2} granted)", currencySymbol, info.TotalBalance, info.ToppedUpBalance, info.GrantedBalance);
+            card.IsCurrencyUsage = true;
+            card.UsedPercent = 0;
+            flatCards.Add(card);
         }
 
         return flatCards;

--- a/AIUsageTracker.Infrastructure/Providers/KimiProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/KimiProvider.cs
@@ -106,24 +106,13 @@ public class KimiProvider : ProviderBase
 
         if (flatCards.Count == 0)
         {
-            return new[]
-            {
-                new ProviderUsage
-                {
-                    ProviderId = this.ProviderId,
-                    ProviderName = providerLabel,
-                    UsedPercent = data.Usage!.Limit > 0 ? UsageMath.CalculateUsedPercent(data.Usage!.Used, data.Usage!.Limit) : 0,
-                    RequestsUsed = data.Usage!.Used,
-                    RequestsAvailable = data.Usage!.Limit,
-                    IsQuotaBased = this.Definition.IsQuotaBased,
-                    PlanType = this.Definition.PlanType,
-                    IsAvailable = true,
-                    Description = "Active",
-                    RawJson = content,
-                    HttpStatus = statusCode,
-                    AuthSource = authSource ?? string.Empty,
-                },
-            };
+            var fallback = this.CreateBaseUsage(providerLabel, content, statusCode);
+            fallback.UsedPercent = data.Usage!.Limit > 0 ? UsageMath.CalculateUsedPercent(data.Usage!.Used, data.Usage!.Limit) : 0;
+            fallback.RequestsUsed = data.Usage!.Used;
+            fallback.RequestsAvailable = data.Usage!.Limit;
+            fallback.Description = "Active";
+            fallback.AuthSource = authSource ?? string.Empty;
+            return new[] { fallback };
         }
 
         return flatCards;
@@ -144,27 +133,19 @@ public class KimiProvider : ProviderBase
             weeklyResetDt = weeklyDt.ToUniversalTime();
         }
 
-        return new ProviderUsage
-        {
-            ProviderId = this.ProviderId,
-            ProviderName = providerLabel,
-            CardId = "weekly",
-            GroupId = this.ProviderId,
-            Name = "Weekly Limit",
-            WindowKind = WindowKind.Rolling,
-            UsedPercent = weeklyUsedPct,
-            RequestsUsed = usage.Used,
-            RequestsAvailable = usage.Limit,
-            IsQuotaBased = this.Definition.IsQuotaBased,
-            PlanType = this.Definition.PlanType,
-            IsAvailable = true,
-            Description = $"{usage.Remaining.ToString(CultureInfo.InvariantCulture)} remaining{(!string.IsNullOrEmpty(usage.ResetTime) ? $" (Resets: {FormatResetTime(usage.ResetTime)})" : string.Empty)}",
-            RawJson = content,
-            HttpStatus = statusCode,
-            NextResetTime = weeklyResetDt,
-            PeriodDuration = TimeSpan.FromDays(7),
-            AuthSource = authSource ?? string.Empty,
-        };
+        var weekly = this.CreateBaseUsage(providerLabel, content, statusCode);
+        weekly.CardId = "weekly";
+        weekly.GroupId = this.ProviderId;
+        weekly.Name = "Weekly Limit";
+        weekly.WindowKind = WindowKind.Rolling;
+        weekly.UsedPercent = weeklyUsedPct;
+        weekly.RequestsUsed = usage.Used;
+        weekly.RequestsAvailable = usage.Limit;
+        weekly.Description = $"{usage.Remaining.ToString(CultureInfo.InvariantCulture)} remaining{(!string.IsNullOrEmpty(usage.ResetTime) ? $" (Resets: {FormatResetTime(usage.ResetTime)})" : string.Empty)}";
+        weekly.NextResetTime = weeklyResetDt;
+        weekly.PeriodDuration = TimeSpan.FromDays(7);
+        weekly.AuthSource = authSource ?? string.Empty;
+        return weekly;
     }
 
     private void AddLimitCards(List<KimiLimitItem> limits, List<ProviderUsage> flatCards, HashSet<string> usedCardIds, string content, int statusCode, string? authSource, string providerLabel)
@@ -209,27 +190,19 @@ public class KimiProvider : ProviderBase
         var periodDuration = ResolvePeriodDuration(quotaBucketKind, win);
         var cardId = DeduplicateCardId(name, usedCardIds);
 
-        return new ProviderUsage
-        {
-            ProviderId = this.ProviderId,
-            ProviderName = providerLabel,
-            CardId = cardId,
-            GroupId = this.ProviderId,
-            Name = name,
-            WindowKind = quotaBucketKind,
-            UsedPercent = itemUsedPercentage,
-            RequestsUsed = itemUsed,
-            RequestsAvailable = det.Limit,
-            IsQuotaBased = this.Definition.IsQuotaBased,
-            PlanType = this.Definition.PlanType,
-            IsAvailable = true,
-            Description = $"{det.Remaining.ToString(CultureInfo.InvariantCulture)} / {det.Limit.ToString(CultureInfo.InvariantCulture)} remaining (Resets: {resetDisplay})",
-            RawJson = content,
-            HttpStatus = statusCode,
-            NextResetTime = itemResetDt,
-            PeriodDuration = periodDuration,
-            AuthSource = authSource ?? string.Empty,
-        };
+        var limit = this.CreateBaseUsage(providerLabel, content, statusCode);
+        limit.CardId = cardId;
+        limit.GroupId = this.ProviderId;
+        limit.Name = name;
+        limit.WindowKind = quotaBucketKind;
+        limit.UsedPercent = itemUsedPercentage;
+        limit.RequestsUsed = itemUsed;
+        limit.RequestsAvailable = det.Limit;
+        limit.Description = $"{det.Remaining.ToString(CultureInfo.InvariantCulture)} / {det.Limit.ToString(CultureInfo.InvariantCulture)} remaining (Resets: {resetDisplay})";
+        limit.NextResetTime = itemResetDt;
+        limit.PeriodDuration = periodDuration;
+        limit.AuthSource = authSource ?? string.Empty;
+        return limit;
     }
 
     private static string DeduplicateCardId(string name, HashSet<string> usedCardIds)

--- a/AIUsageTracker.Infrastructure/Providers/MistralProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/MistralProvider.cs
@@ -71,23 +71,15 @@ public class MistralProvider : ProviderBase
             var response = await this._httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
             var content = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 
-            return response.IsSuccessStatusCode
-                ? new[]
-                {
-                    new ProviderUsage
-                    {
-                        ProviderId = this.ProviderId,
-                        ProviderName = providerLabel,
-                        IsAvailable = true,
-                        UsedPercent = 0,
-                        IsQuotaBased = this.Definition.IsQuotaBased,
-                        PlanType = this.Definition.PlanType,
-                        Description = "Connected (Check Dashboard)",
-                        RawJson = content,
-                        HttpStatus = (int)response.StatusCode,
-                    },
-                }
-                : new[] { this.CreateUnavailableUsage(DescribeUnavailableStatus(response.StatusCode), (int)response.StatusCode) };
+            if (response.IsSuccessStatusCode)
+            {
+                var usage = this.CreateBaseUsage(providerLabel, content, (int)response.StatusCode);
+                usage.UsedPercent = 0;
+                usage.Description = "Connected (Check Dashboard)";
+                return new[] { usage };
+            }
+
+            return new[] { this.CreateUnavailableUsage(DescribeUnavailableStatus(response.StatusCode), (int)response.StatusCode) };
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or JsonException)
         {

--- a/AIUsageTracker.Infrastructure/Providers/XiaomiProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/XiaomiProvider.cs
@@ -82,25 +82,14 @@ public class XiaomiProvider : ProviderBase
         var used = quota > 0 ? Math.Max(0, quota - balance) : 0;
         var usedPercent = quota > 0 ? UsageMath.CalculateUsedPercent(used, quota) : 0;
 
-        return new[]
-        {
-            new ProviderUsage
-            {
-                ProviderId = config.ProviderId,
-                ProviderName = providerLabel,
-                UsedPercent = usedPercent,
-                RequestsUsed = used,
-                RequestsAvailable = quota > 0 ? quota : balance,
-                IsQuotaBased = this.Definition.IsQuotaBased,
-                PlanType = this.Definition.PlanType,
-                IsAvailable = true,
-                Description = quota > 0
-                    ? $"{balance.ToString(CultureInfo.InvariantCulture)} remaining / {quota.ToString(CultureInfo.InvariantCulture)} total"
-                    : $"Balance: {balance.ToString(CultureInfo.InvariantCulture)}",
-                RawJson = content,
-                HttpStatus = httpStatus,
-            },
-        };
+        var usage = this.CreateBaseUsage(providerLabel, content, httpStatus);
+        usage.UsedPercent = usedPercent;
+        usage.RequestsUsed = used;
+        usage.RequestsAvailable = quota > 0 ? quota : balance;
+        usage.Description = quota > 0
+            ? $"{balance.ToString(CultureInfo.InvariantCulture)} remaining / {quota.ToString(CultureInfo.InvariantCulture)} total"
+            : $"Balance: {balance.ToString(CultureInfo.InvariantCulture)}";
+        return new[] { usage };
     }
 
     private sealed class XiaomiResponse


### PR DESCRIPTION
## Summary

- Add \CreateBaseUsage()\ helper to \ProviderBase\ for success-case \ProviderUsage\ creation, complementing the existing \CreateUnavailableUsage()\
- Sets common fields: \ProviderId\, \ProviderName\, \IsAvailable\, \PlanType\, \IsQuotaBased\, \RawJson\, \HttpStatus\
- Migrate 4 providers (7 creation sites) to use the helper:
  - **Mistral** (1 site)
  - **DeepSeek** (2 sites)
  - **Xiaomi** (1 site)
  - **Kimi** (3 sites)

## Changes

- **Net reduction**: -48 lines of repeated property initialization
- Part of infrastructure audit findings (task-51 / finding F1 from \docs/research/infrastructure-audit-findings.md\)
- 1361 tests pass, 0 failures

## Test plan

- [x] \dotnet build\ -- 0 errors
- [x] \dotnet test\ -- 1361 passed, 0 failed
- [ ] CI pipeline passes