### PR TITLE
Cycle 23 Infrastructure: Anthropic Usage provider + rate-limit header parsing

### DIFF
--- a/AIUsageTracker.Core/Providers/ProviderBase.cs
+++ b/AIUsageTracker.Core/Providers/ProviderBase.cs
@@ -48,6 +48,22 @@ public abstract class ProviderBase : IProviderService
         return $"Resets in {((int)resetAfterSeconds.Value).ToString(CultureInfo.InvariantCulture)}s";
     }
 
+    protected static double? TryGetHeaderDouble(System.Net.Http.Headers.HttpResponseHeaders headers, string name)
+    {
+        ArgumentNullException.ThrowIfNull(headers);
+
+        if (headers.TryGetValues(name, out var values))
+        {
+            var raw = values.FirstOrDefault();
+            if (raw != null && double.TryParse(raw, CultureInfo.InvariantCulture, out var result))
+            {
+                return result;
+            }
+        }
+
+        return null;
+    }
+
     protected static DateTime? ResolveResetTimeFromSeconds(double? resetAfterSeconds)
     {
         if (!resetAfterSeconds.HasValue || resetAfterSeconds.Value <= 0)

--- a/AIUsageTracker.Infrastructure/Providers/AnthropicUsageProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/AnthropicUsageProvider.cs
@@ -1,0 +1,207 @@
+// <copyright file="AnthropicUsageProvider.cs" company="AIUsageTracker">
+// Copyright (c) AIUsageTracker. All rights reserved.
+// </copyright>
+
+using System.Globalization;
+using System.Net.Http.Headers;
+using System.Text.Json.Serialization;
+using AIUsageTracker.Core.Models;
+using AIUsageTracker.Core.Providers;
+using Microsoft.Extensions.Logging;
+
+namespace AIUsageTracker.Infrastructure.Providers;
+
+public class AnthropicUsageProvider : ProviderBase
+{
+    private const string BaseUrl = "https://api.anthropic.com";
+    private const string UsageEndpoint = BaseUrl + "/v1/organizations/usage_report/messages";
+    private const string CostEndpoint = BaseUrl + "/v1/organizations/cost_report";
+    private const string AnthropicVersion = "2023-06-01";
+
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<AnthropicUsageProvider> _logger;
+
+    public AnthropicUsageProvider(HttpClient httpClient, ILogger<AnthropicUsageProvider> logger)
+    {
+        this._httpClient = httpClient;
+        this._logger = logger;
+    }
+
+    public static ProviderDefinition StaticDefinition { get; } = new(
+        "anthropic-usage",
+        "Anthropic (Admin)",
+        PlanType.Usage,
+        isQuotaBased: false)
+    {
+        IsCurrencyUsage = true,
+        ExplicitApiKeyPrefixes = new[] { "sk-ant-admin01-" },
+        BadgeColorHex = "#D4A27F",
+        BadgeInitial = "A",
+    };
+
+    public override ProviderDefinition Definition => StaticDefinition;
+
+    public override string ProviderId => StaticDefinition.ProviderId;
+
+    public override async Task<IEnumerable<ProviderUsage>> GetUsageAsync(
+        ProviderConfig config,
+        Action<ProviderUsage>? progressCallback = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        var providerLabel = ProviderMetadataCatalog.GetConfiguredDisplayName(config.ProviderId);
+
+        if (string.IsNullOrEmpty(config.ApiKey))
+        {
+            return new[]
+            {
+                this.CreateUnavailableUsage("Admin API Key missing", state: ProviderUsageState.Missing),
+            };
+        }
+
+        var today = DateTime.UtcNow.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+        var cards = new List<ProviderUsage>();
+        var combinedRaw = string.Empty;
+
+        // ── Fetch daily cost ──────────────────────────────────────────────
+        var costResult = await this.FetchJsonAsync<CostReportResponse>(
+            CostEndpoint + "?start_date=" + today + "&end_date=" + today,
+            config,
+            this._httpClient,
+            this._logger,
+            cancellationToken,
+            CustomizeAdminRequest).ConfigureAwait(false);
+
+        if (!costResult.IsSuccess)
+        {
+            return new[] { costResult.FailureUsage! };
+        }
+
+        combinedRaw = costResult.RawContent;
+
+        var totalCost = costResult.Data?.Data?
+            .Sum(d => d.CostUsd) ?? 0;
+
+        if (totalCost > 0)
+        {
+            cards.Add(new WindowedProviderUsage
+            {
+                ProviderId = this.ProviderId,
+                ProviderName = providerLabel,
+                Name = "Daily Cost",
+                CardId = "daily-cost",
+                GroupId = this.ProviderId,
+                IsAvailable = true,
+                IsCurrencyUsage = true,
+                PlanType = this.Definition.PlanType,
+                IsQuotaBased = this.Definition.IsQuotaBased,
+                UsedPercent = 0,
+                Description = string.Format(CultureInfo.InvariantCulture, "${0:F2} today", totalCost),
+                RawJson = combinedRaw,
+                HttpStatus = costResult.HttpStatus,
+            });
+        }
+
+        // ── Fetch daily token usage ───────────────────────────────────────
+        var usageResult = await this.FetchJsonAsync<UsageReportResponse>(
+            UsageEndpoint + "?start_date=" + today + "&end_date=" + today,
+            config,
+            this._httpClient,
+            this._logger,
+            cancellationToken,
+            CustomizeAdminRequest).ConfigureAwait(false);
+
+        if (usageResult.IsSuccess)
+        {
+            combinedRaw += "\n---\n" + usageResult.RawContent;
+
+            var totalInputTokens = usageResult.Data?.Data?
+                .Sum(d => d.InputTokens) ?? 0;
+            var totalOutputTokens = usageResult.Data?.Data?
+                .Sum(d => d.OutputTokens) ?? 0;
+            var totalTokens = totalInputTokens + totalOutputTokens;
+
+            if (totalTokens > 0)
+            {
+                cards.Add(new WindowedProviderUsage
+                {
+                    ProviderId = this.ProviderId,
+                    ProviderName = providerLabel,
+                    Name = "Daily Tokens",
+                    CardId = "daily-tokens",
+                    GroupId = this.ProviderId,
+                    IsAvailable = true,
+                    IsCurrencyUsage = true,
+                    PlanType = this.Definition.PlanType,
+                    IsQuotaBased = this.Definition.IsQuotaBased,
+                    UsedPercent = 0,
+                    Description = string.Format(CultureInfo.InvariantCulture, "{0:N0} tokens ({1:N0} in / {2:N0} out)", totalTokens, totalInputTokens, totalOutputTokens),
+                    RawJson = combinedRaw,
+                    HttpStatus = usageResult.HttpStatus,
+                });
+            }
+        }
+
+        if (cards.Count == 0)
+        {
+            cards.Add(new StatusProviderUsage
+            {
+                ProviderId = this.ProviderId,
+                ProviderName = providerLabel,
+                IsAvailable = true,
+                Description = "Connected (no usage data for today)",
+                RawJson = combinedRaw,
+                HttpStatus = costResult.HttpStatus,
+            });
+        }
+
+        return cards;
+    }
+
+    private static void CustomizeAdminRequest(HttpRequestMessage request)
+    {
+        var apiKey = request.Headers.Authorization?.Parameter;
+        request.Headers.Authorization = null;
+        if (!string.IsNullOrEmpty(apiKey))
+        {
+            request.Headers.Add("x-api-key", apiKey);
+        }
+
+        request.Headers.Add("anthropic-version", AnthropicVersion);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+    }
+
+    private sealed class CostReportResponse
+    {
+        [JsonPropertyName("data")]
+        public List<CostDataPoint>? Data { get; set; }
+    }
+
+    private sealed class CostDataPoint
+    {
+        [JsonPropertyName("model")]
+        public string? Model { get; set; }
+
+        [JsonPropertyName("total_cost_usd")]
+        public double CostUsd { get; set; }
+    }
+
+    private sealed class UsageReportResponse
+    {
+        [JsonPropertyName("data")]
+        public List<UsageDataPoint>? Data { get; set; }
+    }
+
+    private sealed class UsageDataPoint
+    {
+        [JsonPropertyName("model")]
+        public string? Model { get; set; }
+
+        [JsonPropertyName("input_tokens")]
+        public long InputTokens { get; set; }
+
+        [JsonPropertyName("output_tokens")]
+        public long OutputTokens { get; set; }
+    }
+}

--- a/AIUsageTracker.Infrastructure/Providers/ClaudeCodeProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/ClaudeCodeProvider.cs
@@ -434,33 +434,13 @@ public class ClaudeCodeProvider : ProviderBase
 
     private static RateLimitInfo ExtractRateLimitInfo(System.Net.Http.Headers.HttpResponseHeaders headers)
     {
-        var info = new RateLimitInfo();
-
-        if (headers.TryGetValues("anthropic-ratelimit-requests-limit", out var requestLimitValues) &&
-            int.TryParse(requestLimitValues.FirstOrDefault(), CultureInfo.InvariantCulture, out var limit))
+        return new RateLimitInfo
         {
-            info.RequestsLimit = limit;
-        }
-
-        if (headers.TryGetValues("anthropic-ratelimit-requests-remaining", out var requestRemainingValues) &&
-            int.TryParse(requestRemainingValues.FirstOrDefault(), CultureInfo.InvariantCulture, out var remaining))
-        {
-            info.RequestsRemaining = remaining;
-        }
-
-        if (headers.TryGetValues("anthropic-ratelimit-input-tokens-limit", out var inputLimitValues) &&
-            int.TryParse(inputLimitValues.FirstOrDefault(), CultureInfo.InvariantCulture, out var inputLimit))
-        {
-            info.InputTokensLimit = inputLimit;
-        }
-
-        if (headers.TryGetValues("anthropic-ratelimit-input-tokens-remaining", out var inputRemainingValues) &&
-            int.TryParse(inputRemainingValues.FirstOrDefault(), CultureInfo.InvariantCulture, out var inputRemaining))
-        {
-            info.InputTokensRemaining = inputRemaining;
-        }
-
-        return info;
+            RequestsLimit = (int)(TryGetHeaderDouble(headers, "anthropic-ratelimit-requests-limit") ?? 0),
+            RequestsRemaining = (int)(TryGetHeaderDouble(headers, "anthropic-ratelimit-requests-remaining") ?? 0),
+            InputTokensLimit = (int)(TryGetHeaderDouble(headers, "anthropic-ratelimit-input-tokens-limit") ?? 0),
+            InputTokensRemaining = (int)(TryGetHeaderDouble(headers, "anthropic-ratelimit-input-tokens-remaining") ?? 0),
+        };
     }
 
     private async Task<IEnumerable<ProviderUsage>> GetUsageFromCliAsync(string providerLabel)

