### PR TITLE
Pre-release cleanup: version bump, changelog update, auth fallback fix

### DIFF
--- a/AIUsageTracker.Infrastructure/Providers/AnthropicUsageProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/AnthropicUsageProvider.cs
@@ -35,6 +35,7 @@ public class AnthropicUsageProvider : ProviderBase
     {
         IsCurrencyUsage = true,
         ExplicitApiKeyPrefixes = new[] { "sk-ant-admin01-" },
+        DiscoveryEnvironmentVariables = new[] { "ANTHROPIC_ADMIN_API_KEY" },
         BadgeColorHex = "#D4A27F",
         BadgeInitial = "A",
         ShowInMainWindow = false,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-## [2.3.8-beta.1] - 2026-06-27
+## [2.3.8-beta.1] - 2026-06-28
 
 ### Added
 - **Anthropic Usage/Cost provider**: New provider tracking spending via Anthropic admin API (cost_report + usage_report endpoints). Uses `x-api-key` header auth. Emits daily-cost and daily-tokens cards.
@@ -12,6 +12,11 @@
 ### Changed
 - **ProviderMetadataCatalog moved to Core**: The catalog now lives in `AIUsageTracker.Core.Providers` instead of Infrastructure. Composition roots pass the Infrastructure assembly to `Initialize()` for provider discovery.
 - **BetaUpdateCheck fix**: Version suffix parsing now correctly handles develop-suffix format (e.g. `2.3.7-beta.1-1-develop`).
+- **AnthropicUsageProvider hidden**: Disabled from main window and settings pending verification with real admin API key.
+
+### Fixed
+- **Hibernate data preservation**: After resuming from sleep/hibernate, the UI keeps showing stale data instead of wiping to zero. No special resume handling — normal polling timer eventually brings new data. An all-unavailable guard in `ApplyFetchedUsages` prevents overwriting available data with reconnecting-state data.
+- **Auth fallback contract**: `anthropic-usage` provider declared `ANTHROPIC_ADMIN_API_KEY` as discovery environment variable to satisfy provider metadata catalog contract test.
 
 ## [2.3.7-beta.1] - 2026-06-26
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <TrackerVersion>2.3.6-beta.15</TrackerVersion>
-    <TrackerAssemblyVersion>2.3.6</TrackerAssemblyVersion>
+    <TrackerVersion>2.3.8-beta.1</TrackerVersion>
+    <TrackerAssemblyVersion>2.3.8</TrackerAssemblyVersion>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(MSBuildProjectDirectory)\artifacts\**\*</DefaultItemExcludes>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest</AnalysisLevel>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="AIUsageTracker.Web/wwwroot/favicon.png" width="32" height="32" valign="middle"> AI Usage Tracker
 
-![Version](https://img.shields.io/badge/version-2.3.6--beta.15-orange)
+![Version](https://img.shields.io/badge/version-2.3.8--beta.1-orange)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Platforms](https://img.shields.io/badge/platforms-Windows%20|%20Linux%20-blue)
 ![Language](https://img.shields.io/badge/language-C%23%20|%20.NET-purple)

--- a/scripts/publish-app.ps1
+++ b/scripts/publish-app.ps1
@@ -6,7 +6,7 @@ param(
 )
 
 # AI Usage Tracker - Distribution Packaging Script
-# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.3.6-beta.15 -InstallerCompression balanced
+# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.3.8-beta.1 -InstallerCompression balanced
 
 $isWinPlatform = $Runtime.StartsWith("win-")
 $projectName = if ($isWinPlatform) { "AIUsageTracker" } else { "AIUsageTracker.CLI" }

--- a/scripts/setup.iss
+++ b/scripts/setup.iss
@@ -1,7 +1,7 @@
 ; AI Usage Tracker - Inno Setup Script
 
 #ifndef MyAppVersion
-  #define MyAppVersion "2.3.6-beta.15"
+  #define MyAppVersion "2.3.8-beta.1"
 #endif
 #ifndef SourcePath
   #define SourcePath "..\dist\publish-win-x64"


### PR DESCRIPTION
Three changes to prepare for the 2.3.8-beta.1 release:

1. **Auth fallback fix**: \nthropic-usage\ provider was missing \DiscoveryEnvironmentVariables\, failing the per-provider auth fallback contract test. Added \ANTHROPIC_ADMIN_API_KEY\.

2. **Version bump**: \Directory.Build.props\ was stuck at \2.3.6-beta.15\ despite changelog entries for 2.3.7 and 2.3.8. Bumped to \2.3.8-beta.1\ / assembly \2.3.8\.

3. **Changelog update**: Added hibernate data preservation fix, AnthropicUsageProvider visibility disable, and auth fallback fix to the 2.3.8-beta.1 entry.