### PR TITLE
Add GitHub Pages landing page

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -1,0 +1,50 @@
+name: Deploy Landing Page
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'docs/landing/**'
+      - 'docs/screenshot_*.png'
+      - 'docs/card-catalog/**'
+      - '.github/workflows/deploy-landing.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "landing-pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Assemble site
+        run: |
+          mkdir -p _site
+          cp docs/landing/index.html docs/landing/style.css docs/landing/app.js _site/
+          cp docs/screenshot_*.png _site/ 2>/dev/null || true
+          cp docs/tray_icon_*.png _site/ 2>/dev/null || true
+          cp -r docs/card-catalog _site/ 2>/dev/null || true
+          cp AIUsageTracker.Web/wwwroot/favicon.png _site/ 2>/dev/null || true
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/landing/app.js
+++ b/docs/landing/app.js
@@ -1,0 +1,28 @@
+(function () {
+    'use strict';
+
+    var grid = document.getElementById('screenshotGrid');
+    var lightbox = document.getElementById('lightbox');
+    var lightboxImg = document.getElementById('lightboxImg');
+
+    if (!grid || !lightbox || !lightboxImg) return;
+
+    grid.addEventListener('click', function (e) {
+        if (e.target.tagName !== 'IMG') return;
+        var full = e.target.getAttribute('data-full');
+        if (!full) return;
+        lightboxImg.src = full;
+        lightboxImg.alt = e.target.alt;
+        lightbox.classList.add('active');
+    });
+
+    lightbox.addEventListener('click', function () {
+        lightbox.classList.remove('active');
+    });
+
+    document.addEventListener('keydown', function (e) {
+        if (e.key === 'Escape') {
+            lightbox.classList.remove('active');
+        }
+    });
+})();

