### PR TITLE
fix: migration preserves all card columns, throws on column mismatch (v2.3.6-beta.13)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,16 @@ This document provides essential information for agentic coding assistants worki
   - A `preferences.json` with ONE corrupt property must still salvage ALL other valid properties — the corrupt one is skipped, not the entire file.
 - **Root cause context**: Merge commit `8eb7c163` silently dropped the `JsonStringEnumConverter` attribute from `UpdateChannel`. Users who had `"UpdateChannel": "Beta"` (string) in their `preferences.json` hit a `JsonException` on startup, and `PreferencesStore.LoadAsync()` returned `new AppPreferences()` — wiping EVERY setting (theme, fonts, thresholds, window position, notification config, hidden providers, everything). This must NEVER happen again.
 
+### NEVER Cause Data Loss in Migrations (CRITICAL)
+- **Customer data is sacred. A database migration MUST NEVER lose data. Every column must survive every migration step.**
+- SQLite table-recreation migrations (CREATE new → INSERT INTO new → DROP old → RENAME) are the #1 data-loss risk. The INSERT SELECT MUST include EVERY column that exists in the source table. No exceptions.
+- **Mandatory**: When adding a column to `provider_history` (or any table that `ConvertTimestampsToEpochIfNeeded` recreates), the column MUST be added to BOTH:
+  1. The CREATE TABLE statement in the conversion
+  2. The INSERT INTO ... SELECT statement in the conversion
+- **Mandatory test**: Every table-recreation migration MUST have a test that inserts data WITH the relevant columns populated, runs the migration, and verifies the data survived. A test that only checks column existence is NOT sufficient — it must verify DATA preservation.
+- **Single source of truth**: The EnsureColumn calls and the conversion's column list must stay in sync. If they drift, data is silently destroyed. The conversion's CREATE TABLE and INSERT SELECT must match the EnsureColumn list exactly.
+- **Root cause context**: PR #654 added 6 card columns (`card_type`, `window_kind`, `card_id`, `group_id`, `model_name`, `name`) to `provider_history`. `ConvertTimestampsToEpochIfNeeded` recreated the table with a hardcoded 15-column INSERT that didn't include them. The columns were added back empty via EnsureColumn AFTER the recreation — permanently wiping card classification data from all historical rows. This caused OpenAI dual bars to disappear.
+
 ### NEVER Create Releases Without Explicit Permission
 - **I MUST NEVER** create git tags or releases without your explicit instruction
 - **I MUST NEVER** initiate CI/CD release workflows without your permission

--- a/AIUsageTracker.Monitor/Services/DatabaseMigrationService.cs
+++ b/AIUsageTracker.Monitor/Services/DatabaseMigrationService.cs
@@ -240,8 +240,8 @@ public class DatabaseMigrationService
         EnsureColumn(connection, TableProviders, "config_json", "TEXT");
         EnsureColumn(connection, TableProviders, "auth_source", "TEXT DEFAULT 'manual'");
         EnsureColumn(connection, TableProviders, "plan_type", "TEXT DEFAULT 'usage'");
-        // Add columns that ConvertTimestampsToEpochIfNeeded SELECTs, so the
-        // INSERT INTO provider_history_new doesn't fail on missing columns.
+        // Ensure ALL provider_history columns exist before the timestamp conversion,
+        // because the conversion recreates the table and copies all columns.
         EnsureColumn(connection, TableProviderHistory, "next_reset_time", "TEXT");
         EnsureColumn(connection, TableProviderHistory, "details_json", "TEXT");
         EnsureColumn(connection, TableProviderHistory, "response_latency_ms", "REAL NOT NULL DEFAULT 0");
@@ -249,18 +249,16 @@ public class DatabaseMigrationService
         EnsureColumn(connection, TableProviderHistory, "upstream_response_validity", "INTEGER NOT NULL DEFAULT 0");
         EnsureColumn(connection, TableProviderHistory, "upstream_response_note", "TEXT NOT NULL DEFAULT ''");
         EnsureColumn(connection, TableProviderHistory, "parent_provider_id", "TEXT");
