### PR TITLE
release: v2.3.6-beta.6 (cycle 19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [2.3.6-beta.6] - 2026-06-12
+
+### Fixed
+- **ParseAppVersion `-develop` suffix**: `int.TryParse` failed on pre-release numbers like `"5-develop"`, defaulting `preRelease` to 0 and breaking version comparison. Now strips non-numeric suffixes before parsing.
+
+### Changed
+- **MonitorClient namespace split**: Process/HTTP types (`MonitorLauncher`, `MonitorLauncherProcessController`, `MonitorLifecycleService`, `MonitorService`) moved from `Core.MonitorClient` to `Infrastructure.MonitorClient`. DTO/snapshot types remain in Core.
+- **Collapsed unnecessary interfaces**: Removed `IPreferencesStore`, `IUsageAnalyticsService`, and `IMonitorLauncher` — single-implementation interfaces with no test mocking. Consumers now use concrete types directly.
+- **Deleted dead scaffolded types**: Removed `PercentageValueSemantic`, `BudgetPolicy`, and `ProviderResponseException` — 59 lines of unused code.
+
 ## v2.3.6-beta.5-develop — 2026-06-12
 
 - 9d9f2132 release: v2.3.6-beta.5 (#643)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TrackerVersion>2.3.6-beta.5</TrackerVersion>
+    <TrackerVersion>2.3.6-beta.6</TrackerVersion>
     <TrackerAssemblyVersion>2.3.6</TrackerAssemblyVersion>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(MSBuildProjectDirectory)\artifacts\**\*</DefaultItemExcludes>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>


### PR DESCRIPTION
Beta release for cycle 19.

**Changes:**
- task-88: Fix ParseAppVersion to strip non-numeric suffix from beta numbers
- task-89: Delete 3 dead scaffolded types (59 lines removed)
- task-61: Collapse unnecessary single-implementation interfaces (99 lines removed)
- task-75: Move MonitorClient process/HTTP types to Infrastructure namespace

**Version bump:** 2.3.6-beta.5 -> 2.3.6-beta.6