### PR TITLE
refactor: deduplicate architecture normalization, replace fake generic ParseValue

### DIFF
--- a/AIUsageTracker.Infrastructure/Providers/OpenCodeZenProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/OpenCodeZenProvider.cs
@@ -183,8 +183,7 @@ public class OpenCodeZenProvider : ProviderBase
             : 0;
     }
 
-    private static T ParseValue<T>(string input, string pattern)
-        where T : struct
+    private static int ParseInt(string input, string pattern)
     {
         var match = Regex.Match(
             input,
@@ -194,20 +193,26 @@ public class OpenCodeZenProvider : ProviderBase
         if (match.Success && match.Groups.Count > 1)
         {
             var valueText = match.Groups[1].Value.Replace(",", string.Empty, StringComparison.Ordinal);
-            if (typeof(T) == typeof(double) &&
-                double.TryParse(valueText, NumberStyles.Any, CultureInfo.InvariantCulture, out var doubleValue))
-            {
-                return (T)(object)doubleValue;
-            }
-
-            if (typeof(T) == typeof(int) &&
-                int.TryParse(valueText, NumberStyles.Any, CultureInfo.InvariantCulture, out var intValue))
-            {
-                return (T)(object)intValue;
-            }
+            return int.TryParse(valueText, NumberStyles.Any, CultureInfo.InvariantCulture, out var result) ? result : 0;
         }
 
-        return default;
+        return 0;
+    }
+
+    private static double ParseDouble(string input, string pattern)
+    {
+        var match = Regex.Match(
+            input,
+            pattern,
+            RegexOptions.CultureInvariant | RegexOptions.NonBacktracking,
+            TimeSpan.FromSeconds(1));
+        if (match.Success && match.Groups.Count > 1)
+        {
+            var valueText = match.Groups[1].Value.Replace(",", string.Empty, StringComparison.Ordinal);
+            return double.TryParse(valueText, NumberStyles.Any, CultureInfo.InvariantCulture, out var result) ? result : 0;
+        }
+
+        return 0;
     }
 
     private static string FormatTokens(double tokens)
@@ -295,7 +300,7 @@ public class OpenCodeZenProvider : ProviderBase
         {
             if (line.StartsWith("Messages", StringComparison.OrdinalIgnoreCase))
             {
-                entry.Messages = ParseValue<int>(line, @"Messages\s+([0-9,]+)");
+                entry.Messages = ParseInt(line, @"Messages\s+([0-9,]+)");
             }
             else if (line.StartsWith("Input Tokens", StringComparison.OrdinalIgnoreCase))
             {
@@ -311,7 +316,7 @@ public class OpenCodeZenProvider : ProviderBase
             }
             else if (line.StartsWith("Cost", StringComparison.OrdinalIgnoreCase))
             {
-                entry.Cost = ParseValue<double>(line, @"Cost\s+\$([0-9.]+)");
+                entry.Cost = ParseDouble(line, @"Cost\s+\$([0-9.]+)");
             }
         }
 
@@ -545,17 +550,17 @@ public class OpenCodeZenProvider : ProviderBase
         var cleaned = CleanAnsiOutput(output);
 
         // Overview
-        var totalCost = ParseValue<double>(cleaned, @"Total Cost\s+\$([0-9.]+)");
-        var sessions = ParseValue<int>(cleaned, @"Sessions\s+([0-9,]+)");
-        var messages = ParseValue<int>(cleaned, @"Messages\s+([0-9,]+)");
-        var days = ParseValue<int>(cleaned, @"Days\s+(\d+)");
+        var totalCost = ParseDouble(cleaned, @"Total Cost\s+\$([0-9.]+)");
+        var sessions = ParseInt(cleaned, @"Sessions\s+([0-9,]+)");
+        var messages = ParseInt(cleaned, @"Messages\s+([0-9,]+)");
+        var days = ParseInt(cleaned, @"Days\s+(\d+)");
 
         // Token summary
         // Use [0-9.,KMB] without T — "Input Tokens" in model blocks won't match because
         // 'T' in "Tokens" isn't in the char class, so only the summary "Input 8.4M" matches.
         var inputTokens = ExtractTokenCount(cleaned, @"Input\s+([0-9.,KMB]+)");
         var outputTokens = ExtractTokenCount(cleaned, @"Output\s+([0-9.,KMB]+)");
-        var avgCostPerDay = ParseValue<double>(cleaned, @"Avg Cost/Day\s+\$([0-9.]+)");
+        var avgCostPerDay = ParseDouble(cleaned, @"Avg Cost/Day\s+\$([0-9.]+)");
 
         // Breakdowns
         var models = ParseModelUsage(cleaned);

--- a/AIUsageTracker.Infrastructure/Services/GitHubUpdateChecker.cs
+++ b/AIUsageTracker.Infrastructure/Services/GitHubUpdateChecker.cs
@@ -389,23 +389,7 @@ public class GitHubUpdateChecker
 
     private string GetAppcastUrlForCurrentArchitecture()
     {
-        var currentArch = System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture.ToString().ToLower(System.Globalization.CultureInfo.InvariantCulture);
-
-        var archMapping = new Dictionary<string, string>(StringComparer.Ordinal)
-        {
-            [ArchX64] = ArchX64,
-            [ArchX86] = ArchX86,
-            [ArchArm64] = ArchArm64,
-            [ArchArm] = ArchArm64,
-        };
-
-        var targetArch = archMapping.GetValueOrDefault(currentArch, ArchX64);
-
-        if (!archMapping.ContainsKey(currentArch))
-        {
-            this._logger.LogWarning("Unknown architecture {Architecture}, falling back to x64", currentArch);
-        }
-
+        var targetArch = GetCurrentArchitectureName();
         var url = GetAppcastUrl(targetArch, this._channel == UpdateChannel.Beta);
         this._logger.LogDebug("Using appcast for architecture {Architecture} ({Channel}): {Url}", targetArch, this._channel, url);
         return url;


### PR DESCRIPTION
Cycle 18 Lean Code Sweep continuation.

Changes (2 files, -11 net lines):
- task-78: GetAppcastUrlForCurrentArchitecture now calls GetCurrentArchitectureName instead of maintaining duplicate dictionary mapping
- task-79: Replace fake generic ParseValue<T> (runtime type-checking, (T)(object) casts) with typed ParseInt/ParseDouble methods

Verified: build 0 errors, 1366 tests pass, 0 failures.