--- a/AIUsageTracker.Infrastructure/Providers/GroqProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/GroqProvider.cs
@@ -75,12 +75,12 @@ public class GroqProvider : ProviderBase
                 return new[] { errorUsage };
             }
 
-            var limitRequests = TryParseHeaderDouble(response.Headers, "x-ratelimit-limit-requests");
-            var remainingRequests = TryParseHeaderDouble(response.Headers, "x-ratelimit-remaining-requests");
-            var resetRequestsSeconds = TryParseHeaderDouble(response.Headers, "x-ratelimit-reset-requests");
-            var limitTokens = TryParseHeaderDouble(response.Headers, "x-ratelimit-limit-tokens");
-            var remainingTokens = TryParseHeaderDouble(response.Headers, "x-ratelimit-remaining-tokens");
-            var resetTokensSeconds = TryParseHeaderDouble(response.Headers, "x-ratelimit-reset-tokens");
+            var limitRequests = TryGetHeaderDouble(response.Headers, "x-ratelimit-limit-requests");
+            var remainingRequests = TryGetHeaderDouble(response.Headers, "x-ratelimit-remaining-requests");
+            var resetRequestsSeconds = TryGetHeaderDouble(response.Headers, "x-ratelimit-reset-requests");
+            var limitTokens = TryGetHeaderDouble(response.Headers, "x-ratelimit-limit-tokens");
+            var remainingTokens = TryGetHeaderDouble(response.Headers, "x-ratelimit-remaining-tokens");
+            var resetTokensSeconds = TryGetHeaderDouble(response.Headers, "x-ratelimit-reset-tokens");
 
             var cards = new List<ProviderUsage>();
 
