### PR TITLE
Prepare v2.4.1-beta.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## [Unreleased]
 
+## [2.4.1-beta.1] - 2026-07-03
+
 ### Added
+- **Landing page SEO**: Added `robots.txt`, `sitemap.xml`, FAQ structured data, and Organization structured data for search engine visibility and AI search indexing.
 - **Landing page redesign**: Consolidated three bloated feature sections into a dense 3-column layout (Desktop GUI / Web Dashboard / CLI). Added "Support the Project" section with referral links. Reduced vertical spacing throughout.
 - **Website link in README**: Added link to `aiusagetracker.outerstellar.net`.
 
@@ -11,6 +14,10 @@
 - **Fixed provider count**: Corrected "18+" claim to "16" (the actual count) across all meta tags, JSON-LD, and page copy.
 - **Fixed CLI name**: Removed fabricated "act" binary name from landing page.
 - **Release links**: Download buttons now point to `/releases/latest` for stable releases.
+
+### Fixed
+- **Codex reset time accuracy**: The Codex provider now uses the absolute `reset_at` epoch timestamp from the API instead of computing `now + reset_after_seconds`, which drifted by network latency (~18s). Falls back to relative when `reset_at` is absent.
+- **Semgrep CI**: Replaced stale `semgrep-action@v1` Docker image with direct `pip install semgrep` to fix `ValueError: invalid rule severity value: MEDIUM` crash.
 
 ## [2.4.0] - 2026-07-01
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <TrackerVersion>2.4.0</TrackerVersion>
-    <TrackerAssemblyVersion>2.4.0</TrackerAssemblyVersion>
+    <TrackerVersion>2.4.1-beta.1</TrackerVersion>
+    <TrackerAssemblyVersion>2.4.1</TrackerAssemblyVersion>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(MSBuildProjectDirectory)\artifacts\**\*</DefaultItemExcludes>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest</AnalysisLevel>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="AIUsageTracker.Web/wwwroot/favicon.png" width="32" height="32" valign="middle"> AI Usage Tracker
 
-![Version](https://img.shields.io/badge/version-2.4.0-orange)
+![Version](https://img.shields.io/badge/version-2.4.1--beta.1-orange)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Platforms](https://img.shields.io/badge/platforms-Windows%20|%20Linux%20-blue)
 ![Language](https://img.shields.io/badge/language-C%23%20|%20.NET-purple)

--- a/scripts/publish-app.ps1
+++ b/scripts/publish-app.ps1
@@ -6,7 +6,7 @@ param(
 )
 
 # AI Usage Tracker - Distribution Packaging Script
-# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.4.0 -InstallerCompression balanced
+# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.4.1-beta.1 -InstallerCompression balanced
 
 $isWinPlatform = $Runtime.StartsWith("win-")
 $projectName = if ($isWinPlatform) { "AIUsageTracker" } else { "AIUsageTracker.CLI" }

--- a/scripts/setup.iss
+++ b/scripts/setup.iss
@@ -1,7 +1,7 @@
 ; AI Usage Tracker - Inno Setup Script
 
 #ifndef MyAppVersion
-  #define MyAppVersion "2.4.0"
+  #define MyAppVersion "2.4.1-beta.1"
 #endif
 #ifndef SourcePath
   #define SourcePath "..\dist\publish-win-x64"


### PR DESCRIPTION
## Beta Release Prep

Bumps version to 2.4.1-beta.1 for testing.

### Included since v2.4.0 stable
- **Codex reset time accuracy** — prefers absolute eset_at epoch over relative eset_after_seconds (#700)
- **Landing page SEO** — robots.txt, sitemap.xml, FAQ/Organization structured data (#701)
- **Landing page redesign** — consolidated feature layout, referral links (#699)
- **Semgrep CI fix** — replaced stale Docker action with pip install (#700)

### Version files updated
- Directory.Build.props: 2.4.1-beta.1
- CHANGELOG.md: new version section
- README.md: version badge
- scripts/setup.iss: MyAppVersion

After merge, uto-tag-release.yml creates the 2.4.1-beta.1 tag, which triggers publish.yml to build installers and create the GitHub pre-release.