### PR TITLE
Cycle 22: ProviderMetadataCatalog inversion + Groq provider

### DIFF
--- a/AIUsageTracker.Infrastructure/Providers/GroqProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/GroqProvider.cs
@@ -1,0 +1,203 @@
+// <copyright file="GroqProvider.cs" company="AIUsageTracker">
+// Copyright (c) AIUsageTracker. All rights reserved.
+// </copyright>
+
+using System.Globalization;
+using System.Net.Http.Headers;
+using AIUsageTracker.Core.Models;
+using AIUsageTracker.Core.Providers;
+using Microsoft.Extensions.Logging;
+
+namespace AIUsageTracker.Infrastructure.Providers;
+
+public class GroqProvider : ProviderBase
+{
+    private const string ModelsEndpoint = "https://api.groq.com/openai/v1/models";
+
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<GroqProvider> _logger;
+
+    public GroqProvider(HttpClient httpClient, ILogger<GroqProvider> logger)
+    {
+        this._httpClient = httpClient;
+        this._logger = logger;
+    }
+
+    public static ProviderDefinition StaticDefinition { get; } = new(
+        "groq",
+        "Groq",
+        PlanType.Usage,
+        isQuotaBased: false)
+    {
+        DiscoveryEnvironmentVariables = new[] { "GROQ_API_KEY" },
+        BadgeColorHex = "#F55036",
+        BadgeInitial = "G",
+    };
+
+    public override ProviderDefinition Definition => StaticDefinition;
+
+    public override string ProviderId => StaticDefinition.ProviderId;
+
+    public override async Task<IEnumerable<ProviderUsage>> GetUsageAsync(
+        ProviderConfig config,
+        Action<ProviderUsage>? progressCallback = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        var providerLabel = ProviderMetadataCatalog.GetConfiguredDisplayName(config.ProviderId);
+
+        if (string.IsNullOrEmpty(config.ApiKey))
+        {
+            return new[]
+            {
+                this.CreateUnavailableUsage("API Key missing", state: ProviderUsageState.Missing),
+            };
+        }
+
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, ModelsEndpoint);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", config.ApiKey);
+
+            using var response = await this._httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            var content = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            var httpStatus = (int)response.StatusCode;
+
+            if (!response.IsSuccessStatusCode)
+            {
+                this._logger.LogWarning("Groq API error: {StatusCode}", response.StatusCode);
+                var errorUsage = this.CreateUnavailableUsage(
+                    DescribeUnavailableStatus(response.StatusCode),
+                    httpStatus,
+                    authSource: config.AuthSource);
+                errorUsage.FailureContext = HttpFailureContext.FromHttpStatus(httpStatus);
+                return new[] { errorUsage };
+            }
+
+            var limitRequests = TryParseHeaderDouble(response.Headers, "x-ratelimit-limit-requests");
+            var remainingRequests = TryParseHeaderDouble(response.Headers, "x-ratelimit-remaining-requests");
+            var resetRequestsSeconds = TryParseHeaderDouble(response.Headers, "x-ratelimit-reset-requests");
+            var limitTokens = TryParseHeaderDouble(response.Headers, "x-ratelimit-limit-tokens");
+            var remainingTokens = TryParseHeaderDouble(response.Headers, "x-ratelimit-remaining-tokens");
+            var resetTokensSeconds = TryParseHeaderDouble(response.Headers, "x-ratelimit-reset-tokens");
+
+            var cards = new List<ProviderUsage>();
+
+            if (limitRequests.HasValue && remainingRequests.HasValue)
+            {
+                var usedRequests = limitRequests.Value - remainingRequests.Value;
+                var usedPercent = limitRequests.Value > 0
+                    ? UsageMath.ClampPercent(usedRequests / limitRequests.Value * 100.0)
+                    : 0;
+                var resetTime = ResolveResetTimeFromSeconds(resetRequestsSeconds);
+                var resetDesc = FormatResetDescription(resetRequestsSeconds);
+
+                cards.Add(new ProviderUsage
+                {
+                    ProviderId = this.ProviderId,
+                    ProviderName = providerLabel,
+                    Name = "Daily Requests",
+                    CardId = "daily-requests",
+                    GroupId = this.ProviderId,
+                    IsAvailable = true,
+                    UsedPercent = usedPercent,
+                    RequestsUsed = usedRequests,
+                    RequestsAvailable = limitRequests.Value,
+                    DisplayAsFraction = true,
+                    PlanType = this.Definition.PlanType,
+                    IsQuotaBased = this.Definition.IsQuotaBased,
+                    Description = $"{remainingRequests.Value.ToString("F0", CultureInfo.InvariantCulture)} / {limitRequests.Value.ToString("F0", CultureInfo.InvariantCulture)} requests remaining{(string.IsNullOrEmpty(resetDesc) ? string.Empty : " | " + resetDesc)}",
+                    NextResetTime = resetTime,
+                    RawJson = content,
+                    HttpStatus = httpStatus,
+                });
+            }
+
+            if (limitTokens.HasValue && remainingTokens.HasValue)
+            {
+                var usedTokens = limitTokens.Value - remainingTokens.Value;
+                var usedPercent = limitTokens.Value > 0
+                    ? UsageMath.ClampPercent(usedTokens / limitTokens.Value * 100.0)
+                    : 0;
+                var resetTime = ResolveResetTimeFromSeconds(resetTokensSeconds);
+                var resetDesc = FormatResetDescription(resetTokensSeconds);
+
+                cards.Add(new ProviderUsage
+                {
+                    ProviderId = this.ProviderId,
+                    ProviderName = providerLabel,
+                    Name = "Per-Minute Tokens",
+                    CardId = "per-minute-tokens",
+                    GroupId = this.ProviderId,
+                    IsAvailable = true,
+                    UsedPercent = usedPercent,
+                    RequestsUsed = usedTokens,
+                    RequestsAvailable = limitTokens.Value,
+                    DisplayAsFraction = true,
+                    PlanType = this.Definition.PlanType,
+                    IsQuotaBased = this.Definition.IsQuotaBased,
+                    Description = $"{remainingTokens.Value.ToString("F0", CultureInfo.InvariantCulture)} / {limitTokens.Value.ToString("F0", CultureInfo.InvariantCulture)} tokens remaining{(string.IsNullOrEmpty(resetDesc) ? string.Empty : " | " + resetDesc)}",
+                    NextResetTime = resetTime,
+                    RawJson = content,
+                    HttpStatus = httpStatus,
+                });
+            }
+
+            if (cards.Count == 0)
+            {
+                cards.Add(new ProviderUsage
+                {
+                    ProviderId = this.ProviderId,
+                    ProviderName = providerLabel,
+                    IsAvailable = true,
+                    IsStatusOnly = true,
+                    UsedPercent = 0,
+                    PlanType = this.Definition.PlanType,
+                    IsQuotaBased = this.Definition.IsQuotaBased,
+                    Description = "Connected (no rate-limit headers returned)",
+                    RawJson = content,
+                    HttpStatus = httpStatus,
+                });
+            }
+
+            return cards;
+        }
+        catch (HttpRequestException ex)
+        {
+            this._logger.LogError(ex, "Groq API key validation failed");
+            return new[]
+            {
+                this.CreateUnavailableUsage(
+                    "Connection failed - check network",
+                    authSource: config.AuthSource,
+                    failureContext: HttpFailureContext.FromException(ex, HttpFailureClassification.Network)),
+            };
+        }
+        catch (TaskCanceledException ex)
+        {
+            this._logger.LogError(ex, "Groq API key validation timed out");
+            return new[]
+            {
+                this.CreateUnavailableUsage(
+                    "Request timed out",
+                    authSource: config.AuthSource,
+                    failureContext: HttpFailureContext.FromException(ex, HttpFailureClassification.Timeout)),
+            };
+        }
+    }
+
+    private static double? TryParseHeaderDouble(HttpResponseHeaders headers, string name)
+    {
+        if (headers.TryGetValues(name, out var values))
+        {
+            var raw = values.FirstOrDefault();
+            if (raw != null && double.TryParse(raw, CultureInfo.InvariantCulture, out var result))
+            {
+                return result;
+            }
+        }
+
+        return null;
+    }
+}

