### PR TITLE
Fix hero headline to 'Track your AI providers'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Added
+- **Landing page redesign**: Consolidated three bloated feature sections into a dense 3-column layout (Desktop GUI / Web Dashboard / CLI). Added "Support the Project" section with referral links. Reduced vertical spacing throughout.
+- **Website link in README**: Added link to `aiusagetracker.outerstellar.net`.
+
+### Changed
+- **Provider statuses on landing page**: Groq, MiniMax (China), Gemini, Mistral moved to Beta. MiniMax (Intl), OpenAI (Codex) moved to Tested. Providers sorted by status (Tested, Beta, Planned).
+- **Fixed provider count**: Corrected "18+" claim to "16" (the actual count) across all meta tags, JSON-LD, and page copy.
+- **Fixed CLI name**: Removed fabricated "act" binary name from landing page.
+- **Release links**: Download buttons now point to `/releases/latest` for stable releases.
+
 ## [2.4.0] - 2026-07-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 A streamlined Windows dashboard and tray utility to monitor AI API usage, costs, and quotas across multiple providers.
 
+**Website:** [aiusagetracker.outerstellar.net](https://aiusagetracker.outerstellar.net/)
+
 ## Support
 If you want to support me and are interested in different AI model providers, you can sign up with my referral codes:
 - [Opencode Go](https://opencode.ai/go?ref=BJK682KYXH):GLM-5.1, Kimi K2.6, MiMo-V2.5 (Pro), MiniMax M3, Qwen3.7 Max, DeepSeek V4 Pro/Flash

--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -36,7 +36,7 @@
         "description": "A desktop GUI, web dashboard, and cross-platform CLI to monitor AI API usage, costs, and quotas across 16 providers including Claude, Gemini, OpenAI, GitHub Copilot, DeepSeek, and more.",
         "applicationCategory": "Utilities",
         "operatingSystem": "Windows, Linux",
-        "softwareVersion": "2.3.8-beta.1",
+        "softwareVersion": "2.3.7",
         "offers": {
             "@type": "Offer",
             "price": "0",
@@ -44,7 +44,7 @@
         },
         "license": "https://opensource.org/licenses/MIT",
         "url": "https://aiusagetracker.outerstellar.net/",
-        "downloadUrl": "https://github.com/rygel/AIUsageTracker/releases",
+        "downloadUrl": "https://github.com/rygel/AIUsageTracker/releases/latest",
         "codeRepository": "https://github.com/rygel/AIUsageTracker",
         "programmingLanguage": "C#",
         "runtimePlatform": ".NET 10",
@@ -71,7 +71,7 @@
                 charts and analytics, and a cross-platform CLI. Auto-discovers your keys, stays out of your way.
             </p>
             <div class="hero__cta">
-                <a href="https://github.com/rygel/AIUsageTracker/releases" class="btn btn--primary">
+                <a href="https://github.com/rygel/AIUsageTracker/releases/latest" class="btn btn--primary">
                     Download
                 </a>
                 <a href="https://github.com/rygel/AIUsageTracker" class="btn btn--secondary">
@@ -199,7 +199,7 @@
         <div class="download__steps">
             <div class="download__step">
                 <div class="download__step-num">1</div>
-                <p>Download the latest installer from <a href="https://github.com/rygel/AIUsageTracker/releases">Releases</a></p>
+                <p>Download the latest installer from <a href="https://github.com/rygel/AIUsageTracker/releases/latest">Releases</a></p>
             </div>
             <div class="download__step">
                 <div class="download__step-num">2</div>
@@ -255,7 +255,7 @@
     <div class="container footer__content">
         <div class="footer__links">
             <a href="https://github.com/rygel/AIUsageTracker">GitHub</a>
-            <a href="https://github.com/rygel/AIUsageTracker/releases">Releases</a>
+            <a href="https://github.com/rygel/AIUsageTracker/releases/latest">Releases</a>
             <a href="https://discord.gg/AZtNQtWuJA">Discord</a>
             <a href="https://github.com/rygel/AIUsageTracker/blob/develop/docs/user_manual.md">User Manual</a>
         </div>

--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -64,7 +64,7 @@
                 <img src="favicon.png" alt="" width="32" height="32">
                 <span>AI Usage Tracker</span>
             </div>
-            <h1>Track most AI providers<br><span class="hero__highlight">in one glance</span></h1>
+            <h1>Track your AI providers<br><span class="hero__highlight">in one glance</span></h1>
             <p class="hero__tagline">
                 Three ways to monitor your AI API usage, costs, and quotas across 16 providers:
                 a compact desktop GUI with system tray integration, a full web dashboard with

--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -222,28 +222,20 @@
         <h2 class="section__title">Support the Project</h2>
         <p class="section__subtitle">Use these referral links when signing up &mdash; it costs you nothing and helps fund development</p>
         <div class="support-grid">
-            <a href="#" class="support-card">
-                <span class="support-card__name">Claude Code</span>
+            <a href="https://opencode.ai/go?ref=BJK682KYXH" class="support-card">
+                <span class="support-card__name">OpenCode Go</span>
                 <span class="support-card__action">Sign up &rarr;</span>
             </a>
-            <a href="#" class="support-card">
-                <span class="support-card__name">Gemini</span>
-                <span class="support-card__action">Sign up &rarr;</span>
-            </a>
-            <a href="#" class="support-card">
-                <span class="support-card__name">GitHub Copilot</span>
-                <span class="support-card__action">Sign up &rarr;</span>
-            </a>
-            <a href="#" class="support-card">
-                <span class="support-card__name">DeepSeek</span>
-                <span class="support-card__action">Sign up &rarr;</span>
-            </a>
-            <a href="#" class="support-card">
-                <span class="support-card__name">OpenAI</span>
-                <span class="support-card__action">Sign up &rarr;</span>
-            </a>
-            <a href="#" class="support-card">
+            <a href="https://z.ai/subscribe?ic=JQTB1W1M0L" class="support-card">
                 <span class="support-card__name">Z.AI</span>
+                <span class="support-card__action">Sign up &rarr;</span>
+            </a>
+            <a href="https://platform.minimax.io/subscribe/token-plan?code=7tAWJBCP5L&source=link" class="support-card">
+                <span class="support-card__name">MiniMax</span>
+                <span class="support-card__action">Sign up &rarr;</span>
+            </a>
+            <a href="https://synthetic.new/?referral=SNJDbFCgSUZso9E" class="support-card">
+                <span class="support-card__name">Synthetic</span>
                 <span class="support-card__action">Sign up &rarr;</span>
             </a>
         </div>

--- a/docs/landing/style.css
+++ b/docs/landing/style.css
@@ -162,7 +162,11 @@ body {
 /* ===== SECTIONS ===== */
 
 .section {
-    padding: 40px 0;
+    padding: 0 0 28px;
+}
+
+.section + .section {
+    padding-top: 0;
 }
 
 .section--alt {
@@ -499,7 +503,7 @@ body {
     }
 
     .section {
-        padding: 28px 0;
+        padding-bottom: 20px;
     }
 
     .section__title {


### PR DESCRIPTION
Change hero headline from 'Track most AI providers' to 'Track your AI providers in one glance'.