### PR TITLE
Fix zizmor: set persist-credentials false on landing deploy checkout

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -27,6 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Assemble site
         run: |


### PR DESCRIPTION
Fixes the zizmor security scan finding on PR #685. The checkout step in deploy-landing.yml did not set persist-credentials: false, which could allow credential leakage in workflows that don't need push access.