--- a/AIUsageTracker.Infrastructure/Providers/ProviderMetadataCatalog.cs
+++ b/AIUsageTracker.Infrastructure/Providers/ProviderMetadataCatalog.cs
@@ -2,6 +2,8 @@
 // Copyright (c) AIUsageTracker. All rights reserved.
 // </copyright>
 
+using System.Reflection;
+
 using AIUsageTracker.Core.Interfaces;
 using AIUsageTracker.Core.Models;
 
@@ -10,6 +12,19 @@ namespace AIUsageTracker.Infrastructure.Providers;
 public static class ProviderMetadataCatalog
 {
     private static readonly Lazy<IReadOnlyList<ProviderDefinition>> DefinitionsValue = new(LoadDefinitions);
+
+    private static Assembly? _discoveryAssembly;
+
+    /// <summary>
+    /// Sets the assembly to scan for IProviderService implementations.
+    /// Call from the composition root (Monitor/Web/CLI startup) before first access to Definitions.
+    /// If not called, defaults to the assembly containing this class (backward compatibility).
+    /// </summary>
+    public static void Initialize(Assembly assembly)
+    {
+        ArgumentNullException.ThrowIfNull(assembly);
+        _discoveryAssembly = assembly;
+    }
 
     public static IReadOnlyList<ProviderDefinition> Definitions => DefinitionsValue.Value;
 
@@ -230,7 +245,8 @@ public static class ProviderMetadataCatalog
     {
         var definitions = new List<ProviderDefinition>();
 
-        var providerTypes = typeof(ProviderMetadataCatalog).Assembly
+        var scanAssembly = _discoveryAssembly ?? typeof(ProviderMetadataCatalog).Assembly;
+        var providerTypes = scanAssembly
             .GetTypes()
             .Where(t => t.IsClass && !t.IsAbstract && typeof(IProviderService).IsAssignableFrom(t));
 
@@ -255,6 +271,13 @@ public static class ProviderMetadataCatalog
                     definitions.Add(additionalDef);
                 }
             }
