### PR TITLE
Add SEO infrastructure: robots.txt, sitemap.xml, structured data

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -34,6 +34,7 @@ jobs:
         run: |
           mkdir -p _site
           cp docs/landing/index.html docs/landing/style.css docs/landing/app.js _site/
+          cp docs/landing/robots.txt docs/landing/sitemap.xml _site/
           cp docs/screenshot_*.png _site/ 2>/dev/null || true
           cp docs/tray_icon_*.png _site/ 2>/dev/null || true
           cp -r docs/card-catalog _site/ 2>/dev/null || true

--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -51,6 +51,67 @@
         "screenshot": "https://aiusagetracker.outerstellar.net/screenshot_dashboard_privacy.png"
     }
     </script>
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        "name": "AI Usage Tracker",
+        "url": "https://aiusagetracker.outerstellar.net/",
+        "logo": "https://aiusagetracker.outerstellar.net/favicon.png",
+        "sameAs": [
+            "https://github.com/rygel/AIUsageTracker",
+            "https://discord.gg/AZtNQtWuJA"
+        ]
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+            {
+                "@type": "Question",
+                "name": "What is AI Usage Tracker?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "AI Usage Tracker is a free, open-source Windows desktop application and web dashboard that monitors your AI API usage, costs, and quotas across 16 providers including Claude Code, GitHub Copilot, OpenAI Codex, Gemini, Z.AI, and more."
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "Which AI providers are supported?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "AI Usage Tracker supports 16 providers: Antigravity, Claude Code, GitHub Copilot, Kimi (Moonshot), MiniMax, OpenAI (Codex), Synthetic, Z.AI, DeepSeek, Gemini, Groq, Mistral, OpenCode Go, OpenCode Zen, Xiaomi, and OpenRouter (planned)."
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "Is AI Usage Tracker free?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Yes. AI Usage Tracker is free and open-source under the MIT License. Download the latest release from GitHub."
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "What platforms does AI Usage Tracker run on?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "The desktop GUI runs on Windows. A cross-platform CLI is available for Windows and Linux. A web dashboard provides browser-based access to usage data, charts, and analytics."
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "How does AI Usage Tracker find my API keys?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "AI Usage Tracker auto-discovers existing API keys from environment variables and configuration files (such as .codex/auth.json, Claude settings, and opencode auth.json). No manual setup is required for supported providers."
+                }
+            }
+        ]
+    }
+    </script>
 
     <script async src="https://startupbar.co/widget/loader.js" data-startup-id="d77ace7a-c7d8-4eac-81b9-fe98f973d04a"></script>
 </head>

--- a/docs/landing/robots.txt
+++ b/docs/landing/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://aiusagetracker.outerstellar.net/sitemap.xml

--- a/docs/landing/sitemap.xml
+++ b/docs/landing/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://aiusagetracker.outerstellar.net/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Changes

Adds the missing technical SEO pieces to the GitHub Pages landing site:

- **robots.txt** — allows all crawlers, references sitemap
- **sitemap.xml** — declares the canonical landing page URL
- **FAQPage structured data** — 5 Q&As (what is it, supported providers, is it free, platforms, key discovery) for Google rich results and AI search visibility
- **Organization structured data** — links GitHub and Discord via sameAs
- **deploy-landing.yml** — copies obots.txt and sitemap.xml to _site

The existing on-page SEO (title, meta description, canonical, Open Graph, Twitter Cards, SoftwareApplication schema, single h1, lazy-loaded images) was already in place. This fills the crawlability and structured-data gaps.

## Verification

- Files are valid XML/JSON
- Deploy workflow trigger (docs/landing/**) covers the new files
- No build or test impact — landing page only