--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -1,0 +1,190 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AI Usage Tracker — Monitor all your AI API usage in one place</title>
+    <meta name="description" content="A streamlined Windows dashboard and tray utility to monitor AI API usage, costs, and quotas across multiple providers.">
+    <link rel="icon" href="favicon.png" type="image/png">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<!-- ===== HERO ===== -->
+<header class="hero">
+    <div class="container hero__content">
+        <div class="hero__text">
+            <div class="hero__badge">
+                <img src="favicon.png" alt="" width="32" height="32">
+                <span>AI Usage Tracker</span>
+            </div>
+            <h1>Track every AI provider<br><span class="hero__highlight">in one glance</span></h1>
+            <p class="hero__tagline">
+                A compact Windows dashboard and tray utility that monitors your AI API usage,
+                costs, and quotas across 14+ providers. Auto-discovers your keys, stays out of your way.
+            </p>
+            <div class="hero__cta">
+                <a href="https://github.com/rygel/AIUsageTracker/releases" class="btn btn--primary">
+                    Download
+                </a>
+                <a href="https://github.com/rygel/AIUsageTracker" class="btn btn--secondary">
+                    View on GitHub
+                </a>
+            </div>
+            <div class="hero__meta">
+                <span class="badge">Windows</span>
+                <span class="badge">.NET 8</span>
+                <span class="badge">MIT License</span>
+            </div>
+        </div>
+        <div class="hero__screenshot">
+            <img src="screenshot_dashboard_privacy.png" alt="AI Usage Tracker Dashboard" loading="eager">
+        </div>
+    </div>
+</header>
+
+<!-- ===== PROVIDERS ===== -->
+<section class="section">
+    <div class="container">
+        <h2 class="section__title">Supported Providers</h2>
+        <p class="section__subtitle">All your AI services in a single view</p>
+        <div class="provider-grid">
+            <div class="provider-card"><span class="provider-card__name">Antigravity</span><span class="provider-card__status provider-card__status--ok">Tested</span></div>
+            <div class="provider-card"><span class="provider-card__name">Claude Code</span><span class="provider-card__status provider-card__status--ok">Tested</span></div>
+            <div class="provider-card"><span class="provider-card__name">DeepSeek</span><span class="provider-card__status provider-card__status--beta">Beta</span></div>
+            <div class="provider-card"><span class="provider-card__name">Gemini</span><span class="provider-card__status provider-card__status--ok">Tested</span></div>
+            <div class="provider-card"><span class="provider-card__name">GitHub Copilot</span><span class="provider-card__status provider-card__status--ok">Tested</span></div>
+            <div class="provider-card"><span class="provider-card__name">Kimi (Moonshot)</span><span class="provider-card__status provider-card__status--ok">Tested</span></div>
+            <div class="provider-card"><span class="provider-card__name">Minimax (CN)</span><span class="provider-card__status provider-card__status--beta">Beta</span></div>
+            <div class="provider-card"><span class="provider-card__name">Minimax (Intl)</span><span class="provider-card__status provider-card__status--beta">Beta</span></div>
+            <div class="provider-card"><span class="provider-card__name">Mistral</span><span class="provider-card__status provider-card__status--ok">Tested</span></div>
+            <div class="provider-card"><span class="provider-card__name">OpenAI (Codex)</span><span class="provider-card__status provider-card__status--beta">Beta</span></div>
+            <div class="provider-card"><span class="provider-card__name">Opencode Zen</span><span class="provider-card__status provider-card__status--ok">Tested</span></div>
+            <div class="provider-card"><span class="provider-card__name">Synthetic</span><span class="provider-card__status provider-card__status--ok">Tested</span></div>
+            <div class="provider-card"><span class="provider-card__name">Z.AI</span><span class="provider-card__status provider-card__status--ok">Tested</span></div>
+            <div class="provider-card"><span class="provider-card__name">OpenRouter</span><span class="provider-card__status provider-card__status--planned">Planned</span></div>
+        </div>
+    </div>
+</section>
+
+<!-- ===== FEATURES ===== -->
+<section class="section section--alt">
+    <div class="container">
+        <h2 class="section__title">Features</h2>
+        <p class="section__subtitle">Everything you need to stay on top of your AI usage</p>
+        <div class="feature-grid">
+            <div class="feature-card">
+                <div class="feature-card__icon">&#128269;</div>
+                <h3>Smart Discovery</h3>
+                <p>Automatically scans environment variables, Claude Code credentials, and standard config files. Zero configuration friction.</p>
+            </div>
+            <div class="feature-card">
+                <div class="feature-card__icon">&#128202;</div>
+                <h3>Live Dashboard</h3>
+                <p>Compact always-on-top window with real-time progress bars showing remaining credits, quotas, and spending.</p>
+            </div>
+            <div class="feature-card">
+                <div class="feature-card__icon">&#128226;</div>
+                <h3>Tray Integration</h3>
+                <p>Per-provider tray icons with live progress bars. Glance at your system tray to see which providers are healthy.</p>
+            </div>
+            <div class="feature-card">
+                <div class="feature-card__icon">&#9889;</div>
+                <h3>Pace Projection</h3>
+                <p>Will you hit your limit before reset? Headroom, on-pace, and over-pace badges tell you at a glance.</p>
+            </div>
+            <div class="feature-card">
+                <div class="feature-card__icon">&#127760;</div>
+                <h3>Web Dashboard</h3>
+                <p>Browse usage history, charts, and analytics from any browser. Seven built-in themes including Dracula and Nord.</p>
+            </div>
+            <div class="feature-card">
+                <div class="feature-card__icon">&#128259;</div>
+                <h3>Auto-Updates</h3>
+                <p>In-app release notifications with one-click download. Beta and stable channels supported.</p>
+            </div>
+        </div>
+    </div>
+</section>
+
+<!-- ===== SCREENSHOTS ===== -->
+<section class="section">
+    <div class="container">
+        <h2 class="section__title">Take a Look</h2>
+        <p class="section__subtitle">Click any screenshot to enlarge</p>
+        <div class="screenshot-grid" id="screenshotGrid">
+            <figure class="screenshot-item">
+                <img src="screenshot_dashboard_privacy.png" alt="Dashboard" loading="lazy" data-full="screenshot_dashboard_privacy.png">
+                <figcaption>Dashboard</figcaption>
+            </figure>
+            <figure class="screenshot-item">
+                <img src="screenshot_settings_providers_privacy.png" alt="Provider Settings" loading="lazy" data-full="screenshot_settings_providers_privacy.png">
+                <figcaption>Provider Settings</figcaption>
+            </figure>
+            <figure class="screenshot-item">
+                <img src="screenshot_web_dashboard.png" alt="Web Dashboard" loading="lazy" data-full="screenshot_web_dashboard.png">
+                <figcaption>Web Dashboard</figcaption>
+            </figure>
+            <figure class="screenshot-item">
+                <img src="screenshot_web_charts.png" alt="Usage Charts" loading="lazy" data-full="screenshot_web_charts.png">
+                <figcaption>Usage Charts</figcaption>
+            </figure>
+            <figure class="screenshot-item">
+                <img src="card-catalog/card_preset-default.png" alt="Card Presets" loading="lazy" data-full="card-catalog/card_preset-default.png">
+                <figcaption>Card Presets</figcaption>
+            </figure>
+            <figure class="screenshot-item">
+                <img src="screenshot_settings_cards_privacy.png" alt="Card Settings" loading="lazy" data-full="screenshot_settings_cards_privacy.png">
+                <figcaption>Card Settings</figcaption>
+            </figure>
+        </div>
+    </div>
+</section>
+
+<!-- ===== DOWNLOAD ===== -->
+<section class="section section--alt">
+    <div class="container download">
+        <h2 class="section__title">Get Started</h2>
+        <p class="section__subtitle">Three steps to tracking your AI usage</p>
+        <div class="download__steps">
+            <div class="download__step">
+                <div class="download__step-num">1</div>
+                <p>Download the latest installer from <a href="https://github.com/rygel/AIUsageTracker/releases">Releases</a></p>
+            </div>
+            <div class="download__step">
+                <div class="download__step-num">2</div>
+                <p>Run the installer &mdash; it auto-scans for your existing API keys</p>
+            </div>
+            <div class="download__step">
+                <div class="download__step-num">3</div>
+                <p>Pin the dashboard and watch your usage update in real time</p>
+            </div>
+        </div>
+        <a href="https://github.com/rygel/AIUsageTracker/releases" class="btn btn--primary btn--large">
+            Download Latest Release
+        </a>
+    </div>
+</section>
+
+<!-- ===== FOOTER ===== -->
+<footer class="footer">
+    <div class="container footer__content">
+        <div class="footer__links">
+            <a href="https://github.com/rygel/AIUsageTracker">GitHub</a>
+            <a href="https://github.com/rygel/AIUsageTracker/releases">Releases</a>
+            <a href="https://discord.gg/AZtNQtWuJA">Discord</a>
+            <a href="https://github.com/rygel/AIUsageTracker/blob/develop/docs/user_manual.md">User Manual</a>
+            <a href="https://github.com/rygel/AIUsageTracker/blob/develop/docs/cli_documentation.md">CLI Docs</a>
+        </div>
+        <p class="footer__license">MIT License &mdash; built with .NET 8</p>
+    </div>
+</footer>
+
+<!-- ===== LIGHTBOX ===== -->
+<div class="lightbox" id="lightbox">
+    <img src="" alt="" id="lightboxImg">
+</div>
+
+<script src="app.js"></script>
+</body>
+</html>

