### PR TITLE
Add Codex reset credits to tooltip and database

### DIFF
--- a/AIUsageTracker.Core/Models/QuotaProviderUsage.cs
+++ b/AIUsageTracker.Core/Models/QuotaProviderUsage.cs
@@ -49,4 +49,11 @@ public class QuotaProviderUsage : ProviderUsage
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public TimeSpan? PeriodDuration { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of rate-limit reset credits still available (e.g. Codex
+    /// <c>rate_limit_reset_credits.available_count</c>). Null when the provider does not report it.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? ResetCreditsAvailable { get; set; }
 }

--- a/AIUsageTracker.Core/MonitorClient/AgentGroupedModelUsage.cs
+++ b/AIUsageTracker.Core/MonitorClient/AgentGroupedModelUsage.cs
@@ -16,6 +16,12 @@ public sealed class AgentGroupedModelUsage
 
     public DateTime? NextResetTime { get; set; }
 
+    /// <summary>
+    /// Gets or sets the number of rate-limit reset credits still available (e.g. Codex
+    /// <c>rate_limit_reset_credits.available_count</c>). Null when not reported.
+    /// </summary>
+    public int? ResetCreditsAvailable { get; set; }
+
     public string Description { get; set; } = string.Empty;
 
     public double? EffectiveUsedPercentage { get; set; }

--- a/AIUsageTracker.Infrastructure/Providers/CodexProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/CodexProvider.cs
@@ -93,6 +93,8 @@ public class CodexProvider : ProviderBase
     private const string JsonKeyUsedPercent = "used_percent";
     private const string JsonKeyResetAfterSeconds = "reset_after_seconds";
     private const string JsonKeyResetAt = "reset_at";
+    private const string JsonKeyRateLimitResetCredits = "rate_limit_reset_credits";
+    private const string JsonKeyAvailableCount = "available_count";
 
     private readonly HttpClient _httpClient;
     private readonly ILogger<CodexProvider> _logger;
@@ -485,6 +487,9 @@ public class CodexProvider : ProviderBase
         var sparkWindow = ExtractSparkWindow(root);
         var accountIdentity = ResolveAccountIdentity(root, jwtEmail, authIdentity, accountId);
 
+        var resetCreditsDouble = root.ReadDouble(JsonKeyRateLimitResetCredits, JsonKeyAvailableCount);
+        int? resetCreditsAvailable = resetCreditsDouble.HasValue ? (int)resetCreditsDouble.Value : (int?)null;
+
         var effectiveSparkPercent = sparkWindow.HasWindowData
             ? (double?)Math.Max(sparkWindow.PrimaryUsedPercent ?? 0.0, sparkWindow.SecondaryUsedPercent ?? 0.0)
             : null;
@@ -510,6 +515,7 @@ public class CodexProvider : ProviderBase
         burstCard.AuthSource = AuthSource.CodexNative(planType);
         burstCard.NextResetTime = burstResetTime;
         burstCard.PeriodDuration = TimeSpan.FromHours(5);
+        burstCard.ResetCreditsAvailable = resetCreditsAvailable;
         burstCard.RawJson = rawJson;
         burstCard.HttpStatus = httpStatus;
 

--- a/AIUsageTracker.Monitor/Migrations/V15__Add_reset_credits_available.sql
+++ b/AIUsageTracker.Monitor/Migrations/V15__Add_reset_credits_available.sql
@@ -1,0 +1,4 @@
+-- Add reset_credits_available to provider_history for Codex rate_limit_reset_credits.available_count.
+-- Stores the number of manual rate-limit resets the user still has available.
+-- Null for providers that do not report it; preserved indefinitely as part of usage history.
+ALTER TABLE provider_history ADD COLUMN reset_credits_available INTEGER;

--- a/AIUsageTracker.Monitor/Services/CachedGroupedUsageProjectionService.cs
+++ b/AIUsageTracker.Monitor/Services/CachedGroupedUsageProjectionService.cs
@@ -112,6 +112,7 @@ public sealed class CachedGroupedUsageProjectionService
                 usage.Description,
                 usage.FetchedAt,
                 NextResetTime = q?.NextResetTime,
+                ResetCreditsAvailable = q?.ResetCreditsAvailable,
             };
         });
 

