### PR TITLE
Add CNAME and startupbar widget to landing page

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -38,6 +38,7 @@ jobs:
           cp docs/tray_icon_*.png _site/ 2>/dev/null || true
           cp -r docs/card-catalog _site/ 2>/dev/null || true
           cp AIUsageTracker.Web/wwwroot/favicon.png _site/ 2>/dev/null || true
+          echo "aiusagetracker.outerstellar.net" > _site/CNAME
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -7,6 +7,7 @@
     <meta name="description" content="A streamlined Windows dashboard and tray utility to monitor AI API usage, costs, and quotas across multiple providers.">
     <link rel="icon" href="favicon.png" type="image/png">
     <link rel="stylesheet" href="style.css">
+    <script async src="https://startupbar.co/widget/loader.js" data-startup-id="d77ace7a-c7d8-4eac-81b9-fe98f973d04a"></script>
 </head>
 <body>
 


### PR DESCRIPTION
Two changes:

1. CNAME file in deploy workflow: \iusagetracker.outerstellar.net\
2. Startupbar widget script in index.html head

**DNS setup needed:** Add CNAME record for \iusagetracker\ pointing to \ygel.github.io\ at your DNS registrar, then enter the domain in Settings -> Pages -> Custom domain.