### PR TITLE
Cycle 22: Analytics page + CSV export

### DIFF
--- a/AIUsageTracker.Core/Models/SpendingTrendPoint.cs
+++ b/AIUsageTracker.Core/Models/SpendingTrendPoint.cs
@@ -1,0 +1,16 @@
+// <copyright file="SpendingTrendPoint.cs" company="AIUsageTracker">
+// Copyright (c) AIUsageTracker. All rights reserved.
+// </copyright>
+
+namespace AIUsageTracker.Core.Models;
+
+public class SpendingTrendPoint
+{
+    public string ProviderId { get; set; } = string.Empty;
+
+    public string ProviderName { get; set; } = string.Empty;
+
+    public string Date { get; set; } = string.Empty;
+
+    public double Amount { get; set; }
+}

--- a/AIUsageTracker.Web/Pages/Analytics.cshtml
+++ b/AIUsageTracker.Web/Pages/Analytics.cshtml
@@ -1,0 +1,131 @@
+@page "/analytics"
+@model AnalyticsModel
+@{
+    ViewData["Title"] = "Spending Trends";
+}
+
+<h1 class="page-title">Spending Trends</h1>
+
+@if (!Model.IsDatabaseAvailable)
+{
+    <div class="alert alert-warning">
+        Database not found. The Monitor must run first.
+    </div>
+}
+else if (!Model.HasCurrencyProviders)
+{
+    <div class="alert alert-info">
+        No currency-based providers are configured. Spending trends are available for providers that track dollar-based usage (e.g., OpenRouter, DeepSeek).
+    </div>
+}
+else
+{
+    <div class="chart-controls mb-2">
+        <a class="btn btn-secondary btn-sm" href="/analytics?days=7">7 Days</a>
+        <a class="btn btn-secondary btn-sm" href="/analytics?days=14">14 Days</a>
+        <a class="btn btn-secondary btn-sm" href="/analytics?days=30">30 Days</a>
+        <a class="btn btn-secondary btn-sm" href="/analytics?days=90">90 Days</a>
+    </div>
+
+    <div class="chart-container">
+        <canvas id="spendingChart"></canvas>
+    </div>
+
+    @if (Model.SpendingData?.Any() != true)
+    {
+        <div class="alert alert-info">
+            No spending data available yet. The Monitor needs to collect data over time.
+        </div>
+    }
+}
+
+@section Scripts {
+    @if (Model.SpendingData?.Any() == true)
+    {
+        <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+        <script>
+            const spendingData = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.SpendingData));
+            const providerColors = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.ProviderColors ?? new Dictionary<string, string>()));
+
+            const defaultColors = ['#06b6d4', '#8b5cf6', '#f97316', '#10b981', '#f43f5e', '#eab308'];
+
+            function getColor(name, index) {
+                if (providerColors[name]) return providerColors[name];
+                return defaultColors[index % defaultColors.length];
+            }
+
+            function buildChart() {
+                if (!spendingData || spendingData.length === 0) return null;
+
+                const providers = [...new Set(spendingData.map(d => d.ProviderName))].sort();
+                const allDates = [...new Set(spendingData.map(d => d.Date))].sort();
+
+                const labels = allDates.map(d => {
+                    const date = new Date(d + 'T00:00:00');
+                    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+                });
+
+                const datasets = providers.map((name, i) => {
+                    const providerData = spendingData.filter(d => d.ProviderName === name);
+                    const color = getColor(name, i);
+                    const data = allDates.map(date => {
+                        const point = providerData.find(d => d.Date === date);
+                        return point ? point.Amount : null;
+                    });
+
+                    return {
+                        label: name,
+                        data: data,
+                        borderColor: color,
+                        backgroundColor: color + '20',
+                        fill: false,
+                        tension: 0.2,
+                        pointRadius: 2,
+                        pointHoverRadius: 6,
+                        spanGaps: true
+                    };
+                });
+
+                return { labels, datasets };
+            }
+
+            const chartState = buildChart();
+            if (chartState) {
+                const ctx = document.getElementById('spendingChart');
+                new Chart(ctx, {
+                    type: 'line',
+                    data: { labels: chartState.labels, datasets: chartState.datasets },
+                    options: {
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        interaction: { intersect: false, mode: 'index' },
+                        animation: false,
+                        scales: {
+                            x: {
+                                title: { display: false },
+                                ticks: { maxRotation: 45, minRotation: 45, maxTicksLimit: 20 }
+                            },
+                            y: {
+                                beginAtZero: true,
+                                title: { display: true, text: 'Cumulative Spend ($)' },
+                                ticks: {
+                                    callback: function(value) { return '$' + value.toFixed(2); }
+                                }
+                            }
+                        },
+                        plugins: {
+                            legend: { position: 'bottom', labels: { boxWidth: 12, padding: 15 } },
+                            tooltip: {
+                                callbacks: {
+                                    label: function(c) {
+                                        return c.dataset.label + ': $' + (c.parsed.y?.toFixed(2) ?? '-');
+                                    }
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+        </script>
+    }
+}

--- a/AIUsageTracker.Web/Pages/Analytics.cshtml.cs
+++ b/AIUsageTracker.Web/Pages/Analytics.cshtml.cs
@@ -1,0 +1,84 @@
+// <copyright file="Analytics.cshtml.cs" company="AIUsageTracker">
+// Copyright (c) AIUsageTracker. All rights reserved.
+// </copyright>
+
+using AIUsageTracker.Core.Interfaces;
+using AIUsageTracker.Core.Models;
+using AIUsageTracker.Infrastructure.Providers;
+using AIUsageTracker.Web.Services;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.OutputCaching;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace AIUsageTracker.Web.Pages;
+
+[OutputCache(PolicyName = "AnalyticsCache")]
+public class AnalyticsModel : PageModel
+{
+    private const string ProviderColorsCacheKey = "analytics-provider-colors-v1";
+
+    private readonly WebDatabaseService _dbService;
+    private readonly IConfigLoader _configLoader;
+    private readonly IMemoryCache _memoryCache;
+
+    public AnalyticsModel(
+        WebDatabaseService dbService,
+        IConfigLoader configLoader,
+        IMemoryCache memoryCache)
+    {
+        this._dbService = dbService;
+        this._configLoader = configLoader;
+        this._memoryCache = memoryCache;
+    }
+
+    public IReadOnlyList<SpendingTrendPoint>? SpendingData { get; set; }
+
+    public IReadOnlyDictionary<string, string> ProviderColors { get; set; } = new Dictionary<string, string>(StringComparer.Ordinal);
+
+    public bool IsDatabaseAvailable => this._dbService.IsDatabaseAvailable();
+
+    public bool HasCurrencyProviders { get; private set; }
+
+    public async Task OnGetAsync(int days = 30)
+    {
+        if (!this.IsDatabaseAvailable)
+        {
+            return;
+        }
+
+        var currencyProviderIds = ProviderMetadataCatalog.Definitions
+            .Where(d => d.IsCurrencyUsage)
+            .Select(d => d.ProviderId)
+            .ToList();
+
+        this.HasCurrencyProviders = currencyProviderIds.Count > 0;
+
+        var dataTask = this._dbService.GetSpendingTrendAsync(currencyProviderIds, days);
+        var colorTask = this.GetProviderColorsAsync();
+
+        await Task.WhenAll(dataTask, colorTask).ConfigureAwait(false);
+
+        this.SpendingData = await dataTask.ConfigureAwait(false);
+        this.ProviderColors = await colorTask.ConfigureAwait(false);
+    }
+
+    private async Task<IReadOnlyDictionary<string, string>> GetProviderColorsAsync()
+    {
+        return await this._memoryCache.GetOrCreateAsync(ProviderColorsCacheKey, async entry =>
+        {
+            entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(5);
+
+            var colors = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var configs = await this._configLoader.LoadConfigAsync().ConfigureAwait(false);
+            foreach (var model in configs
+                .Where(cfg => cfg.Models != null)
+                .SelectMany(cfg => cfg.Models!)
+                .Where(m => !string.IsNullOrEmpty(m.Color) && !string.IsNullOrEmpty(m.Name)))
+            {
+                colors[model.Name!] = model.Color!;
+            }
+
+            return colors;
+        }).ConfigureAwait(false) ?? new Dictionary<string, string>(StringComparer.Ordinal);
+    }
+}

--- a/AIUsageTracker.Web/Pages/History.cshtml
+++ b/AIUsageTracker.Web/Pages/History.cshtml
@@ -12,39 +12,47 @@
         <strong>Database not found!</strong> The Monitor database is not available.
     </div>
 }
-else if (Model.History?.Any() != true)
-{
-    <div class="alert alert-info">
-        No history data available yet.
-    </div>
-}
 else
 {
-    <div class="table-container">
-        <table>
-            <thead>
-                <tr>
-                    <th>Time</th>
-                    <th>Provider</th>
-                    <th>Usage</th>
-                    <th>Status</th>
-                </tr>
-            </thead>
-            <tbody>
-                @foreach (var usage in Model.History)
-                {
-                    <tr>
-                        <td>@usage.FetchedAt.ToString("g")</td>
-                        <td>@usage.ProviderName</td>
-                        <td>@usage.RemainingPercent.ToString("F1")%</td>
-                        <td>
-                            <span class="provider-status @(usage.IsAvailable ? "active" : "inactive")">
-                                @(usage.IsAvailable ? "Active" : "Inactive")
-                            </span>
-                        </td>
-                    </tr>
-                }
-            </tbody>
-        </table>
+    <div class="section-header">
+        <div></div>
+        <a class="btn btn-secondary btn-sm" href="/history?handler=export">Export CSV</a>
     </div>
+
+    if (Model.History?.Any() != true)
+    {
+        <div class="alert alert-info">
+            No history data available yet.
+        </div>
+    }
+    else
+    {
+        <div class="table-container">
+            <table>
+                <thead>
+                    <tr>
+                        <th>Time</th>
+                        <th>Provider</th>
+                        <th>Usage</th>
+                        <th>Status</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var usage in Model.History)
+                    {
+                        <tr>
+                            <td>@usage.FetchedAt.ToString("g")</td>
+                            <td>@usage.ProviderName</td>
+                            <td>@usage.RemainingPercent.ToString("F1")%</td>
+                            <td>
+                                <span class="provider-status @(usage.IsAvailable ? "active" : "inactive")">
+                                    @(usage.IsAvailable ? "Active" : "Inactive")
+                                </span>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    }
 }

--- a/AIUsageTracker.Web/Pages/History.cshtml.cs
+++ b/AIUsageTracker.Web/Pages/History.cshtml.cs
@@ -2,14 +2,20 @@
 // Copyright (c) AIUsageTracker. All rights reserved.
 // </copyright>
 
+using System.Globalization;
+using System.Text;
 using AIUsageTracker.Core.Models;
 using AIUsageTracker.Web.Services;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace AIUsageTracker.Web.Pages;
 
 public class HistoryModel : PageModel
 {
+    private const int ExportRowLimit = 10_000;
+    private const int ExportDayLimit = 90;
+
     private readonly WebDatabaseService _dbService;
 
     public HistoryModel(WebDatabaseService dbService)
@@ -27,5 +33,55 @@ public class HistoryModel : PageModel
         {
             this.History = await this._dbService.GetHistoryAsync(100).ConfigureAwait(false);
         }
+    }
+
+    public async Task<IActionResult> OnGetExportAsync()
+    {
+        if (!this.IsDatabaseAvailable)
+        {
+            return this.NotFound("Database not available.");
+        }
+
+        var data = await this._dbService.GetAllHistoryForExportAsync(ExportRowLimit).ConfigureAwait(false);
+
+        var cutoff = DateTime.UtcNow.AddDays(-ExportDayLimit);
+        var filtered = data
+            .Where(u => u.FetchedAt >= cutoff)
+            .OrderByDescending(u => u.FetchedAt)
+            .ToList();
+
+        var csv = new StringBuilder();
+        csv.AppendLine("timestamp,provider_id,provider_name,requests_used,requests_available,requests_percentage,is_available");
+
+        foreach (var usage in filtered)
+        {
+            csv.Append(CultureInfo.InvariantCulture, $"{usage.FetchedAt:O},");
+            csv.Append(CsvEscape(usage.ProviderId)).Append(',');
+            csv.Append(CsvEscape(usage.ProviderName)).Append(',');
+            csv.Append(usage.RequestsUsed.ToString(CultureInfo.InvariantCulture)).Append(',');
+            csv.Append(usage.RequestsAvailable.ToString(CultureInfo.InvariantCulture)).Append(',');
+            csv.Append(usage.UsedPercent.ToString(CultureInfo.InvariantCulture)).Append(',');
+            csv.AppendLine(usage.IsAvailable ? "true" : "false");
+        }
+
+        var bytes = Encoding.UTF8.GetBytes(csv.ToString());
+        var fileName = $"ai-usage-export-{DateTime.UtcNow:yyyy-MM-dd}.csv";
+
+        return this.File(bytes, "text/csv", fileName);
+    }
+
+    private static string CsvEscape(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        if (value.Contains(',', StringComparison.Ordinal) || value.Contains('"', StringComparison.Ordinal) || value.Contains('\n', StringComparison.Ordinal))
+        {
+            return $"\"{value.Replace("\"", "\"\"", StringComparison.Ordinal)}\"";
+        }
+
+        return value;
     }
 }

--- a/AIUsageTracker.Web/Pages/Shared/_Layout.cshtml
+++ b/AIUsageTracker.Web/Pages/Shared/_Layout.cshtml
@@ -42,6 +42,11 @@
                         </a>
                     </li>
                     <li class="nav-item">
+                        <a href="/analytics" class="nav-link @(Context.Request.Path.Value?.Contains("/analytics") == true ? "active" : "")">
+                            <span class="nav-text">Analytics</span>
+                        </a>
+                    </li>
+                    <li class="nav-item">
                         <a href="/providers" class="nav-link @(Context.Request.Path.Value?.Contains("/providers") == true ? "active" : "")">
                             <span class="nav-text">Providers</span>
                         </a>

--- a/AIUsageTracker.Web/Services/WebDatabaseService.cs
+++ b/AIUsageTracker.Web/Services/WebDatabaseService.cs
@@ -87,6 +87,29 @@ public class WebDatabaseService : IWebDatabaseRepository
             GROUP BY h.provider_id, (strftime('%s', h.fetched_at) / @BucketSeconds)
             ORDER BY Timestamp ASC";
 
+    private const string SpendingTrendSql = @"
+            WITH normalized AS (
+                SELECT h.provider_id AS ProviderId,
+                       MIN(p.provider_name) AS ProviderName,
+                       h.requests_used AS Amount,
+                       CASE
+                           WHEN typeof(h.fetched_at) IN ('integer', 'real')
+                               THEN date(CAST(h.fetched_at AS INTEGER), 'unixepoch')
+                           ELSE date(h.fetched_at)
+                       END AS Day
+                FROM provider_history h
+                JOIN providers p ON h.provider_id = p.provider_id
+                WHERE h.provider_id IN @ProviderIds
+                  AND h.fetched_at >= @CutoffUtc
+            )
+            SELECT ProviderId,
+                   ProviderName,
+                   Day AS Date,
+                   MAX(Amount) AS Amount
+            FROM normalized
+            GROUP BY ProviderId, Day
+            ORDER BY Day ASC";
+
     private const string RecentResetEventsSql = @"
             SELECT 
                 id AS Id, 
@@ -263,6 +286,35 @@ public class WebDatabaseService : IWebDatabaseRepository
             "WebDB GetChartDataAsync hours={Hours} bucketMinutes={BucketMinutes} rows={Count} elapsedMs={ElapsedMs}",
             hours,
             bucketMinutes,
+            list.Count,
+            sw.ElapsedMilliseconds);
+        return list;
+    }
+
+    public async Task<IReadOnlyList<SpendingTrendPoint>> GetSpendingTrendAsync(IEnumerable<string> providerIds, int days = 30)
+    {
+        var sw = Stopwatch.StartNew();
+
+        var ids = providerIds as IReadOnlyCollection<string> ?? providerIds.ToList();
+        if (ids.Count == 0)
+        {
+            return [];
+        }
+
+        var cutoffUtc = DateTime.UtcNow.AddDays(-days).ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
+
+        var list = await this.QueryDisplayNamedListIfDatabaseAvailableAsync(
+            connection => connection.QueryAsync<SpendingTrendPoint>(SpendingTrendSql, new
+            {
+                ProviderIds = ids,
+                CutoffUtc = cutoffUtc,
+            }),
+            []).ConfigureAwait(false);
+
+        this._logger.LogInformation(
+            "WebDB GetSpendingTrendAsync days={Days} providers={ProviderCount} rows={Count} elapsedMs={ElapsedMs}",
+            days,
+            ids.Count,
             list.Count,
             sw.ElapsedMilliseconds);
         return list;

--- a/AIUsageTracker.Web/Services/WebStartupServiceExtensions.cs
+++ b/AIUsageTracker.Web/Services/WebStartupServiceExtensions.cs
@@ -27,6 +27,12 @@ internal static class WebStartupServiceExtensions
                 policy.Expire(TimeSpan.FromSeconds(20));
                 policy.SetVaryByQuery("hours");
             });
+
+            options.AddPolicy("AnalyticsCache", policy =>
+            {
+                policy.Expire(TimeSpan.FromSeconds(30));
+                policy.SetVaryByQuery("days");
+            });
         });
         services.AddResponseCompression(options =>
         {


### PR DESCRIPTION
## Changes

- **task-97**: Spending trends analytics page (/analytics) with Chart.js, SpendingTrendPoint model, GetSpendingTrendAsync query, output cache policy, and nav link
- **task-98**: Usage data CSV export on History page with RFC 4180 escaping and 90-day filter

Build passes. All non-UI tests pass.