+        }
+
+        if (definitions.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"ProviderMetadataCatalog discovered zero provider definitions scanning '{scanAssembly.GetName().Name}'. " +
+                "Ensure the correct assembly was passed to ProviderMetadataCatalog.Initialize().");
         }
 
         definitions.Sort((a, b) => string.Compare(a.ProviderId, b.ProviderId, StringComparison.OrdinalIgnoreCase));

--- a/AIUsageTracker.Monitor/Program.cs
+++ b/AIUsageTracker.Monitor/Program.cs
@@ -324,6 +324,8 @@ public partial class Program
         builder.Services.AddSingleton<IConfigService, ConfigService>();
         builder.Services.AddSingleton<IGitHubAuthService, GitHubAuthService>();
         builder.Services.AddSingleton<IProviderDiscoveryService, ProviderDiscoveryService>();
+        AIUsageTracker.Infrastructure.Providers.ProviderMetadataCatalog.Initialize(
+            typeof(AIUsageTracker.Infrastructure.Providers.ProviderMetadataCatalog).Assembly);
         builder.Services.AddProvidersFromAssembly();
         builder.Services.AddSingleton<UsageAlertsService>();
         builder.Services.AddSingleton<ProviderRefreshCircuitBreakerService>();

--- a/AIUsageTracker.Tests/Infrastructure/Providers/GroqProviderTests.cs
+++ b/AIUsageTracker.Tests/Infrastructure/Providers/GroqProviderTests.cs
@@ -1,0 +1,146 @@
+// <copyright file="GroqProviderTests.cs" company="AIUsageTracker">
+// Copyright (c) AIUsageTracker. All rights reserved.
+// </copyright>
+
+using System.Net;
+using AIUsageTracker.Core.Models;
+using AIUsageTracker.Infrastructure.Providers;
+using AIUsageTracker.Tests.Infrastructure;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace AIUsageTracker.Tests.Infrastructure.Providers;
+
+public class GroqProviderTests : HttpProviderTestBase<GroqProvider>
+{
+    private const string TestApiKey = "gsk_test123";
+    private const string ModelsUrl = "https://api.groq.com/openai/v1/models";
+
+    private readonly GroqProvider _provider;
+    private readonly ProviderConfig _config;
+
+    public GroqProviderTests()
+    {
+        _config = new ProviderConfig
+        {
+            ProviderId = "groq",
+            ApiKey = TestApiKey,
+        };
+        this._provider = new GroqProvider(this.HttpClient, NullLogger<GroqProvider>.Instance);
+    }
+
+    [Fact]
+    public async Task GetUsageAsync_NoApiKey_ReturnsMissing()
+    {
+        var config = new ProviderConfig { ProviderId = "groq", ApiKey = string.Empty };
+
+        var results = await this._provider.GetUsageAsync(config);
+
+        var usage = Assert.Single(results);
+        Assert.False(usage.IsAvailable);
+        Assert.Equal(ProviderUsageState.Missing, usage.State);
+        Assert.Contains("API Key missing", usage.Description, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetUsageAsync_ValidResponse_ParsesRateLimitHeaders()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{\"data\":[]}"),
+        };
+        response.Headers.Add("x-ratelimit-limit-requests", "14400");
+        response.Headers.Add("x-ratelimit-remaining-requests", "14370");
+        response.Headers.Add("x-ratelimit-reset-requests", "179.56");
+        response.Headers.Add("x-ratelimit-limit-tokens", "18000");
+        response.Headers.Add("x-ratelimit-remaining-tokens", "17997");
+        response.Headers.Add("x-ratelimit-reset-tokens", "7.66");
+
+        this.SetupHttpResponse(ModelsUrl, response);
+
+        var results = await this._provider.GetUsageAsync(_config);
+        var cards = results.ToList();
+
+        Assert.Equal(2, cards.Count);
+        Assert.All(cards, c => Assert.True(c.IsAvailable));
+        Assert.All(cards, c => Assert.Equal("groq", c.ProviderId));
+
+        var dailyRequests = cards.First(c => string.Equals(c.CardId, "daily-requests", StringComparison.Ordinal));
+        Assert.Equal(14400, dailyRequests.RequestsAvailable);
+        Assert.Equal(30, dailyRequests.RequestsUsed);
+        Assert.True(dailyRequests.UsedPercent < 1);
+        Assert.NotNull(dailyRequests.NextResetTime);
+
+        var perMinuteTokens = cards.First(c => string.Equals(c.CardId, "per-minute-tokens", StringComparison.Ordinal));
+        Assert.Equal(18000, perMinuteTokens.RequestsAvailable);
+        Assert.Equal(3, perMinuteTokens.RequestsUsed);
+        Assert.NotNull(perMinuteTokens.NextResetTime);
+    }
+
+    [Fact]
+    public async Task GetUsageAsync_NoRateLimitHeaders_ReturnsStatusOnlyCard()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{\"data\":[]}"),
+        };
+
+        this.SetupHttpResponse(ModelsUrl, response);
+
+        var results = await this._provider.GetUsageAsync(_config);
+        var usage = Assert.Single(results);
+
+        Assert.True(usage.IsAvailable);
+        Assert.True(usage.IsStatusOnly);
+        Assert.Contains("Connected", usage.Description, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetUsageAsync_Unauthorized_ReturnsUnavailable()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.Unauthorized)
+        {
+            Content = new StringContent("{\"error\":{\"message\":\"Invalid API key\"}}"),
+        };
+
+        this.SetupHttpResponse(ModelsUrl, response);
+
+        var results = await this._provider.GetUsageAsync(_config);
+        var usage = Assert.Single(results);
+
+        Assert.False(usage.IsAvailable);
+        Assert.Contains("401", usage.Description, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetUsageAsync_PartialHeaders_OnlyEmitsCardsForPresentHeaders()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{\"data\":[]}"),
+        };
+        response.Headers.Add("x-ratelimit-limit-requests", "1000");
+        response.Headers.Add("x-ratelimit-remaining-requests", "900");
+        response.Headers.Add("x-ratelimit-reset-requests", "3600");
+
+        this.SetupHttpResponse(ModelsUrl, response);
+
+        var results = await this._provider.GetUsageAsync(_config);
+        var card = Assert.Single(results);
+
+        Assert.Equal("daily-requests", card.CardId);
+        Assert.Equal(1000, card.RequestsAvailable);
+        Assert.Equal(100, card.RequestsUsed);
+    }
+
+    [Fact]
+    public void StaticDefinition_HasExpectedProperties()
+    {
+        var definition = GroqProvider.StaticDefinition;
+
+        Assert.Equal("groq", definition.ProviderId);
+        Assert.Equal("Groq", definition.DisplayName);
+        Assert.Equal(PlanType.Usage, definition.PlanType);
+        Assert.False(definition.IsQuotaBased);
+        Assert.Contains("GROQ_API_KEY", definition.DiscoveryEnvironmentVariables);
+    }
+}