-
-        // Convert fetched_at TEXT → INTEGER epoch. This recreates provider_history,
-        // so run it BEFORE adding columns it doesn't preserve.
-        ConvertTimestampsToEpochIfNeeded(connection);
-
-        // Add columns that the timestamp conversion's new table doesn't include.
         EnsureColumn(connection, TableProviderHistory, "card_id", "TEXT");
         EnsureColumn(connection, TableProviderHistory, "group_id", "TEXT");
         EnsureColumn(connection, TableProviderHistory, "window_kind", "INTEGER NOT NULL DEFAULT 0");
         EnsureColumn(connection, TableProviderHistory, "model_name", "TEXT");
         EnsureColumn(connection, TableProviderHistory, "name", "TEXT");
         EnsureColumn(connection, TableProviderHistory, "card_type", "TEXT");
+
+        // Convert fetched_at TEXT → INTEGER epoch. All columns are ensured above
+        // so the table recreation preserves all data.
+        ConvertTimestampsToEpochIfNeeded(connection);
 
         ExecuteNonQuery(
             connection,
@@ -291,8 +289,20 @@ public class DatabaseMigrationService
             return;
         }
 
+        // Capture source columns BEFORE migration. Every column must survive.
+        var sourceColumns = GetColumnNames(connection, TableProviderHistory);
+        var sourceSnapshotColumns = GetColumnNames(connection, "raw_snapshots");
+
+        // Build INSERT SELECT dynamically from actual source columns.
+        // If the new CREATE TABLE is missing a source column, the INSERT THROWS.
+        var historySelect = BuildColumnSelect(sourceColumns);
+        var historyTarget = string.Join(", ", sourceColumns.Select(c => $"\"{c}\""));
+
+        var snapshotSelect = BuildColumnSelect(sourceSnapshotColumns);
+        var snapshotTarget = string.Join(", ", sourceSnapshotColumns.Select(c => $"\"{c}\""));
+
         ExecuteNonQuery(connection, "PRAGMA foreign_keys = OFF");
