### PR TITLE
fix: installer uses .NET 10 runtime instead of .NET 8 (issue #647)

### DIFF
--- a/AIUsageTracker.Infrastructure/MonitorClient/MonitorLauncherProcessController.cs
+++ b/AIUsageTracker.Infrastructure/MonitorClient/MonitorLauncherProcessController.cs
@@ -47,10 +47,23 @@ internal static class MonitorLauncherProcessController
     {
         try
         {
-            using var process = Process.Start(startInfo);
+            var process = Process.Start(startInfo);
             if (process == null)
             {
                 MonitorService.LogDiagnostic($"Monitor launch returned no process for target '{launchTarget}'.");
+                return false;
+            }
+
+            // Wait briefly to detect immediate crash (e.g. missing ASP.NET Core runtime)
+            process.WaitForExit(milliseconds: 3000);
+            if (process.HasExited)
+            {
+                var exitCode = process.ExitCode;
+                MonitorService.LogDiagnostic(
+                    $"Monitor process exited immediately (exit code {exitCode}). " +
+                    "This typically indicates a missing .NET runtime. " +
+                    "Ensure the .NET 10.0 ASP.NET Core Runtime is installed.");
+                process.Dispose();
                 return false;
             }
 
@@ -182,8 +195,8 @@ internal static class MonitorLauncherProcessController
     {
         return new[]
         {
-            Path.Combine(baseDirectory, "..", "..", "..", "..", "AIUsageTracker.Monitor", "bin", "Debug", "net8.0", monitorExecutableName),
-            Path.Combine(baseDirectory, "..", "..", "..", "..", "AIUsageTracker.Monitor", "bin", "Release", "net8.0", monitorExecutableName),
+            Path.Combine(baseDirectory, "..", "..", "..", "..", "AIUsageTracker.Monitor", "bin", "Debug", "net10.0", monitorExecutableName),
+            Path.Combine(baseDirectory, "..", "..", "..", "..", "AIUsageTracker.Monitor", "bin", "Release", "net10.0", monitorExecutableName),
             Path.Combine(baseDirectory, monitorExecutableName),
             Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "AIUsageTracker", monitorExecutableName),
             Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "AIUsageTracker", monitorExecutableName),

--- a/AIUsageTracker.UI.Slim/Services/BrowserService.cs
+++ b/AIUsageTracker.UI.Slim/Services/BrowserService.cs
@@ -105,8 +105,8 @@ public class BrowserService : IBrowserService
     {
         var possiblePaths = new[]
         {
-            Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", WebProjectName, "bin", "Debug", "net8.0", $"{WebProjectName}.exe"),
-            Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", WebProjectName, "bin", "Release", "net8.0", $"{WebProjectName}.exe"),
+            Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", WebProjectName, "bin", "Debug", "net10.0", $"{WebProjectName}.exe"),
+            Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", WebProjectName, "bin", "Release", "net10.0", $"{WebProjectName}.exe"),
             Path.Combine(AppContext.BaseDirectory, $"{WebProjectName}.exe"),
         };
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -34,7 +34,7 @@ The **Implementation Layer**. It contains:
 - **Data Access**: SQLite implementation using Dapper for usage history.
 - **Services**: Concrete implementations of Core interfaces (e.g., `WindowsNotificationService`).
 - **Configuration**: Logic for loading/saving `auth.json` and `providers.json`.
-- **Philosophy**: This is where the "heavy lifting" happens. It Target's `net8.0-windows` because it uses Windows-specific APIs.
+- **Philosophy**: This is where the "heavy lifting" happens. It targets `net10.0-windows` because it uses Windows-specific APIs.
 
 ### [AIUsageTracker.Monitor](file:///c:/Develop/Claude/opencode-tracker/AIUsageTracker.Monitor)
 The **Background Engine**.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ If a new violation appears, fix it before pushing. Do not:
 
 ## Architecture
 
-- **AIUsageTracker.UI.Slim** — WPF main window + settings dialog (net8.0-windows)
+- **AIUsageTracker.UI.Slim** — WPF main window + settings dialog (net10.0-windows)
 - **AIUsageTracker.Monitor** — Background agent that polls providers and serves usage data over HTTP
 - **AIUsageTracker.Core** — Shared models, interfaces, monitor client
 - **AIUsageTracker.Infrastructure** — Provider implementations (Synthetic, Codex, OpenAI, etc.)

--- a/scripts/setup.iss
+++ b/scripts/setup.iss
@@ -35,17 +35,17 @@ begin
 
   if NeedsDesktopRuntime then
   begin
-    Dependency_AddDotNet80Desktop;
+    Dependency_AddDotNet100Desktop;
   end;
 
   if NeedsAspNetRuntime then
   begin
-    Dependency_AddDotNet80Asp;
+    Dependency_AddDotNet100Asp;
   end;
 
   if NeedsNetRuntime then
   begin
-    Dependency_AddDotNet80;
+    Dependency_AddDotNet100;
   end;
 end;
 


### PR DESCRIPTION
Closes #647

## Summary
- Installer was calling Dependency_AddDotNet80* instead of Dependency_AddDotNet100*, so users got .NET 8 runtimes but the app targets .NET 10
- Updated stale net8.0 executable paths to net10.0 in MonitorLauncher and BrowserService
- Added immediate-crash detection to Monitor launcher: if the process exits within 3 seconds, logs a diagnostic suggesting missing ASP.NET Core Runtime
- Updated CLAUDE.md and ARCHITECTURE.md documentation references

## Root cause
After the .NET 8 to .NET 10 migration, three places still referenced .NET 8:
1. scripts/setup.iss -- installer dependencies
2. MonitorLauncherProcessController.cs -- executable path candidates
3. BrowserService.cs -- web project executable paths

## Test plan
- [x] Solution builds with 0 errors
- [x] No new test failures (existing flaky UI test unrelated)
- [ ] Verify installer installs .NET 10 ASP.NET Core Runtime on clean machine
- [ ] Verify Monitor starts successfully after installer-provided runtime