### PR TITLE
Fix auto-tag workflow: allow credential persistence for tag push

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -29,7 +29,6 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
-          persist-credentials: false
 
       - name: Resolve Version and Channel
         id: resolve


### PR DESCRIPTION
The auto-tag-release workflow had \persist-credentials: false\ on the checkout step, which prevented git from authenticating when pushing the tag. This is the first beta release to actually reach the tag-creation path (previous runs all hit the skip path), so the bug was latent.

Removed \persist-credentials: false\ so the default \GITHUB_TOKEN\ persists and \git push origin v<version>\ can authenticate.