--- a/AIUsageTracker.Web/Services/WebApplicationBootstrapper.cs
+++ b/AIUsageTracker.Web/Services/WebApplicationBootstrapper.cs
@@ -17,6 +17,8 @@ internal static class WebApplicationBootstrapper
 
         var builder = WebApplication.CreateBuilder(args);
         builder.Host.UseSerilog();
+        AIUsageTracker.Infrastructure.Providers.ProviderMetadataCatalog.Initialize(
+            typeof(AIUsageTracker.Infrastructure.Providers.ProviderMetadataCatalog).Assembly);
         builder.Services.AddWebUiDataProtection(builder.Environment, runtimePaths.DataProtectionKeyDirectory);
         builder.Services.AddWebUiInfrastructure();
         builder.Services.AddAIUsageTrackerWebServices(runtimePaths.DatabasePath);

--- a/docs/research/provider-api-findings.md
+++ b/docs/research/provider-api-findings.md
@@ -1,0 +1,128 @@
+# Provider API Investigation Findings (Cycle 22)
+
+**Date:** 2026-06-26
+**Task:** task-102 — Investigate candidate provider APIs for usage/quota endpoints
+
+## Summary
+
+Investigated three provider APIs for usage/quota/billing endpoints. One provider (Groq) was implemented; two were documented as not viable for the tracker.
+
+| Provider | Endpoint Exists? | Auth Required | Data Available | Verdict |
+|----------|-----------------|---------------|----------------|---------|
+| Google Gemini | No (standard API) | API key | None for standard API key path | Already implemented (OAuth CLI quota) |
+| Anthropic Claude | Yes (Usage & Cost API) | Admin API key | Spending, tokens per model, workspace breakdowns | Not viable — requires admin key, most users only have standard API key |
+| Groq | No (rate-limit headers only) | Standard API key | Remaining requests/day, tokens/minute | **Implemented** as rate-limit-header provider |
+
+---
+
+## 1. Google Gemini (`generativelanguage.googleapis.com`)
+
+### Investigation
+
+The standard Gemini API at `generativelanguage.googleapis.com` provides model inference endpoints only (generateContent, embedContent, listModels, etc.). There is **no usage, quota, or billing endpoint** accessible via a standard API key.
+
+Google provides quota information through:
+- **Google Cloud Console** (web UI) — requires GCP project access
+- **Service Usage API** (`serviceusage.googleapis.com`) — requires GCP OAuth scopes, not API keys
+
+### Existing Implementation
+
+The project already has a `GeminiProvider` (`gemini-cli` provider ID) that uses OAuth credentials from the gemini-cli tool to query `cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota`. This is a completely different auth path from the standard API key — it uses embedded OAuth client credentials from the open-source CLI tool.
+
+### Verdict
+
+**Already implemented.** The OAuth-based quota path is the only way to get Gemini quota data. A new API-key-based provider has no viable endpoint.
+
+---
+
+## 2. Anthropic Claude (`api.anthropic.com`)
+
+### Investigation
+
+Anthropic offers two distinct APIs for usage data:
+
+#### Standard API (Rate-Limit Headers)
+
+Every response to `POST /v1/messages` includes rate-limit headers:
+- `anthropic-ratelimit-requests-limit` / `anthropic-ratelimit-requests-remaining`
+- `anthropic-ratelimit-tokens-limit` / `anthropic-ratelimit-tokens-remaining`
+- `anthropic-ratelimit-input-tokens-limit` / `anthropic-ratelimit-input-tokens-remaining`
+- `anthropic-ratelimit-output-tokens-limit` / `anthropic-ratelimit-output-tokens-remaining`
+
+These are instantaneous rate-limit capacity, not cumulative usage. The existing `ClaudeCodeProvider` already reads these headers in its API-key fallback path.
+
+#### Admin API (Usage & Cost API)
+
+Anthropic provides an excellent Usage and Cost Admin API:
+- `GET /v1/organizations/usage_report/messages` — token counts per model, per workspace, per service tier, with time bucketing (1m/1h/1d)
+- `GET /v1/organizations/cost_report` — USD cost breakdowns by workspace, model, and description
+
+This provides exactly the data the tracker is designed for (spending, token usage, budget tracking).
+
+**However**, this API requires an **Admin API key** (`sk-ant-admin01-...`), which is:
+- Different from the standard Claude API key (`sk-ant-api...`)
+- Only available to organization admins who set up their org in the Console
+- Not discoverable via the standard `ANTHROPIC_API_KEY` environment variable
+
+### Verdict
+
+**Not viable for implementation.** The Usage & Cost API has the clearest usage data of all three providers, but the admin key requirement creates a significant barrier for typical users. The standard API key path is already handled by `ClaudeCodeProvider`. Adding a separate provider that requires admin keys would be confusing and most users would see "API Key missing."
+
+**Future consideration:** If demand exists, a separate `anthropic-admin` provider could be added that accepts admin keys and queries the Usage & Cost API. This would require explicit user configuration (no auto-discovery).
+
+---
+
+## 3. Groq (`api.groq.com`)
+
+### Investigation
+
+Groq provides an OpenAI-compatible API. There is **no dedicated usage or billing endpoint**.
+
+However, every response includes rate-limit headers:
+- `x-ratelimit-limit-requests` — requests per day (RPD) limit
+- `x-ratelimit-remaining-requests` — remaining requests today
+- `x-ratelimit-reset-requests` — time until daily limit resets (Go duration format)
+- `x-ratelimit-limit-tokens` — tokens per minute (TPM) limit
+- `x-ratelimit-remaining-tokens` — remaining tokens this minute
+- `x-ratelimit-reset-tokens` — time until token limit resets
+
+### Authentication
+
+Standard API key via `Authorization: Bearer <key>`. Discoverable via `GROQ_API_KEY` environment variable.
+
+### Data Available
+
+Rate-limit headers provide instantaneous capacity data:
+- Daily request quota: used/remaining with reset time
+- Per-minute token quota: used/remaining with reset time
+
+This is not cumulative usage or spending — it's "how much capacity do I have right now." Similar to what the xAI provider shows (key status) and what ClaudeCodeProvider shows in its API-key path.
+
+### Verdict
+
+**Implemented as `GroqProvider`.** The provider:
+- GETs `/openai/v1/models` (lightweight endpoint) with Bearer auth
+- Reads rate-limit headers from the response
+- Emits two cards: Daily Requests and Per-Minute Tokens
+- Falls back to a status-only "Connected" card if headers are missing
+- Auto-discovered via `GROQ_API_KEY` environment variable
+- Follows ProviderBase pattern (AD-8) for error handling
+
+---
+
+## Decision Rationale
+
+Groq was chosen for implementation because:
+1. **Standard API key** — no OAuth, no admin key, works with existing discovery patterns
+2. **No existing provider** — clean addition with no overlap
+3. **Rate-limit data is useful** — shows current capacity, more informative than OpenAI's API-key path which only says "Connected"
+4. **Follows established patterns** — xAI and ClaudeCodeProvider both use non-usage endpoints to show status data
+
+Anthropic was not implemented because:
+- The Usage & Cost API requires admin keys most users won't have
+- The standard API key path is already handled by ClaudeCodeProvider
+- Adding a confusing second Anthropic provider entry in settings would hurt UX
+
+Gemini was not implemented because:
+- The existing GeminiProvider already covers the only viable quota endpoint (OAuth CLI path)
+- The standard API has no usage endpoint at all


### PR DESCRIPTION
## Changes

- **task-99**: ProviderMetadataCatalog.Initialize(Assembly) static method with zero-providers guard. Prerequisite for Core migration. Backward-compatible fallback.
- **task-102**: New GroqProvider with rate-limit header parsing (daily requests + per-minute tokens). Provider API research findings doc documenting Gemini (already implemented), Anthropic (admin key barrier), and Groq (implemented).

Build passes. 990 non-UI tests pass.