### PR TITLE
refactor: cycle 18 Infrastructure - remove dead dependency and constructor

### DIFF
--- a/AIUsageTracker.Infrastructure/AIUsageTracker.Infrastructure.csproj
+++ b/AIUsageTracker.Infrastructure/AIUsageTracker.Infrastructure.csproj
@@ -4,7 +4,6 @@
     <PackageReference Include="Dapper" Version="2.1.72" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.5" />
-    <PackageReference Include="System.Drawing.Common" Version="10.0.5" />
     <PackageReference Include="NetSparkleUpdater.SparkleUpdater" Version="3.0.4" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />

--- a/AIUsageTracker.Web/Services/MonitorProcessService.cs
+++ b/AIUsageTracker.Web/Services/MonitorProcessService.cs
@@ -18,15 +18,7 @@ public class MonitorProcessService
     private readonly IMonitorService _monitorService;
     private readonly IMonitorLauncherClient _monitorLauncherClient;
 
-    public MonitorProcessService(ILogger<MonitorProcessService> logger, IMonitorService monitorService)
-        : this(logger, monitorService, new MonitorLauncherClient(new MonitorLauncher(Microsoft.Extensions.Logging.Abstractions.NullLogger<MonitorLauncher>.Instance)))
-    {
-    }
-
-    public MonitorProcessService(
-        ILogger<MonitorProcessService> logger,
-        IMonitorService monitorService,
-        IMonitorLauncherClient monitorLauncherClient)
+    public MonitorProcessService(ILogger<MonitorProcessService> logger, IMonitorService monitorService, IMonitorLauncherClient monitorLauncherClient)
     {
         this._logger = logger;
         this._monitorService = monitorService;


### PR DESCRIPTION
Cycle 18 Lean Code Sweep (Infrastructure tasks).

Changes:
- Remove dead System.Drawing.Common NuGet reference from Infrastructure.csproj (zero usage)
- Remove dead default constructor in MonitorProcessService that bypassed DI

Verified with dotnet build + dotnet test.