--- a/docs/landing/style.css
+++ b/docs/landing/style.css
@@ -1,0 +1,467 @@
+:root {
+    --bg-primary: #1a1a1a;
+    --bg-secondary: #242424;
+    --bg-tertiary: #2a2a2a;
+    --text-primary: #e8e8e8;
+    --text-secondary: #b0b0b0;
+    --text-muted: #808080;
+    --accent: #3b82f6;
+    --accent-hover: #60a5fa;
+    --accent-success: #22c55e;
+    --accent-warning: #eab308;
+    --accent-danger: #ef4444;
+    --radius: 12px;
+    --max-width: 1100px;
+}
+
+*, *::before, *::after {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+html {
+    scroll-behavior: smooth;
+}
+
+body {
+    font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+}
+
+.container {
+    max-width: var(--max-width);
+    margin: 0 auto;
+    padding: 0 24px;
+}
+
+/* ===== BUTTONS ===== */
+
+.btn {
+    display: inline-block;
+    padding: 12px 28px;
+    border-radius: var(--radius);
+    font-size: 1rem;
+    font-weight: 600;
+    text-decoration: none;
+    transition: transform 0.15s ease, background-color 0.15s ease;
+    border: none;
+    cursor: pointer;
+}
+
+.btn--primary {
+    background: var(--accent);
+    color: #fff;
+}
+
+.btn--primary:hover {
+    background: var(--accent-hover);
+    transform: translateY(-1px);
+}
+
+.btn--secondary {
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+    border: 1px solid var(--bg-secondary);
+}
+
+.btn--secondary:hover {
+    background: #333;
+    transform: translateY(-1px);
+}
+
+.btn--large {
+    padding: 16px 40px;
+    font-size: 1.1rem;
+    margin-top: 8px;
+}
+
+/* ===== HERO ===== */
+
+.hero {
+    background: linear-gradient(160deg, #1a1a2e 0%, var(--bg-primary) 60%);
+    padding: 80px 0 60px;
+    overflow: hidden;
+}
+
+.hero__content {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 48px;
+    align-items: center;
+}
+
+.hero__badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 6px 16px;
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: 100px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+    margin-bottom: 24px;
+}
+
+.hero__badge img {
+    border-radius: 6px;
+}
+
+.hero h1 {
+    font-size: 2.8rem;
+    font-weight: 800;
+    line-height: 1.15;
+    margin-bottom: 20px;
+    letter-spacing: -0.5px;
+}
+
+.hero__highlight {
+    background: linear-gradient(90deg, var(--accent), var(--accent-success));
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+.hero__tagline {
+    font-size: 1.15rem;
+    color: var(--text-secondary);
+    margin-bottom: 32px;
+    max-width: 480px;
+}
+
+.hero__cta {
+    display: flex;
+    gap: 16px;
+    margin-bottom: 24px;
+}
+
+.hero__meta {
+    display: flex;
+    gap: 10px;
+}
+
+.badge {
+    padding: 4px 12px;
+    background: rgba(255, 255, 255, 0.06);
+    border-radius: 6px;
+    font-size: 0.8rem;
+    color: var(--text-muted);
+}
+
+.hero__screenshot img {
+    width: 100%;
+    border-radius: var(--radius);
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+/* ===== SECTIONS ===== */
+
+.section {
+    padding: 80px 0;
+}
+
+.section--alt {
+    background: var(--bg-secondary);
+}
+
+.section__title {
+    text-align: center;
+    font-size: 2rem;
+    font-weight: 700;
+    margin-bottom: 8px;
+}
+
+.section__subtitle {
+    text-align: center;
+    color: var(--text-muted);
+    font-size: 1.05rem;
+    margin-bottom: 48px;
+}
+
+/* ===== PROVIDER GRID ===== */
+
+.provider-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 12px;
+}
+
+.provider-card {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 14px 18px;
+    background: var(--bg-secondary);
+    border: 1px solid rgba(255, 255, 255, 0.04);
+    border-radius: var(--radius);
+    transition: border-color 0.15s ease;
+}
+
+.provider-card:hover {
+    border-color: rgba(255, 255, 255, 0.12);
+}
+
+.provider-card__name {
+    font-weight: 500;
+    font-size: 0.95rem;
+}
+
+.provider-card__status {
+    font-size: 0.75rem;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-weight: 600;
+}
+
+.provider-card__status--ok {
+    background: rgba(34, 197, 94, 0.15);
+    color: var(--accent-success);
+}
+
+.provider-card__status--beta {
+    background: rgba(234, 179, 8, 0.15);
+    color: var(--accent-warning);
+}
+
+.provider-card__status--planned {
+    background: rgba(128, 128, 128, 0.15);
+    color: var(--text-muted);
+}
+
+/* ===== FEATURE GRID ===== */
+
+.feature-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 24px;
+}
+
+.feature-card {
+    padding: 32px 24px;
+    background: var(--bg-primary);
+    border: 1px solid rgba(255, 255, 255, 0.04);
+    border-radius: var(--radius);
+    transition: transform 0.15s ease, border-color 0.15s ease;
+}
+
+.feature-card:hover {
+    transform: translateY(-2px);
+    border-color: rgba(59, 130, 246, 0.3);
+}
+
+.feature-card__icon {
+    font-size: 2rem;
+    margin-bottom: 16px;
+}
+
+.feature-card h3 {
+    font-size: 1.15rem;
+    margin-bottom: 8px;
+}
+
+.feature-card p {
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+}
+
+/* ===== SCREENSHOT GRID ===== */
+
+.screenshot-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 20px;
+}
+
+.screenshot-item {
+    cursor: pointer;
+}
+
+.screenshot-item img {
+    width: 100%;
+    border-radius: var(--radius);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.screenshot-item img:hover {
+    transform: scale(1.02);
+    border-color: rgba(59, 130, 246, 0.4);
+}
+
+.screenshot-item figcaption {
+    text-align: center;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    margin-top: 8px;
+}
+
+/* ===== DOWNLOAD ===== */
+
+.download {
+    text-align: center;
+}
+
+.download__steps {
+    display: flex;
+    justify-content: center;
+    gap: 48px;
+    margin-bottom: 40px;
+}
+
+.download__step {
+    text-align: center;
+    max-width: 200px;
+}
+
+.download__step-num {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background: var(--accent);
+    color: #fff;
+    font-weight: 700;
+    font-size: 1.1rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0 auto 12px;
+}
+
+.download__step p {
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+}
+
+.download__step a {
+    color: var(--accent);
+}
+
+/* ===== FOOTER ===== */
+
+.footer {
+    background: #111;
+    padding: 40px 0;
+    border-top: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.footer__content {
+    text-align: center;
+}
+
+.footer__links {
+    display: flex;
+    justify-content: center;
+    gap: 24px;
+    margin-bottom: 16px;
+    flex-wrap: wrap;
+}
+
+.footer__links a {
+    color: var(--text-secondary);
+    text-decoration: none;
+    font-size: 0.9rem;
+    transition: color 0.15s ease;
+}
+
+.footer__links a:hover {
+    color: var(--accent);
+}
+
+.footer__license {
+    color: var(--text-muted);
+    font-size: 0.85rem;
+}
+
+/* ===== LIGHTBOX ===== */
+
+.lightbox {
+    display: none;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.92);
+    z-index: 100;
+    align-items: center;
+    justify-content: center;
+    padding: 40px;
+    cursor: pointer;
+}
+
+.lightbox.active {
+    display: flex;
+}
+
+.lightbox img {
+    max-width: 95%;
+    max-height: 90vh;
+    border-radius: var(--radius);
+    box-shadow: 0 20px 80px rgba(0, 0, 0, 0.6);
+}
+
+/* ===== RESPONSIVE ===== */
+
+@media (max-width: 900px) {
+    .hero {
+        padding: 60px 0 40px;
+    }
+
+    .hero__content {
+        grid-template-columns: 1fr;
+        text-align: center;
+    }
+
+    .hero__tagline {
+        margin: 0 auto 32px;
+    }
+
+    .hero__cta {
+        justify-content: center;
+    }
+
+    .hero__meta {
+        justify-content: center;
+    }
+
+    .hero__badge {
+        justify-content: center;
+    }
+
+    .hero__screenshot {
+        order: -1;
+    }
+
+    .hero h1 {
+        font-size: 2.2rem;
+    }
+
+    .feature-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .screenshot-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+
+    .download__steps {
+        flex-direction: column;
+        gap: 24px;
+    }
+}
+
+@media (max-width: 600px) {
+    .screenshot-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .section {
+        padding: 56px 0;
+    }
+
+    .section__title {
+        font-size: 1.6rem;
+    }
+}

--- a/docs/superpowers/specs/2026-06-28-github-pages-landing-design.md
+++ b/docs/superpowers/specs/2026-06-28-github-pages-landing-design.md
@@ -1,0 +1,63 @@
+# GitHub Pages Landing Page Design
+
+## Goal
+A single-page static site at `https://rygel.github.io/AIUsageTracker/` showcasing the app's features, supported providers, and screenshots.
+
+## Technology
+- Hand-written `index.html` + `style.css` + minimal JS (for mobile nav / lightbox)
+- No frameworks, no build tools, no dependencies
+- GitHub Pages serves from `docs/landing/` folder
+
+## File Structure
+```
+docs/landing/
+  index.html      — single-page site
+  style.css       — all styling
+  app.js          — minimal JS (screenshot lightbox, mobile nav toggle)
+```
+
+## Page Sections
+
+### 1. Hero
+- Left: app icon (favicon.png), app name, tagline, two CTA buttons (Download, GitHub)
+- Right: dashboard screenshot
+- Dark gradient background
+
+### 2. Provider Grid
+- Responsive grid of provider name badges
+- Covers all 14+ supported providers from README
+
+### 3. Feature Highlights
+- 3-column responsive grid (collapses to 1 column on mobile)
+- Six features: Smart Discovery, Live Dashboard, Tray Integration, Pace Projection, Multi-Provider, Auto-Updates
+
+### 4. Screenshot Showcase
+- Grid of 6-8 best screenshots with click-to-enlarge (CSS-only lightbox)
+
+### 5. Download Section
+- Version badge, releases link, 3-step install instructions
+
+### 6. Footer
+- Links: GitHub, Discord, User Manual, CLI docs, Architecture, MIT license
+
+## Visual Design
+- Background: `#0f0f23` primary, `#1a1a2e` cards
+- Accent: `#e94560` (CTAs, links, highlights)
+- Text: `#eee` primary, `#aaa` secondary
+- Font: system-ui stack
+- Border radius: 12px on cards
+- Max content width: 1200px centered
+
+## Deployment
+- GitHub Pages settings: serve from `docs/` folder on `main` branch
+- `docs/landing/index.html` becomes the site root
+- Existing `docs/` screenshots referenced by relative path (already in repo)
+
+## Assets (all existing, no new files needed)
+- `docs/screenshot_dashboard_privacy.png` — hero
+- `docs/screenshot_settings_providers_privacy.png` — providers
+- `docs/screenshot_web_dashboard.png` — web UI
+- `docs/screenshot_web_charts.png` — charts
+- `docs/card-catalog/card_preset-default.png` — card presets
+- `docs/card-catalog/card_pace-off.png` — pace badges
+- `AIUsageTracker.Web/wwwroot/favicon.png` — app icon


### PR DESCRIPTION
Single-page static site deployed via GitHub Actions to GitHub Pages.

**What it includes:**
- Hero section with app icon, tagline, and dashboard screenshot
- Provider grid (all 14+ supported providers with status badges)
- Feature highlights (6 cards: Smart Discovery, Live Dashboard, Tray Integration, Pace Projection, Web Dashboard, Auto-Updates)
- Screenshot gallery with click-to-enlarge lightbox
- Download section with 3-step quick start
- Footer with links to GitHub, Discord, docs

**Technical:**
- Hand-written HTML/CSS/JS -- no frameworks, no dependencies
- Dark theme using the app's exact color palette (#1a1a1a / #3b82f6)
- Fully responsive (mobile breakpoints at 900px and 600px)
- Deployed via deploy-landing.yml workflow that assembles the site from docs/landing/ + screenshots

**After merge:** Enable GitHub Pages in repo Settings -> Pages -> Source: GitHub Actions