### PR TITLE
fix: startup delay + card_type migration for pre-Evolve databases

### DIFF
--- a/AIUsageTracker.Infrastructure/MonitorClient/MonitorLauncherProcessController.cs
+++ b/AIUsageTracker.Infrastructure/MonitorClient/MonitorLauncherProcessController.cs
@@ -54,8 +54,10 @@ internal static class MonitorLauncherProcessController
                 return false;
             }
 
-            // Wait briefly to detect immediate crash (e.g. missing ASP.NET Core runtime)
-            process.WaitForExit(milliseconds: 3000);
+            // Wait briefly to detect immediate crash (e.g. missing ASP.NET Core runtime).
+            // Runtime-missing crashes happen within ~100ms; 500ms catches those without
+            // penalizing normal startup.
+            process.WaitForExit(milliseconds: 500);
             if (process.HasExited)
             {
                 var exitCode = process.ExitCode;

--- a/AIUsageTracker.Monitor/Services/DatabaseMigrationService.cs
+++ b/AIUsageTracker.Monitor/Services/DatabaseMigrationService.cs
@@ -253,6 +253,7 @@ public class DatabaseMigrationService
         EnsureColumn(connection, TableProviderHistory, "window_kind", "INTEGER NOT NULL DEFAULT 0");
         EnsureColumn(connection, TableProviderHistory, "model_name", "TEXT");
         EnsureColumn(connection, TableProviderHistory, "name", "TEXT");
+        EnsureColumn(connection, TableProviderHistory, "card_type", "TEXT");
 
         // Convert fetched_at TEXT → INTEGER epoch for databases that pre-date V11.
         ConvertTimestampsToEpochIfNeeded(connection);


### PR DESCRIPTION
Two critical bugs in beta 9:

**1. card_type column missing (completely broken)**
The V14 migration only runs through Evolve. Databases that predate Evolve skip all migrations. EnsureSchemaCompatibility had EnsureColumn calls for every other new column but missed card_type. Every API query crashed with SQLite Error 1: 'no such column: h.card_type'

**2. 3-second startup delay**
The Monitor crash-detection wait blocked for 3s on every cold start. Reduced to 500ms.