@@ -181,19 +181,5 @@ public class GroqProvider : ProviderBase
                     failureContext: HttpFailureContext.FromException(ex, HttpFailureClassification.Timeout)),
             };
         }
-    }
-
-    private static double? TryParseHeaderDouble(HttpResponseHeaders headers, string name)
-    {
-        if (headers.TryGetValues(name, out var values))
-        {
-            var raw = values.FirstOrDefault();
-            if (raw != null && double.TryParse(raw, CultureInfo.InvariantCulture, out var result))
-            {
-                return result;
-            }
-        }
-
-        return null;
     }
 }

--- a/AIUsageTracker.Tests/Core/ProviderBaseTests.cs
+++ b/AIUsageTracker.Tests/Core/ProviderBaseTests.cs
@@ -35,6 +35,9 @@ public class ProviderBaseTests
 
         public string TestDescribeUnavailableException(Exception ex, string context = "Test context")
             => DescribeUnavailableException(ex, context);
+
+        public double? TestTryGetHeaderDouble(System.Net.Http.Headers.HttpResponseHeaders headers, string name)
+            => TryGetHeaderDouble(headers, name);
     }
 
     private readonly TestProvider _provider = new();
@@ -89,5 +92,48 @@ public class ProviderBaseTests
         var description = this._provider.TestDescribeUnavailableException(ex);
 
         Assert.Contains("Connection failed", description, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TryGetHeaderDouble_ValidHeader_ReturnsValue()
+    {
+        var response = new HttpResponseMessage();
+        response.Headers.Add("x-ratelimit-limit-requests", "14400");
+
+        var result = this._provider.TestTryGetHeaderDouble(response.Headers, "x-ratelimit-limit-requests");
+
+        Assert.Equal(14400, result);
+    }
+
+    [Fact]
+    public void TryGetHeaderDouble_DecimalValue_ReturnsValue()
+    {
+        var response = new HttpResponseMessage();
+        response.Headers.Add("x-ratelimit-reset-requests", "179.56");
+
+        var result = this._provider.TestTryGetHeaderDouble(response.Headers, "x-ratelimit-reset-requests");
+
+        Assert.Equal(179.56, result);
+    }
+
+    [Fact]
+    public void TryGetHeaderDouble_MissingHeader_ReturnsNull()
+    {
+        var response = new HttpResponseMessage();
+
+        var result = this._provider.TestTryGetHeaderDouble(response.Headers, "x-ratelimit-limit-requests");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void TryGetHeaderDouble_MalformedValue_ReturnsNull()
+    {
+        var response = new HttpResponseMessage();
+        response.Headers.Add("x-ratelimit-limit-requests", "not-a-number");
+
+        var result = this._provider.TestTryGetHeaderDouble(response.Headers, "x-ratelimit-limit-requests");
+
+        Assert.Null(result);
     }
 }

--- a/AIUsageTracker.Tests/Infrastructure/Providers/AnthropicUsageProviderTests.cs
+++ b/AIUsageTracker.Tests/Infrastructure/Providers/AnthropicUsageProviderTests.cs
@@ -1,0 +1,208 @@
+// <copyright file="AnthropicUsageProviderTests.cs" company="AIUsageTracker">
+// Copyright (c) AIUsageTracker. All rights reserved.
+// </copyright>
+
+using System.Net;
+using AIUsageTracker.Core.Models;
+using AIUsageTracker.Infrastructure.Providers;
+using AIUsageTracker.Tests.Infrastructure;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace AIUsageTracker.Tests.Infrastructure.Providers;
+
+public class AnthropicUsageProviderTests : HttpProviderTestBase<AnthropicUsageProvider>
+{
+    private const string TestAdminKey = "sk-ant-admin01-test-key";
+    private const string CostUrl = "https://api.anthropic.com/v1/organizations/cost_report";
+    private const string UsageUrl = "https://api.anthropic.com/v1/organizations/usage_report/messages";
+
+    private readonly AnthropicUsageProvider _provider;
+    private readonly ProviderConfig _config;
+
+    public AnthropicUsageProviderTests()
+    {
+        _config = new ProviderConfig
+        {
+            ProviderId = "anthropic-usage",
+            ApiKey = TestAdminKey,
+        };
+        this._provider = new AnthropicUsageProvider(this.HttpClient, NullLogger<AnthropicUsageProvider>.Instance);
+    }
+
+    [Fact]
+    public async Task GetUsageAsync_NoApiKey_ReturnsMissing()
+    {
+        var config = new ProviderConfig { ProviderId = "anthropic-usage", ApiKey = string.Empty };
+
+        var results = await this._provider.GetUsageAsync(config);
+
+        var usage = Assert.Single(results);
+        Assert.False(usage.IsAvailable);
+        Assert.Equal(ProviderUsageState.Missing, usage.State);
+        Assert.Contains("Admin API Key missing", usage.Description, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetUsageAsync_CostReportError_ReturnsUnavailable()
+    {
+        var errorResponse = new HttpResponseMessage(HttpStatusCode.Unauthorized)
+        {
+            Content = new StringContent("{\"error\":{\"message\":\"invalid key\"}}"),
+        };
+
+        this.SetupHttpResponse(
+            r => r.RequestUri != null && r.RequestUri.ToString().StartsWith(CostUrl, StringComparison.Ordinal),
+            errorResponse);
+
+        var results = await this._provider.GetUsageAsync(_config);
+
+        var usage = Assert.Single(results);
+        Assert.False(usage.IsAvailable);
+        Assert.Contains("Authentication failed", usage.Description, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetUsageAsync_ValidCostAndUsage_ReturnsBothCards()
+    {
+        var costResponse = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                "{\"data\":[{\"model\":\"claude-sonnet-4-20250514\",\"total_cost_usd\":5.42}]}"),
+        };
+
+        var usageResponse = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                "{\"data\":[{\"model\":\"claude-sonnet-4-20250514\",\"input_tokens\":12000,\"output_tokens\":8000}]}"),
+        };
+
+        this.SetupHttpResponse(
+            r => r.RequestUri != null && r.RequestUri.ToString().StartsWith(CostUrl, StringComparison.Ordinal),
+            costResponse);
+        this.SetupHttpResponse(
+            r => r.RequestUri != null && r.RequestUri.ToString().StartsWith(UsageUrl, StringComparison.Ordinal),
+            usageResponse);
+
+        var results = (await this._provider.GetUsageAsync(_config))
+            .Cast<QuotaProviderUsage>()
+            .ToList();
+
+        Assert.Equal(2, results.Count);
+
+        var costCard = results.FirstOrDefault(c => c.CardId == "daily-cost");
+        Assert.NotNull(costCard);
+        Assert.True(costCard!.IsAvailable);
+        Assert.Contains("$5.42", costCard.Description, StringComparison.Ordinal);
+
+        var tokenCard = results.FirstOrDefault(c => c.CardId == "daily-tokens");
+        Assert.NotNull(tokenCard);
+        Assert.True(tokenCard!.IsAvailable);
+        Assert.Contains("20,000 tokens", tokenCard.Description, StringComparison.Ordinal);
+        Assert.Contains("12,000 in", tokenCard.Description, StringComparison.Ordinal);
+        Assert.Contains("8,000 out", tokenCard.Description, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetUsageAsync_NoCostData_ReturnsStatusCard()
+    {
+        var costResponse = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{\"data\":[]}"),
+        };
+
+        var usageResponse = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{\"data\":[]}"),
+        };
+
+        this.SetupHttpResponse(
+            r => r.RequestUri != null && r.RequestUri.ToString().StartsWith(CostUrl, StringComparison.Ordinal),
+            costResponse);
+        this.SetupHttpResponse(
+            r => r.RequestUri != null && r.RequestUri.ToString().StartsWith(UsageUrl, StringComparison.Ordinal),
+            usageResponse);
+
+        var results = await this._provider.GetUsageAsync(_config);
+
+        var usage = Assert.Single(results);
+        Assert.True(usage.IsAvailable);
+        Assert.Contains("no usage data", usage.Description, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task GetUsageAsync_CostOnly_NoUsageTokens_ReturnsCostCardOnly()
+    {
+        var costResponse = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                "{\"data\":[{\"model\":\"claude-sonnet-4-20250514\",\"total_cost_usd\":1.50}]}"),
+        };
+
+        var usageResponse = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{\"data\":[]}"),
+        };
+
+        this.SetupHttpResponse(
+            r => r.RequestUri != null && r.RequestUri.ToString().StartsWith(CostUrl, StringComparison.Ordinal),
+            costResponse);
+        this.SetupHttpResponse(
+            r => r.RequestUri != null && r.RequestUri.ToString().StartsWith(UsageUrl, StringComparison.Ordinal),
+            usageResponse);
+
+        var results = (await this._provider.GetUsageAsync(_config))
+            .Cast<QuotaProviderUsage>()
+            .ToList();
+
+        var usage = Assert.Single(results);
+        Assert.Equal("daily-cost", usage.CardId);
+        Assert.Contains("$1.50", usage.Description, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void StaticDefinition_HasCorrectProviderId()
+    {
+        Assert.Equal("anthropic-usage", AnthropicUsageProvider.StaticDefinition.ProviderId);
+        Assert.Equal("Anthropic (Admin)", AnthropicUsageProvider.StaticDefinition.DisplayName);
+        Assert.True(AnthropicUsageProvider.StaticDefinition.IsCurrencyUsage);
+    }
+
+    [Fact]
+    public async Task GetUsageAsync_UsesXApiKeyHeaderNotBearer()
+    {
+        HttpRequestMessage? capturedRequest = null;
+
+        var costResponse = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{\"data\":[]}"),
+        };
+
+        var usageResponse = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{\"data\":[]}"),
+        };
+
+        this.SetupHttpResponse(
+            r =>
+            {
+                if (r.RequestUri != null && r.RequestUri.ToString().StartsWith(CostUrl, StringComparison.Ordinal))
+                {
+                    capturedRequest = r;
+                    return true;
+                }
+
+                return false;
+            },
+            costResponse);
+        this.SetupHttpResponse(
+            r => r.RequestUri != null && r.RequestUri.ToString().StartsWith(UsageUrl, StringComparison.Ordinal),
+            usageResponse);
+
+        await this._provider.GetUsageAsync(_config);
+
+        Assert.NotNull(capturedRequest);
+        Assert.Null(capturedRequest!.Headers.Authorization);
+        Assert.True(capturedRequest.Headers.Contains("x-api-key"));
+        Assert.True(capturedRequest.Headers.Contains("anthropic-version"));
+    }
+}


### PR DESCRIPTION
## Changes

- **task-103**: Anthropic Usage/Cost provider via admin API. Uses x-api-key header. Two API calls (cost_report + usage_report/messages). Emits WindowedProviderUsage cards. 7 unit tests.
- **task-106**: Rate-limit header parsing on ProviderBase. Moved TryParseHeaderDouble from GroqProvider to ProviderBase.TryGetHeaderDouble. Refactored ClaudeCodeProvider. 4 new tests.

## Verification
- Build: PASS
- Tests: 1554 pass (1413 + 141 Monitor.Tests)
