### PR TITLE
Disable AnthropicUsageProvider visibility

### DIFF
--- a/AIUsageTracker.Infrastructure/Providers/AnthropicUsageProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/AnthropicUsageProvider.cs
@@ -37,6 +37,8 @@ public class AnthropicUsageProvider : ProviderBase
         ExplicitApiKeyPrefixes = new[] { "sk-ant-admin01-" },
         BadgeColorHex = "#D4A27F",
         BadgeInitial = "A",
+        ShowInMainWindow = false,
+        ShowInSettings = false,
     };
 
     public override ProviderDefinition Definition => StaticDefinition;


### PR DESCRIPTION
Provider response model field names are unverified. Hidden from main window and settings until tested with a real admin API key.