### PR TITLE
Simplify hibernate fix: just keep stale data, no special resume behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -511,3 +511,4 @@ ci_screenshots/
 .sonarqube/
 build-task107.err
 test-task107.err
+build-hib.err

--- a/AIUsageTracker.UI.Slim/MainWindow.Polling.cs
+++ b/AIUsageTracker.UI.Slim/MainWindow.Polling.cs
@@ -323,7 +323,6 @@ public partial class MainWindow : Window
         {
             this._logger.LogInformation(
                 "Skipping update: incoming data is all unavailable, preserving existing data");
-            this.ShowStatus($"{now:HH:mm:ss} (reconnecting...)", StatusType.Warning);
             return;
         }
 

--- a/AIUsageTracker.UI.Slim/MainWindow.xaml.cs
+++ b/AIUsageTracker.UI.Slim/MainWindow.xaml.cs
@@ -563,19 +563,6 @@ public partial class MainWindow : Window
     [System.Runtime.Versioning.SupportedOSPlatform("windows")]
     private void OnPowerModeChanged(object sender, PowerModeChangedEventArgs e)
     {
-        if (e.Mode == PowerModes.Resume)
-        {
-            this._logger.LogInformation("System resumed from sleep/hibernate");
-            this.Dispatcher.InvokeAsync(() =>
-            {
-                if (this._pollingTimer != null && this._pollingTimer.Interval != StartupPollingInterval)
-                {
-                    this._pollingTimer.Interval = StartupPollingInterval;
-                }
-
-                _ = this.RefreshDataAsync();
-            });
-        }
     }
 
     private void UpdatePrivacyButtonState()


### PR DESCRIPTION
Reverts the rapid polling and immediate refresh added in PR #682. After hibernate, just keep showing stale data from before until the normal polling timer brings in new data. The all-unavailable guard in ApplyFetchedUsages stays but is simplified — silently skips, no status message.