### PR TITLE
release: v2.3.6-beta.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## [Unreleased]
 
+## [2.3.6-beta.9] - 2026-06-25
+
+### Added
+- **ProviderUsage subtype hierarchy**: Sealed subtypes (`QuotaProviderUsage`, `WindowedProviderUsage`, `ModelScopedProviderUsage`, `StatusProviderUsage`) with compile-time safety and polymorphic JSON serialization via `[JsonDerivedType]` discriminators.
+- **Database migration V14**: Added `card_type` discriminator column to `provider_history` for subtype reconstruction on read.
+- **Web UI**: Spending summary, sparklines, and terminal title.
+- **Architecture guardrail tests**: 8 tests enforcing ProviderUsage hierarchy invariants.
+
+### Fixed
+- **Issue #647**: Installer installed .NET 8 runtimes instead of .NET 10 — Monitor crashed silently on machines without ASP.NET Core Runtime.
+- **DB read path**: ProviderUsage subtypes now correctly reconstructed from `card_type` discriminator on every `QueryAsync` call.
+- **Processing pipeline**: `StatusProviderUsage` no longer converted to `QuotaProviderUsage` with zeros during normalization.
+- **Monitor launcher**: Detects immediate process exit (missing runtime) and logs a diagnostic message.
+- **Update notification**: Preserved after hibernation network failure.
+
+### Changed
+- **16 providers migrated** to emit concrete `ProviderUsage` subtypes instead of setting `CardType` on the base class.
+- **Stale `net8.0` paths** updated to `net10.0` in MonitorLauncher and BrowserService.
+
 ## [2.3.6-beta.8] - 2026-06-12
 
 ### Tests

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TrackerVersion>2.3.6-beta.8</TrackerVersion>
+    <TrackerVersion>2.3.6-beta.9</TrackerVersion>
     <TrackerAssemblyVersion>2.3.6</TrackerAssemblyVersion>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(MSBuildProjectDirectory)\artifacts\**\*</DefaultItemExcludes>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="AIUsageTracker.Web/wwwroot/favicon.png" width="32" height="32" valign="middle"> AI Usage Tracker
 
-![Version](https://img.shields.io/badge/version-2.3.6--beta.8-orange)
+![Version](https://img.shields.io/badge/version-2.3.6--beta.9-orange)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Platforms](https://img.shields.io/badge/platforms-Windows%20|%20Linux%20-blue)
 ![Language](https://img.shields.io/badge/language-C%23%20|%20.NET-purple)

--- a/scripts/publish-app.ps1
+++ b/scripts/publish-app.ps1
@@ -6,7 +6,7 @@ param(
 )
 
 # AI Usage Tracker - Distribution Packaging Script
-# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.3.6-beta.8 -InstallerCompression balanced
+# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.3.6-beta.9 -InstallerCompression balanced
 
 $isWinPlatform = $Runtime.StartsWith("win-")
 $projectName = if ($isWinPlatform) { "AIUsageTracker" } else { "AIUsageTracker.CLI" }

--- a/scripts/setup.iss
+++ b/scripts/setup.iss
@@ -1,7 +1,7 @@
 ; AI Usage Tracker - Inno Setup Script
 
 #ifndef MyAppVersion
-  #define MyAppVersion "2.3.6-beta.8"
+  #define MyAppVersion "2.3.6-beta.9"
 #endif
 #ifndef SourcePath
   #define SourcePath "..\dist\publish-win-x64"


### PR DESCRIPTION
Version bump to 2.3.6-beta.9

## Changes
- Directory.Build.props: TrackerVersion 2.3.6-beta.8 -> 2.3.6-beta.9
- scripts/setup.iss: MyAppVersion updated
- README.md: version badge updated
- CHANGELOG.md: release entry with all Cycle 20 changes

After merge, the auto-tag-release.yml workflow will create the v2.3.6-beta.9 tag, which triggers publish.yml.