### PR TITLE
Prepare v2.4.0 stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,25 @@
 
 ## [Unreleased]
 
-## [2.3.8-beta.1] - 2026-06-28
+## [2.4.0] - 2026-07-01
 
 ### Added
 - **Anthropic Usage/Cost provider**: New provider tracking spending via Anthropic admin API (cost_report + usage_report endpoints). Uses `x-api-key` header auth. Emits daily-cost and daily-tokens cards.
+- **Groq provider**: New provider tracking rate-limit headers (daily requests + per-minute tokens) via `GROQ_API_KEY`.
 - **Spending summary on Web dashboard**: Homepage now shows total spent, budget remaining, and per-provider breakdown for currency-based providers.
-- **Rate-limit header parsing**: Shared `TryGetHeaderDouble` method on `ProviderBase` for extracting rate-limit headers. GroqProvider and ClaudeCodeProvider refactored to use it.
+- **CSV export**: Export button on History page downloads 90 days of usage data in RFC 4180 CSV format.
+- **Analytics page**: Web dashboard `/analytics` page with per-model breakdown, latency trends, HTTP status history, and provider details JSON panel.
+- **Landing page**: Public landing page at `aiusagetracker.outerstellar.net` with provider list, feature overview, screenshots, and download links.
+- **Rate-limit header parsing**: Shared `TryGetHeaderDouble` method on `ProviderBase` for extracting rate-limit headers.
 
 ### Changed
 - **ProviderMetadataCatalog moved to Core**: The catalog now lives in `AIUsageTracker.Core.Providers` instead of Infrastructure. Composition roots pass the Infrastructure assembly to `Initialize()` for provider discovery.
-- **BetaUpdateCheck fix**: Version suffix parsing now correctly handles develop-suffix format (e.g. `2.3.7-beta.1-1-develop`).
-- **AnthropicUsageProvider hidden**: Disabled from main window and settings pending verification with real admin API key.
+- **Rendering architecture cleanup**: Removed card type filtering (`.OfType<T>()`) from rendering pipeline. Labels come exclusively from `QuotaWindowDefinition.DualBarLabel`. Deleted `LegacyParentCardBuilder`.
+- **Hibernate data preservation**: After resuming from sleep/hibernate, the UI keeps showing stale data instead of wiping to zero. All-unavailable guard prevents overwriting good data with reconnecting-state data.
 
 ### Fixed
-- **Hibernate data preservation**: After resuming from sleep/hibernate, the UI keeps showing stale data instead of wiping to zero. No special resume handling — normal polling timer eventually brings new data. An all-unavailable guard in `ApplyFetchedUsages` prevents overwriting available data with reconnecting-state data.
+- **Migration data loss (CRITICAL)**: `ConvertTimestampsToEpochIfNeeded` recreated `provider_history` with a hardcoded column list that omitted 6 card columns. Fixed by reading column names dynamically from `PRAGMA table_info`.
+- **OpenAI (Codex) dual bars missing (CRITICAL)**: Rendering code filtered `.OfType<WindowedProviderUsage>()` which silently discarded `ModelScopedProviderUsage` cards. Fixed by filtering on `QuotaProviderUsage` base type.
 - **Auth fallback contract**: `anthropic-usage` provider declared `ANTHROPIC_ADMIN_API_KEY` as discovery environment variable to satisfy provider metadata catalog contract test.
 
 ## [2.3.7-beta.1] - 2026-06-26

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <TrackerVersion>2.3.8-beta.1</TrackerVersion>
-    <TrackerAssemblyVersion>2.3.8</TrackerAssemblyVersion>
+    <TrackerVersion>2.4.0</TrackerVersion>
+    <TrackerAssemblyVersion>2.4.0</TrackerAssemblyVersion>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(MSBuildProjectDirectory)\artifacts\**\*</DefaultItemExcludes>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest</AnalysisLevel>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="AIUsageTracker.Web/wwwroot/favicon.png" width="32" height="32" valign="middle"> AI Usage Tracker
 
-![Version](https://img.shields.io/badge/version-2.3.8--beta.1-orange)
+![Version](https://img.shields.io/badge/version-2.4.0-orange)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Platforms](https://img.shields.io/badge/platforms-Windows%20|%20Linux%20-blue)
 ![Language](https://img.shields.io/badge/language-C%23%20|%20.NET-purple)

--- a/scripts/publish-app.ps1
+++ b/scripts/publish-app.ps1
@@ -6,7 +6,7 @@ param(
 )
 
 # AI Usage Tracker - Distribution Packaging Script
-# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.3.8-beta.1 -InstallerCompression balanced
+# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.4.0 -InstallerCompression balanced
 
 $isWinPlatform = $Runtime.StartsWith("win-")
 $projectName = if ($isWinPlatform) { "AIUsageTracker" } else { "AIUsageTracker.CLI" }

--- a/scripts/setup.iss
+++ b/scripts/setup.iss
@@ -1,7 +1,7 @@
 ; AI Usage Tracker - Inno Setup Script
 
 #ifndef MyAppVersion
-  #define MyAppVersion "2.3.8-beta.1"
+  #define MyAppVersion "2.4.0"
 #endif
 #ifndef SourcePath
   #define SourcePath "..\dist\publish-win-x64"


### PR DESCRIPTION
Promote from beta to stable. Version files updated across Directory.Build.props, README, setup.iss, publish-app.ps1. Changelog consolidated from 2.3.6-beta.x through 2.3.8-beta.1 into a single stable entry.

Changes since 2.3.7:
- 2 new providers (Anthropic cost tracking, Groq rate-limit headers)
- Web dashboard spending summary, analytics page, CSV export
- Landing page at aiusagetracker.outerstellar.net
- Rendering architecture cleanup (definition-driven cards)
- 2 critical data-loss fixes (migration columns, Codex dual bars)
- Hibernate data preservation fix

Build: 0 errors, 162 warnings (all pre-existing analyzer warnings).