### PR TITLE
Add spending summary, sparklines, and terminal title

### DIFF
--- a/AIUsageTracker.Monitor/Program.cs
+++ b/AIUsageTracker.Monitor/Program.cs
@@ -27,6 +27,14 @@ public partial class Program
     public static async Task Main(string[] args)
     {
         bool isDebugMode = args.Contains("--debug", StringComparer.Ordinal);
+
+        try
+        {
+            Console.Title = "AI Usage Tracker - Monitor";
+        }
+        catch (PlatformNotSupportedException) { }
+        catch (System.IO.IOException) { }
+
         IAppPathProvider pathProvider = new DefaultAppPathProvider();
         var holdsStartupMutex = false;
 

--- a/AIUsageTracker.Web/Pages/Index.cshtml
+++ b/AIUsageTracker.Web/Pages/Index.cshtml
@@ -38,6 +38,32 @@
             var visibleUsage = (Model.LatestUsage ?? new List<AIUsageTracker.Core.Models.ProviderUsage>())
                 .Where(u => Model.ShowInactiveProviders || u.IsAvailable)
                 .ToList();
+
+            var currencyProviders = visibleUsage.Where(u => u.IsCurrencyUsage && u.IsAvailable).ToList();
+            var totalSpent = currencyProviders.Sum(u => u.RequestsUsed);
+            var totalBudget = currencyProviders.Sum(u => u.RequestsAvailable);
+            var spentPercent = totalBudget > 0 ? (totalSpent / totalBudget) * 100.0 : 0;
+        }
+
+        @if (currencyProviders.Count > 0)
+        {
+            <div class="section-header">
+                <h2 class="mb-2">Spending Overview</h2>
+            </div>
+            <div class="stats-grid">
+                <div class="stat-card">
+                    <h3>Total Spent</h3>
+                    <div class="stat-value @GetUsageClass(spentPercent)">$@totalSpent.ToString("F2")</div>
+                </div>
+                <div class="stat-card">
+                    <h3>Total Budget</h3>
+                    <div class="stat-value">$@totalBudget.ToString("F2")</div>
+                </div>
+                <div class="stat-card">
+                    <h3>Currency Providers</h3>
+                    <div class="stat-value">@currencyProviders.Count</div>
+                </div>
+            </div>
         }
 
         @if (visibleUsage.Count > 0)

--- a/AIUsageTracker.Web/Pages/Index.cshtml
+++ b/AIUsageTracker.Web/Pages/Index.cshtml
@@ -273,6 +273,17 @@
                             }
                         </div>
                         
+                        @if (hasUsableMetrics && Model.SparklineData.TryGetValue(usage.ProviderId, out var sparkPoints) && sparkPoints.Count > 1)
+                        {
+                            var w = 100.0;
+                            var h = 24.0;
+                            var step = w / (sparkPoints.Count - 1);
+                            var pts = sparkPoints.Select((v, i) => $"{(i * step).ToString("F1", System.Globalization.CultureInfo.InvariantCulture)},{(h - (v / 100.0 * h)).ToString("F1", System.Globalization.CultureInfo.InvariantCulture)}");
+                            <svg class="sparkline" viewBox="0 0 @w.ToString("F0") @h.ToString("F0")" preserveAspectRatio="none" width="100%" height="@h.ToString("F0")">
+                                <polyline points="@string.Join(" ", pts)" fill="none" stroke="currentColor" stroke-width="1.5" />
+                            </svg>
+                        }
+                        
                         @{
                             // For flat-card providers, show sibling cards in the same group as sub-rows.
                             var siblingCards = !string.IsNullOrEmpty(usage.GroupId) && usage.CardId != null

--- a/AIUsageTracker.Web/Pages/Index.cshtml.cs
+++ b/AIUsageTracker.Web/Pages/Index.cshtml.cs
@@ -44,6 +44,9 @@ public class IndexModel : PageModel
 
     public IReadOnlyList<UsageComparison> UsageComparisons { get; private set; } = [];
 
+    public IReadOnlyDictionary<string, List<double>> SparklineData { get; private set; }
+        = new Dictionary<string, List<double>>(StringComparer.OrdinalIgnoreCase);
+
     public bool IsDatabaseAvailable => this._dbService.IsDatabaseAvailable();
 
     public bool ShowUsedPercentage { get; set; }
@@ -152,6 +155,7 @@ public class IndexModel : PageModel
         }
 
         await this.LoadAnalyticsAsync(this.LatestUsage.Select(x => x.ProviderId).ToList()).ConfigureAwait(false);
+        await this.LoadSparklineDataAsync(this.LatestUsage.Select(x => x.ProviderId).ToList()).ConfigureAwait(false);
     }
 
     private async Task LoadAnalyticsAsync(IReadOnlyList<string> providerIds)
@@ -183,6 +187,22 @@ public class IndexModel : PageModel
         {
             this.UsageComparisons = (await this._analyticsService.GetUsageComparisonsAsync(providerIds).ConfigureAwait(false)).ToList();
         }
+    }
+
+    private async Task LoadSparklineDataAsync(IReadOnlyList<string> providerIds)
+    {
+        var samples = await this._dbService.GetHistorySamplesAsync(providerIds, 24, 24).ConfigureAwait(false);
+
+        this.SparklineData = samples
+            .GroupBy(s => s.ProviderId, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(
+                g => g.Key,
+                g => g.OrderBy(s => s.FetchedAt)
+                      .Select(s => s.RequestsAvailable > 0
+                          ? Math.Clamp((s.RequestsUsed / s.RequestsAvailable) * 100.0, 0, 100)
+                          : 0)
+                      .ToList(),
+                StringComparer.OrdinalIgnoreCase);
     }
 
     private async Task LoadColorThresholdsAsync()

--- a/AIUsageTracker.Web/wwwroot/css/site.css
+++ b/AIUsageTracker.Web/wwwroot/css/site.css
@@ -351,6 +351,12 @@ body {
     text-align: right;
 }
 
+.sparkline {
+    margin-top: 0.4rem;
+    color: var(--text-secondary);
+    opacity: 0.7;
+}
+
 .forecast-time {
     font-size: 0.75rem;
     margin-top: 0.2rem;


### PR DESCRIPTION
## Changes

- **Spending Overview section** on Web Dashboard homepage (task-91)
  - Sums total spent and total budget across currency-based providers
  - Hidden when no currency providers are active

- **Provider history sparklines** on Web Dashboard (task-92)
  - Inline SVG polyline per provider card showing 24h usage trend
  - Uses existing GetHistorySamplesAsync -- no new DB queries
  - Theme-aware via currentColor

- **Terminal title** for Monitor console process (task-93)
  - Sets console title to AI Usage Tracker - Monitor

## Test Results
- 1363 tests pass, 0 failures
- Build clean, 0 errors