### PR TITLE
Cycle 22: Tray tooltip aggregate usage

### DIFF
--- a/AIUsageTracker.UI.Slim/App.TrayIcon.cs
+++ b/AIUsageTracker.UI.Slim/App.TrayIcon.cs
@@ -39,6 +39,25 @@ public partial class App
             enablePaceAdjustment);
 
         this.SyncProviderTrayIcons(desiredIcons, yellowThreshold, redThreshold, showUsed);
+        this.UpdateMainTrayTooltip(usages);
+    }
+
+    private void UpdateMainTrayTooltip(IReadOnlyList<ProviderUsage> usages)
+    {
+        if (this._trayIcon == null)
+        {
+            return;
+        }
+
+        var active = usages.Where(u => u.IsAvailable).ToList();
+        if (active.Count == 0)
+        {
+            this._trayIcon.ToolTipText = "AI Usage Tracker";
+            return;
+        }
+
+        var avgRemaining = active.Average(u => u.RemainingPercent);
+        this._trayIcon.ToolTipText = $"AI Usage Tracker — {active.Count} active, {avgRemaining:F0}% avg remaining";
     }
 
     private static Dictionary<string, (string ToolTip, double FillPercent, PaceColorResult PaceColor, bool IsQuota)> BuildDesiredIcons(


### PR DESCRIPTION
## Changes

- **task-100**: System tray tooltip showing active provider count and average remaining percentage. Wired into UpdateProviderTrayIcons.

Build passes.