-        ExecuteNonQuery(connection, @"
+        ExecuteNonQuery(connection, $@"
             CREATE TABLE provider_history_new (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 provider_id TEXT NOT NULL,
@@ -309,18 +319,21 @@ public class DatabaseMigrationService
                 fetched_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
                 details_json TEXT,
                 parent_provider_id TEXT REFERENCES providers(provider_id) ON DELETE SET NULL,
+                card_id TEXT,
+                group_id TEXT,
+                window_kind INTEGER NOT NULL DEFAULT 0,
+                model_name TEXT,
+                name TEXT,
+                card_type TEXT,
                 FOREIGN KEY (provider_id) REFERENCES providers(provider_id) ON DELETE CASCADE
             );
-            INSERT INTO provider_history_new
-            SELECT id, provider_id, is_available, status_message, next_reset_time,
-                   requests_used, requests_available, requests_percentage,
-                   response_latency_ms, http_status, upstream_response_validity, upstream_response_note,
-                   CAST(strftime('%s', fetched_at) AS INTEGER),
-                   details_json, parent_provider_id
+            INSERT INTO provider_history_new ({historyTarget})
+            SELECT {historySelect}
             FROM provider_history;
             DROP TABLE provider_history;
             ALTER TABLE provider_history_new RENAME TO provider_history;
-
+        ");
+        ExecuteNonQuery(connection, $@"
             CREATE TABLE raw_snapshots_new (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 provider_id TEXT NOT NULL REFERENCES providers(provider_id) ON DELETE CASCADE,
@@ -328,14 +341,67 @@ public class DatabaseMigrationService
                 http_status INTEGER NOT NULL DEFAULT 200,
                 fetched_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
             );
-            INSERT INTO raw_snapshots_new
-            SELECT id, provider_id, raw_json, http_status,
-                   CAST(strftime('%s', fetched_at) AS INTEGER)
+            INSERT INTO raw_snapshots_new ({snapshotTarget})
+            SELECT {snapshotSelect}
             FROM raw_snapshots;
             DROP TABLE raw_snapshots;
             ALTER TABLE raw_snapshots_new RENAME TO raw_snapshots;
         ");
         ExecuteNonQuery(connection, "PRAGMA foreign_keys = ON");
+
+        // Verify no columns were lost — defensive assertion against future drift.
+        var newHistoryColumns = GetColumnNames(connection, TableProviderHistory);
+        var missingHistory = sourceColumns.Except(newHistoryColumns, StringComparer.OrdinalIgnoreCase).ToList();
+        if (missingHistory.Count > 0)
+        {
+            throw new InvalidOperationException(
+                $"Timestamp conversion destroyed columns from provider_history: {string.Join(", ", missingHistory)}. "
+                + "The CREATE TABLE must include every source column.");
+        }
+
+        var newSnapshotColumns = GetColumnNames(connection, "raw_snapshots");
+        var missingSnapshot = sourceSnapshotColumns.Except(newSnapshotColumns, StringComparer.OrdinalIgnoreCase).ToList();
+        if (missingSnapshot.Count > 0)
+        {
+            throw new InvalidOperationException(
+                $"Timestamp conversion destroyed columns from raw_snapshots: {string.Join(", ", missingSnapshot)}.");
+        }
+    }
+
+    /// <summary>
+    /// Builds a SELECT expression list that copies every column, transforming
+    /// <c>fetched_at</c> from TEXT to epoch INTEGER. Everything else passes through.
+    /// </summary>
+    private static string BuildColumnSelect(List<string> columns)
+    {
+        var exprs = columns.Select(c =>
+            string.Equals(c, "fetched_at", StringComparison.OrdinalIgnoreCase)
+                ? "CAST(strftime('%s', fetched_at) AS INTEGER)"
+                : $"\"{c}\"");
+        return string.Join(", ", exprs);
+    }
+
+    private static List<string> GetColumnNames(SqliteConnection connection, string tableName)
+    {
+        if (!TableInfoSql.TryGetValue(tableName, out var pragmaSql))
+        {
+            throw new ArgumentException($"Table '{tableName}' is not in the migration allowlist.", nameof(tableName));
+        }
+
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = pragmaSql;
+        using var reader = cmd.ExecuteReader();
+        var columns = new List<string>();
+        while (reader.Read())
+        {
+            var name = reader["name"]?.ToString();
+            if (!string.IsNullOrWhiteSpace(name))
+            {
+                columns.Add(name);
+            }
+        }
+
+        return columns;
     }
 
     private static string? GetColumnType(SqliteConnection connection, string tableName, string columnName)

--- a/AIUsageTracker.Tests/Services/DatabaseMigrationServiceTests.cs
+++ b/AIUsageTracker.Tests/Services/DatabaseMigrationServiceTests.cs
@@ -98,9 +98,168 @@ public sealed class DatabaseMigrationServiceTests : IDisposable
         command.ExecuteNonQuery();
     }
 
+    [Fact]
+    public void RunMigrations_LegacyDatabase_TimestampConversionPreservesCardColumns()
+    {
+        // Insert rows WITH card data, then run migration, then verify the data survived.
+        // This catches the bug where ConvertTimestampsToEpochIfNeeded recreated the table
+        // without copying card_type/window_kind/card_id columns.
+        this.CreateLegacySchemaWithCardData();
+
+        var service = new DatabaseMigrationService(this._dbPath, NullLogger<DatabaseMigrationService>.Instance);
+        service.RunMigrations();
+
+        using var connection = new SqliteConnection($"Data Source={this._dbPath}");
+        connection.Open();
+
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = @"
+            SELECT card_id, group_id, window_kind, model_name, name, card_type
+            FROM provider_history WHERE provider_id = 'openai' ORDER BY id";
+
+        using var reader = cmd.ExecuteReader();
+        Assert.True(reader.Read());
+        Assert.Equal("burst", reader.GetString(0));
+        Assert.Equal("rolling", reader.GetString(1));
+        Assert.Equal(1, reader.GetInt32(2));
+        Assert.Equal("gpt-4", reader.GetString(3));
+        Assert.Equal("GPT-4", reader.GetString(4));
+        Assert.Equal("windowed", reader.GetString(5));
+    }
+
+    [Fact]
+    public void RunMigrations_LegacyTableWithUnknownColumn_ThrowsInsteadOfSilentlyDropping()
+    {
+        // If the source table has a column the conversion's CREATE TABLE doesn't know about,
+        // the migration MUST throw — never silently drop data.
+        this.CreateLegacySchemaWithUnknownColumn();
+
+        var service = new DatabaseMigrationService(this._dbPath, NullLogger<DatabaseMigrationService>.Instance);
+
+        // The INSERT will fail because provider_history_new has no column "future_column".
+        Assert.ThrowsAny<Exception>(() => service.RunMigrations());
+    }
+
+    private void CreateLegacySchemaWithUnknownColumn()
+    {
+        // Simulates a database with a column the migration code doesn't know about.
+        // The migration MUST throw, not silently drop it.
+        using var connection = new SqliteConnection($"Data Source={this._dbPath}");
+        connection.Open();
+
+        const string sql = @"
+            CREATE TABLE providers (
+                provider_id TEXT PRIMARY KEY,
+                provider_name TEXT,
+                auth_source TEXT DEFAULT 'manual'
+            );
+
+            CREATE TABLE provider_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                provider_id TEXT NOT NULL,
+                requests_used REAL NOT NULL DEFAULT 0,
+                requests_available REAL NOT NULL DEFAULT 0,
+                requests_percentage REAL NOT NULL DEFAULT 0,
+                is_available INTEGER NOT NULL DEFAULT 1,
+                status_message TEXT NOT NULL DEFAULT '',
+                fetched_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                future_column TEXT
+            );
+
+            CREATE TABLE raw_snapshots (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                provider_id TEXT NOT NULL,
+                raw_json TEXT NOT NULL,
+                http_status INTEGER NOT NULL DEFAULT 200,
+                fetched_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+
+            CREATE TABLE reset_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                provider_id TEXT NOT NULL,
+                provider_name TEXT NOT NULL,
+                previous_usage REAL,
+                new_usage REAL,
+                reset_type TEXT NOT NULL,
+                timestamp TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+
+            INSERT INTO provider_history (provider_id, future_column)
+            VALUES ('test', 'precious data');";
+
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        command.ExecuteNonQuery();
+    }
+
     public void Dispose()
     {
         TestTempPaths.CleanupPath(this._dbPath);
+    }
+
+    private void CreateLegacySchemaWithCardData()
+    {
+        // Simulates a database from a version that already had card columns
+        // but still uses TEXT timestamps (pre-epoch-conversion).
+        using var connection = new SqliteConnection($"Data Source={this._dbPath}");
+        connection.Open();
+
+        const string sql = @"
+            CREATE TABLE providers (
+                provider_id TEXT PRIMARY KEY,
+                provider_name TEXT,
+                auth_source TEXT DEFAULT 'manual'
+            );
+
+            CREATE TABLE provider_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                provider_id TEXT NOT NULL,
+                requests_used REAL NOT NULL DEFAULT 0,
+                requests_available REAL NOT NULL DEFAULT 0,
+                requests_percentage REAL NOT NULL DEFAULT 0,
+                is_available INTEGER NOT NULL DEFAULT 1,
+                status_message TEXT NOT NULL DEFAULT '',
+                fetched_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                card_id TEXT,
+                group_id TEXT,
+                window_kind INTEGER NOT NULL DEFAULT 0,
+                model_name TEXT,
+                name TEXT,
+                card_type TEXT
+            );
+
+            CREATE TABLE raw_snapshots (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                provider_id TEXT NOT NULL,
+                raw_json TEXT NOT NULL,
+                http_status INTEGER NOT NULL DEFAULT 200,
+                fetched_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+
+            CREATE TABLE reset_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                provider_id TEXT NOT NULL,
+                provider_name TEXT NOT NULL,
+                previous_usage REAL,
+                new_usage REAL,
+                reset_type TEXT NOT NULL,
+                timestamp TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+
+            INSERT INTO providers (provider_id, provider_name)
+            VALUES ('openai', 'OpenAI');
+
+            INSERT INTO provider_history
+                (provider_id, requests_used, requests_available, requests_percentage,
+                 is_available, status_message, fetched_at,
+                 card_id, group_id, window_kind, model_name, name, card_type)
+            VALUES
+                ('openai', 100, 200, 50, 1, 'OK', '2024-01-15 10:30:00',
+                 'burst', 'rolling', 1, 'gpt-4', 'GPT-4', 'windowed');";
+
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        command.ExecuteNonQuery();
     }
 
     private void CreateLegacySchemaWithoutEvolveMetadata()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [2.3.6-beta.13] - 2026-06-26
+
+### Fixed
+- **Migration data loss (CRITICAL)**: `ConvertTimestampsToEpochIfNeeded` recreated `provider_history` with a hardcoded column list that omitted 6 card columns (`card_id`, `group_id`, `window_kind`, `model_name`, `name`, `card_type`). All historical card classification data was silently wiped, causing OpenAI dual bars to disappear. Fixed by reading column names dynamically from `PRAGMA table_info` so the INSERT can never miss a column. Post-migration assertion verifies no columns were lost and throws if they were.
+
+### Added
+- **Strict migration test**: New test proves that a source table with an unknown column causes the migration to throw instead of silently dropping data.
+- **Data preservation test**: New test inserts card data before migration and verifies it survives.
+- **AGENTS.md rule**: Mandatory rule requiring every table-recreation migration to have a data-preservation test, and all columns must appear in both the CREATE TABLE and INSERT SELECT.
+
 ## [2.3.6-beta.12] - 2026-06-26
 
 ### Fixed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TrackerVersion>2.3.6-beta.12</TrackerVersion>
+    <TrackerVersion>2.3.6-beta.13</TrackerVersion>
     <TrackerAssemblyVersion>2.3.6</TrackerAssemblyVersion>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(MSBuildProjectDirectory)\artifacts\**\*</DefaultItemExcludes>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="AIUsageTracker.Web/wwwroot/favicon.png" width="32" height="32" valign="middle"> AI Usage Tracker
 
-![Version](https://img.shields.io/badge/version-2.3.6--beta.12-orange)
+![Version](https://img.shields.io/badge/version-2.3.6--beta.13-orange)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Platforms](https://img.shields.io/badge/platforms-Windows%20|%20Linux%20-blue)
 ![Language](https://img.shields.io/badge/language-C%23%20|%20.NET-purple)

--- a/scripts/publish-app.ps1
+++ b/scripts/publish-app.ps1
@@ -6,7 +6,7 @@ param(
 )
 
 # AI Usage Tracker - Distribution Packaging Script
-# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.3.6-beta.12 -InstallerCompression balanced
+# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.3.6-beta.13 -InstallerCompression balanced
 
 $isWinPlatform = $Runtime.StartsWith("win-")
 $projectName = if ($isWinPlatform) { "AIUsageTracker" } else { "AIUsageTracker.CLI" }

--- a/scripts/setup.iss
+++ b/scripts/setup.iss
@@ -1,7 +1,7 @@
 ; AI Usage Tracker - Inno Setup Script
 
 #ifndef MyAppVersion
-  #define MyAppVersion "2.3.6-beta.12"
+  #define MyAppVersion "2.3.6-beta.13"
 #endif
 #ifndef SourcePath
   #define SourcePath "..\dist\publish-win-x64"


### PR DESCRIPTION
.pr-body.md