### PR TITLE
refactor: remove 21 code-restating comments across UI files

### DIFF
--- a/AIUsageTracker.UI.Slim/MainWindow.Rendering.cs
+++ b/AIUsageTracker.UI.Slim/MainWindow.Rendering.cs
@@ -169,7 +169,6 @@ public partial class MainWindow : Window
 
         var header = this.CreateCollapsibleHeaderGrid(margin);
 
-        // Toggle button
         var toggleText = this.CreateText(
             getCollapsed() ? "\u25B6" : "\u25BC",
             toggleFontSize,
@@ -180,7 +179,6 @@ public partial class MainWindow : Window
         toggleText.Opacity = toggleOpacity;
         toggleText.Tag = "ToggleIcon";
 
-        // Title
         var titleBlock = this.CreateText(
             titleText,
             10.0,
@@ -189,10 +187,8 @@ public partial class MainWindow : Window
             new Thickness(0, 0, 10, 0));
         titleBlock.VerticalAlignment = VerticalAlignment.Center;
 
-        // Separator line
         var line = this.CreateSeparator(accent, lineOpacity);
 
-        // Container
         var container = new StackPanel();
         if (!string.IsNullOrEmpty(groupKey))
         {
@@ -201,7 +197,6 @@ public partial class MainWindow : Window
 
         container.Visibility = getCollapsed() ? Visibility.Collapsed : Visibility.Visible;
 
-        // Click handler
         header.Cursor = System.Windows.Input.Cursors.Hand;
         header.MouseLeftButtonDown += this.CreateHeaderClickHandler(getCollapsed, setCollapsed, container, toggleText);
 
@@ -271,7 +266,6 @@ public partial class MainWindow : Window
                 continue;
             }
 
-            // Collect all cards in this group
             var groupCards = new List<ProviderUsage>();
             while (i < usages.Count && string.Equals(usages[i].GroupId, groupId, StringComparison.OrdinalIgnoreCase))
             {
@@ -422,7 +416,6 @@ public partial class MainWindow : Window
             this.StatusText.Text = effectiveMessage;
         }
 
-        // Update LED color
         if (this.StatusLed != null)
         {
             this.StatusLed.Fill = indicatorKind switch

--- a/AIUsageTracker.UI.Slim/SettingsWindow.Cards.cs
+++ b/AIUsageTracker.UI.Slim/SettingsWindow.Cards.cs
@@ -56,7 +56,6 @@ public partial class SettingsWindow
 
         this.PopulateCardSlotOptions();
 
-        // Load saved slot configuration from preferences
         this.PrimaryBadgeSlot.SelectedValue = this._preferences.CardPrimaryBadge;
         this.SecondaryBadgeSlot.SelectedValue = this._preferences.CardSecondaryBadge;
         this.StatusLineSlot.SelectedValue = this._preferences.CardStatusLine;

--- a/AIUsageTracker.UI.Slim/SettingsWindow.Monitor.cs
+++ b/AIUsageTracker.UI.Slim/SettingsWindow.Monitor.cs
@@ -20,10 +20,8 @@ public partial class SettingsWindow
     {
         try
         {
-            // Check if agent is running
             var isRunning = await this._monitorLifecycleService.IsAgentRunningAsync().ConfigureAwait(true);
 
-            // Get the actual port from the agent
             int port = await this._monitorLifecycleService.GetAgentPortAsync().ConfigureAwait(true);
 
             if (this.MonitorStatusText != null)
@@ -31,7 +29,6 @@ public partial class SettingsWindow
                 this.MonitorStatusText.Text = isRunning ? "Running" : "Not Running";
             }
 
-            // Update port display
             if (this.FindName("MonitorPortText") is TextBlock portText)
             {
                 portText.Text = port.ToString(System.Globalization.CultureInfo.InvariantCulture);
@@ -92,7 +89,6 @@ public partial class SettingsWindow
     {
         try
         {
-            // Kill any running agent process
             foreach (var process in System.Diagnostics.Process.GetProcessesByName("AIUsageTracker.Monitor")
                 .Concat(System.Diagnostics.Process.GetProcessesByName("AIUsageTracker.Monitor")))
             {
@@ -108,7 +104,6 @@ public partial class SettingsWindow
 
             await Task.Delay(1000).ConfigureAwait(true);
 
-            // Restart agent
             if (await this._monitorLifecycleService.EnsureAgentRunningAsync().ConfigureAwait(true))
             {
                 MessageBox.Show(

--- a/AIUsageTracker.UI.Slim/SettingsWindow.Providers.cs
+++ b/AIUsageTracker.UI.Slim/SettingsWindow.Providers.cs
@@ -717,7 +717,6 @@ public partial class SettingsWindow
 
         var panel = new StackPanel { Margin = new Thickness(0, 4, 0, 0) };
 
-        // Source line
         var sourceLine = new TextBlock
         {
             FontSize = 9,

--- a/AIUsageTracker.UI.Slim/SettingsWindow.xaml.cs
+++ b/AIUsageTracker.UI.Slim/SettingsWindow.xaml.cs
@@ -520,7 +520,6 @@ public partial class SettingsWindow : Window
         this.YellowThreshold.Text = this._preferences.ColorThresholdYellow.ToString(System.Globalization.CultureInfo.InvariantCulture);
         this.RedThreshold.Text = this._preferences.ColorThresholdRed.ToString(System.Globalization.CultureInfo.InvariantCulture);
 
-        // Font settings
         this.PopulateFontComboBox();
         this.FontFamilyCombo.SelectedItem = this._preferences.FontFamily;
         this.FontSizeBox.Text = this._preferences.FontSize.ToString(System.Globalization.CultureInfo.InvariantCulture);
@@ -635,19 +634,15 @@ public partial class SettingsWindow : Window
             return;
         }
 
-        // Update font family
         if (!string.IsNullOrEmpty(this._preferences.FontFamily))
         {
             this.FontPreviewText.FontFamily = new System.Windows.Media.FontFamily(this._preferences.FontFamily);
         }
 
-        // Update font size
         this.FontPreviewText.FontSize = this._preferences.FontSize > 0 ? this._preferences.FontSize : 12;
 
-        // Update font weight
         this.FontPreviewText.FontWeight = this._preferences.FontBold ? FontWeights.Bold : FontWeights.Normal;
 
-        // Update font style
         this.FontPreviewText.FontStyle = this._preferences.FontItalic ? FontStyles.Italic : FontStyles.Normal;
     }
 
@@ -756,13 +751,11 @@ public partial class SettingsWindow : Window
     {
         try
         {
-            // Trigger refresh on agent
             await this._monitorService.TriggerRefreshAsync().ConfigureAwait(true);
 
             // Wait a moment for refresh to complete
             await Task.Delay(2000).ConfigureAwait(true);
 
-            // Reload data
             await this.LoadDataAsync().ConfigureAwait(true);
 
             MessageBox.Show(


### PR DESCRIPTION
Cycle 18 Lean Code Sweep - task-85.

Removed 21 comments that simply restated the code below them (e.g., '// Title' before 'var titleBlock =', '// Update LED color' before 'StatusLed.Fill = ...'). No architectural or WHY context lost.

Files (5 files, -21 lines):
- SettingsWindow.xaml.cs: 7 comments
- SettingsWindow.Providers.cs: 1 comment
- SettingsWindow.Monitor.cs: 5 comments
- SettingsWindow.Cards.cs: 1 comment
- MainWindow.Rendering.cs: 7 comments

Verified: build 0 errors, 1365 tests pass, 0 failures.