--- a/AIUsageTracker.Monitor/Services/DatabaseMigrationService.cs
+++ b/AIUsageTracker.Monitor/Services/DatabaseMigrationService.cs
@@ -255,6 +255,7 @@ public class DatabaseMigrationService
         EnsureColumn(connection, TableProviderHistory, "model_name", "TEXT");
         EnsureColumn(connection, TableProviderHistory, "name", "TEXT");
         EnsureColumn(connection, TableProviderHistory, "card_type", "TEXT");
+        EnsureColumn(connection, TableProviderHistory, "reset_credits_available", "INTEGER");
 
         // Convert fetched_at TEXT → INTEGER epoch. All columns are ensured above
         // so the table recreation preserves all data.
@@ -325,6 +326,7 @@ public class DatabaseMigrationService
                 model_name TEXT,
                 name TEXT,
                 card_type TEXT,
+                reset_credits_available INTEGER,
                 FOREIGN KEY (provider_id) REFERENCES providers(provider_id) ON DELETE CASCADE
             );
             INSERT INTO provider_history_new ({historyTarget})

--- a/AIUsageTracker.Monitor/Services/GroupedUsageProjectionService.cs
+++ b/AIUsageTracker.Monitor/Services/GroupedUsageProjectionService.cs
@@ -139,6 +139,7 @@ public static class GroupedUsageProjectionService
                     UsedPercentage = usedPercentage,
                     RemainingPercentage = remainingPercentage,
                     NextResetTime = q?.NextResetTime,
+                    ResetCreditsAvailable = q?.ResetCreditsAvailable,
                     Description = u.Description ?? string.Empty,
                     QuotaBuckets = BuildSummaryQuotaBuckets(usedPercentage, remainingPercentage, q?.NextResetTime, u.Description),
                 };

--- a/AIUsageTracker.Monitor/Services/ProviderUsageProcessingPipeline.cs
+++ b/AIUsageTracker.Monitor/Services/ProviderUsageProcessingPipeline.cs
@@ -332,6 +332,7 @@ public class ProviderUsageProcessingPipeline : IProviderUsageProcessingPipeline
             quotaCandidate.IsStatusOnly = (srcQuota?.IsStatusOnly ?? false) || (definition?.IsStatusOnly ?? false);
             quotaCandidate.IsCurrencyUsage = (srcQuota?.IsCurrencyUsage ?? false) || (definition?.IsCurrencyUsage ?? false);
             quotaCandidate.NextResetTime = normalizedNextResetTimeUtc;
+            quotaCandidate.ResetCreditsAvailable = srcQuota?.ResetCreditsAvailable;
         }
 
 

--- a/AIUsageTracker.Monitor/Services/UsageDatabase.cs
+++ b/AIUsageTracker.Monitor/Services/UsageDatabase.cs
@@ -277,7 +277,8 @@ public class UsageDatabase : IUsageDatabase
                         response_latency_ms, http_status,
                         upstream_response_validity, upstream_response_note,
                         parent_provider_id, card_id, group_id,
-                        window_kind, model_name, name, card_type
+                        window_kind, model_name, name, card_type,
+                        reset_credits_available
                     ) VALUES (
                         @ProviderId,
                         @RequestsUsed, @RequestsAvailable, @RequestsPercentage,
@@ -285,7 +286,8 @@ public class UsageDatabase : IUsageDatabase
                         @ResponseLatencyMs, @HttpStatus,
                         @UpstreamResponseValidity, @UpstreamResponseNote,
                         @ParentProviderId, @CardId, @GroupId,
-                        @WindowKind, @ModelName, @Name, @CardType
+                        @WindowKind, @ModelName, @Name, @CardType,
+                        @ResetCreditsAvailable
                     )";
 
                 await connection.ExecuteAsync(insertSql, toInsert).ConfigureAwait(false);
