### PR TITLE
fix: timestamp conversion was dropping newer provider_history columns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ This document provides essential information for agentic coding assistants worki
 - **Never duplicate provider metadata into DB tables.** The database stores raw values only; provider definitions (ProviderDefinition class) are the authority for interpretation.
 - Provider definitions are immutable per provider ID. If semantics change, a new provider class with a new ID is created.
 - When encountering data integrity concerns, do NOT suggest adding columns. Keep the schema minimal.
+- **When adding a column to `EnsureSchemaCompatibility`**: you MUST add a corresponding `Assert.Contains` in `DatabaseMigrationServiceTests.RunMigrations_LegacyDatabaseWithoutEvolveMetadata_AddsMissingProviderColumns`. Every column in the compatibility bootstrap must have a test assertion — no exceptions. This is how we prevent beta-9-style breakage where `card_type` was added to the code but missing from the test, shipping a release that crashed every API call on pre-Evolve databases.
 
 ### Take Full Ownership
 - Do not give hedged answers like "this will work IF the API returns X." Investigate the actual data (database, logs, live endpoints) and report what IS happening.

--- a/AIUsageTracker.Monitor/Services/DatabaseMigrationService.cs
+++ b/AIUsageTracker.Monitor/Services/DatabaseMigrationService.cs
@@ -240,23 +240,27 @@ public class DatabaseMigrationService
         EnsureColumn(connection, TableProviders, "config_json", "TEXT");
         EnsureColumn(connection, TableProviders, "auth_source", "TEXT DEFAULT 'manual'");
         EnsureColumn(connection, TableProviders, "plan_type", "TEXT DEFAULT 'usage'");
+        // Add columns that ConvertTimestampsToEpochIfNeeded SELECTs, so the
+        // INSERT INTO provider_history_new doesn't fail on missing columns.
         EnsureColumn(connection, TableProviderHistory, "next_reset_time", "TEXT");
         EnsureColumn(connection, TableProviderHistory, "details_json", "TEXT");
-        EnsureColumn(connection, TableProviderHistory, "next_reset_time", "TEXT");
         EnsureColumn(connection, TableProviderHistory, "response_latency_ms", "REAL NOT NULL DEFAULT 0");
         EnsureColumn(connection, TableProviderHistory, "http_status", "INTEGER NOT NULL DEFAULT 0");
         EnsureColumn(connection, TableProviderHistory, "upstream_response_validity", "INTEGER NOT NULL DEFAULT 0");
         EnsureColumn(connection, TableProviderHistory, "upstream_response_note", "TEXT NOT NULL DEFAULT ''");
         EnsureColumn(connection, TableProviderHistory, "parent_provider_id", "TEXT");
+
+        // Convert fetched_at TEXT → INTEGER epoch. This recreates provider_history,
+        // so run it BEFORE adding columns it doesn't preserve.
+        ConvertTimestampsToEpochIfNeeded(connection);
+
+        // Add columns that the timestamp conversion's new table doesn't include.
         EnsureColumn(connection, TableProviderHistory, "card_id", "TEXT");
         EnsureColumn(connection, TableProviderHistory, "group_id", "TEXT");
         EnsureColumn(connection, TableProviderHistory, "window_kind", "INTEGER NOT NULL DEFAULT 0");
         EnsureColumn(connection, TableProviderHistory, "model_name", "TEXT");
         EnsureColumn(connection, TableProviderHistory, "name", "TEXT");
         EnsureColumn(connection, TableProviderHistory, "card_type", "TEXT");
-
-        // Convert fetched_at TEXT → INTEGER epoch for databases that pre-date V11.
-        ConvertTimestampsToEpochIfNeeded(connection);
 
         ExecuteNonQuery(
             connection,

--- a/AIUsageTracker.Tests/Services/DatabaseMigrationServiceTests.cs
+++ b/AIUsageTracker.Tests/Services/DatabaseMigrationServiceTests.cs
@@ -43,6 +43,13 @@ public sealed class DatabaseMigrationServiceTests : IDisposable
         Assert.Contains("http_status", historyColumns, StringComparer.OrdinalIgnoreCase);
         Assert.Contains("upstream_response_validity", historyColumns, StringComparer.OrdinalIgnoreCase);
         Assert.Contains("upstream_response_note", historyColumns, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("parent_provider_id", historyColumns, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("card_id", historyColumns, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("group_id", historyColumns, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("window_kind", historyColumns, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("model_name", historyColumns, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("name", historyColumns, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("card_type", historyColumns, StringComparer.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -72,6 +79,23 @@ public sealed class DatabaseMigrationServiceTests : IDisposable
         var name = (string?)await command.ExecuteScalarAsync();
 
         Assert.Equal("Google Antigravity", name);
+    }
+
+    [Fact]
+    public void RunMigrations_LegacyDatabase_CardTypeQueryWorksAfterMigration()
+    {
+        this.CreateLegacySchemaWithoutEvolveMetadata();
+
+        var service = new DatabaseMigrationService(this._dbPath, NullLogger<DatabaseMigrationService>.Instance);
+        service.RunMigrations();
+
+        // Verify that queries referencing card_type don't crash — this is the exact
+        // query pattern that broke beta 9 on pre-Evolve databases.
+        using var connection = new SqliteConnection($"Data Source={this._dbPath}");
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT COALESCE(card_type, 'quota') FROM provider_history LIMIT 1";
+        command.ExecuteNonQuery();
     }
 
     public void Dispose()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Timestamp conversion dropping newer columns**: `ConvertTimestampsToEpochIfNeeded` recreated `provider_history` but only preserved a subset of columns, silently wiping `card_id`, `group_id`, `window_kind`, `model_name`, `name`, and `card_type` on databases with TEXT `fetched_at`. Fixed by reordering: conversion runs first, then all `EnsureColumn` calls add columns the conversion doesn't preserve.
+- **Migration test coverage**: Added assertions for all `provider_history` columns plus a direct `card_type` query test. Added project rule to AGENTS.md requiring test assertions for every `EnsureColumn` addition.
+
 ## [2.3.6-beta.10] - 2026-06-25
 
 ### Fixed


### PR DESCRIPTION
Deeper fix for the migration ordering bug found by the new tests.

ConvertTimestampsToEpochIfNeeded recreates provider_history but only preserves a subset of columns. EnsureColumn calls for card_id, group_id, window_kind, model_name, name, and card_type ran BEFORE the conversion and were silently wiped.

Fix: columns the conversion SELECTs go before it, columns the conversion doesn't preserve go after it.

Tests: all provider_history columns now asserted, plus a direct card_type query test.