### PR TITLE
Prepare v2.4.2-beta.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+## [2.4.2-beta.1] - 2026-07-04
+
+### Added
+- **Codex reset credits in tooltip**: The Codex card tooltip now shows `rate_limit_reset_credits.available_count` — the number of manual rate-limit resets still available.
+- **Codex reset credits in database**: `reset_credits_available` column added to `provider_history`. Every history row permanently records how many reset credits were available, letting users track when credits were consumed.
+
+### Fixed
+- **Auto-tag workflow**: Fixed `persist-credentials: false` that prevented the auto-tag-release workflow from pushing git tags. Future beta/stable releases will auto-tag correctly.
+
 ## [2.4.1-beta.1] - 2026-07-03
 
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <TrackerVersion>2.4.1-beta.1</TrackerVersion>
-    <TrackerAssemblyVersion>2.4.1</TrackerAssemblyVersion>
+    <TrackerVersion>2.4.2-beta.1</TrackerVersion>
+    <TrackerAssemblyVersion>2.4.2</TrackerAssemblyVersion>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(MSBuildProjectDirectory)\artifacts\**\*</DefaultItemExcludes>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest</AnalysisLevel>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="AIUsageTracker.Web/wwwroot/favicon.png" width="32" height="32" valign="middle"> AI Usage Tracker
 
-![Version](https://img.shields.io/badge/version-2.4.1--beta.1-orange)
+![Version](https://img.shields.io/badge/version-2.4.2--beta.1-orange)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Platforms](https://img.shields.io/badge/platforms-Windows%20|%20Linux%20-blue)
 ![Language](https://img.shields.io/badge/language-C%23%20|%20.NET-purple)

--- a/scripts/publish-app.ps1
+++ b/scripts/publish-app.ps1
@@ -6,7 +6,7 @@ param(
 )
 
 # AI Usage Tracker - Distribution Packaging Script
-# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.4.1-beta.1 -InstallerCompression balanced
+# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.4.2-beta.1 -InstallerCompression balanced
 
 $isWinPlatform = $Runtime.StartsWith("win-")
 $projectName = if ($isWinPlatform) { "AIUsageTracker" } else { "AIUsageTracker.CLI" }

--- a/scripts/setup.iss
+++ b/scripts/setup.iss
@@ -1,7 +1,7 @@
 ; AI Usage Tracker - Inno Setup Script
 
 #ifndef MyAppVersion
-  #define MyAppVersion "2.4.1-beta.1"
+  #define MyAppVersion "2.4.2-beta.1"
 #endif
 #ifndef SourcePath
   #define SourcePath "..\dist\publish-win-x64"


### PR DESCRIPTION
Beta release prep. Includes Codex reset credits (#704) and auto-tag workflow fix (#703). After merge, auto-tag creates the tag (now fixed) and publish.yml builds installers.