@@ -325,7 +327,8 @@ public class UsageDatabase : IUsageDatabase
             && (long)usage.HttpStatus == last.HttpStatus
             && string.Equals(newStatusMessage, last.StatusMessage ?? string.Empty, StringComparison.Ordinal)
             && string.Equals(newNextResetTime, last.NextResetTime, StringComparison.Ordinal)
-            && string.Equals((usage as WindowedProviderUsage)?.Name ?? (usage as ModelScopedProviderUsage)?.Name, last.Name, StringComparison.Ordinal);
+            && string.Equals((usage as WindowedProviderUsage)?.Name ?? (usage as ModelScopedProviderUsage)?.Name, last.Name, StringComparison.Ordinal)
+            && q?.ResetCreditsAvailable == last.ResetCreditsAvailable;
     }
 
     private static void ClassifyHistoryEntries(
@@ -377,7 +380,8 @@ public class UsageDatabase : IUsageDatabase
                     (int)(w?.WindowKind ?? m?.WindowKind ?? WindowKind.None),
                     m?.ModelName,
                     w?.Name ?? m?.Name,
-                    GetCardType(u)));
+                    GetCardType(u),
+                    q?.ResetCreditsAvailable));
             }
         }
     }
@@ -409,7 +413,8 @@ public class UsageDatabase : IUsageDatabase
                    h.status_message AS StatusMessage,
                    h.next_reset_time AS NextResetTime,
                    h.http_status AS HttpStatus,
-                   h.name AS Name
+                   h.name AS Name,
+                   h.reset_credits_available AS ResetCreditsAvailable
             FROM provider_history h
             WHERE h.id IN (
                 SELECT MAX(id)
@@ -434,7 +439,8 @@ public class UsageDatabase : IUsageDatabase
         string? StatusMessage,
         string? NextResetTime,
         long HttpStatus,
-        string? Name);
+        string? Name,
+        long? ResetCreditsAvailable);
 
     private sealed record HistoryInsertParams(
         string ProviderId,
@@ -455,7 +461,8 @@ public class UsageDatabase : IUsageDatabase
         int WindowKind,
         string? ModelName,
         string? Name,
-        string CardType);
+        string CardType,
+        int? ResetCreditsAvailable);
 
     private sealed record HistoryTouchParams(long Id, long FetchedAt);
 
@@ -645,7 +652,8 @@ public class UsageDatabase : IUsageDatabase
                        COALESCE(h.window_kind, 0) AS WindowKind,
                        h.model_name AS ModelName,
                        h.name AS Name,
-                       COALESCE(h.card_type, 'quota') AS CardType
+                       COALESCE(h.card_type, 'quota') AS CardType,
+                       h.reset_credits_available AS ResetCreditsAvailable
                 FROM provider_history h
                 LEFT JOIN providers p ON h.provider_id = p.provider_id
                 WHERE h.id IN (
@@ -759,6 +767,7 @@ public class UsageDatabase : IUsageDatabase
             quota.DisplayAsFraction = source.DisplayAsFraction;
             quota.IsStatusOnly = source.IsStatusOnly;
             quota.NextResetTime = source.NextResetTime;
+            quota.ResetCreditsAvailable = source.ResetCreditsAvailable;
             quota.UsagePerHour = source.UsagePerHour;
             quota.WindowKind = source.WindowKind;
             quota.Name = source.Name;

--- a/AIUsageTracker.Tests/Integration/ProviderResponseDeserializationTests.cs
+++ b/AIUsageTracker.Tests/Integration/ProviderResponseDeserializationTests.cs
@@ -63,6 +63,9 @@ public class ProviderResponseDeserializationTests
             "credits": {
                 "balance": 150.00,
                 "unlimited": false
+            },
+            "rate_limit_reset_credits": {
+                "available_count": 3
             }
         }
         """;
@@ -93,6 +96,7 @@ public class ProviderResponseDeserializationTests
         Assert.Equal("codex", burstCard.ProviderId);
         Assert.Equal(42.5, burstCard.UsedPercent, precision: 1);
         Assert.NotNull(burstCard.NextResetTime);
+        Assert.Equal(3, burstCard.ResetCreditsAvailable);
 
         // Weekly card (secondary_window, 7d)
         var weeklyCard = usages.First(u => string.Equals(u.CardId, "weekly", StringComparison.Ordinal));

--- a/AIUsageTracker.Tests/Services/DatabaseMigrationServiceTests.cs
+++ b/AIUsageTracker.Tests/Services/DatabaseMigrationServiceTests.cs
@@ -50,6 +50,7 @@ public sealed class DatabaseMigrationServiceTests : IDisposable
         Assert.Contains("model_name", historyColumns, StringComparer.OrdinalIgnoreCase);
         Assert.Contains("name", historyColumns, StringComparer.OrdinalIgnoreCase);
         Assert.Contains("card_type", historyColumns, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("reset_credits_available", historyColumns, StringComparer.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/AIUsageTracker.UI.Slim/FlatWindowCardBuilder.cs
+++ b/AIUsageTracker.UI.Slim/FlatWindowCardBuilder.cs
@@ -44,6 +44,7 @@ internal static class FlatWindowCardBuilder
                 FetchedAt = provider.FetchedAt,
                 NextResetTime = modelState.NextResetTime,
                 PeriodDuration = ResolvePeriodDuration(provider.ProviderId),
+                ResetCreditsAvailable = model.ResetCreditsAvailable,
             });
         }
 

--- a/AIUsageTracker.UI.Slim/MainWindowRuntimeLogic.cs
+++ b/AIUsageTracker.UI.Slim/MainWindowRuntimeLogic.cs
@@ -364,6 +364,11 @@ internal static partial class MainWindowRuntimeLogic
             tooltipBuilder.AppendLine($"Description: {usage.Description}");
         }
 
+        if (usage is QuotaProviderUsage qReset && qReset.ResetCreditsAvailable.HasValue)
+        {
+            tooltipBuilder.AppendLine($"Reset credits available: {qReset.ResetCreditsAvailable.Value}");
+        }
+
         if (ShouldRenderDerivedUsageDetails(usage))
         {
             AppendWindowLimitLines(tooltipBuilder, usage, useRelativeResetTime);


### PR DESCRIPTION
## Summary

Surfaces Codex `rate_limit_reset_credits.available_count` (the number of manual rate-limit resets the user still has) in the card tooltip and persists it permanently in `provider_history`.

### Changes

**Provider** (`CodexProvider.cs`):
- Parses `rate_limit_reset_credits.available_count` from the WHAM API response
- Sets `ResetCreditsAvailable` on the burst (5h primary) card

**Model** (`QuotaProviderUsage.cs`):
- New `int? ResetCreditsAvailable` property

**Database** (permanent storage, never deleted):
- New `reset_credits_available INTEGER` column in `provider_history` (Evolve V15 migration)
- `EnsureColumn` + `ConvertTimestampsToEpochIfNeeded` CREATE TABLE updated for legacy DBs
- Wired into INSERT, dedup gate, and `GetLatestHistoryAsync` SELECT
- Every history row for Codex now records how many reset credits were available at that point

**Data flow** (full pipeline threading):
- `ProviderUsageProcessingPipeline` preserves the value through normalization
- `AgentGroupedModelUsage` carries it through the API response
- `CachedGroupedUsageProjectionService` includes it in ETag (cache invalidation on change)
- `FlatWindowCardBuilder` sets it on the UI card

**UI tooltip** (`MainWindowRuntimeLogic.cs`):
- Shows `Reset credits available: 3` in the Codex card tooltip

### Test coverage
- `CodexProvider_ParsesRealisticResponse_WithAllWindows` asserts burstCard.ResetCreditsAvailable == 3
- `RunMigrations_LegacyDatabaseWithoutEvolveMetadata_AddsMissingProviderColumns` asserts column exists after migration
- All tests pass
