### PR TITLE
Release v2.4.2-beta.2: Fix reset credits tooltip rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [2.4.2-beta.2] - 2026-07-04
+
+### Fixed
+- **Reset credits tooltip rendering**: The `reset_credits_available` value was stored in the database and returned by the API but not shown in the card tooltip. For dual-bar providers (Codex), the value lives on the child burst card inside `WindowCards`, not on the parent `WindowedProviderUsage`. Added `ResolveResetCredits` helper that checks both the parent usage and the burst window card.
+
 ## [2.4.2-beta.1] - 2026-07-04
 
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TrackerVersion>2.4.2-beta.1</TrackerVersion>
+    <TrackerVersion>2.4.2-beta.2</TrackerVersion>
     <TrackerAssemblyVersion>2.4.2</TrackerAssemblyVersion>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(MSBuildProjectDirectory)\artifacts\**\*</DefaultItemExcludes>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="AIUsageTracker.Web/wwwroot/favicon.png" width="32" height="32" valign="middle"> AI Usage Tracker
 
-![Version](https://img.shields.io/badge/version-2.4.2--beta.1-orange)
+![Version](https://img.shields.io/badge/version-2.4.2--beta.2-orange)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Platforms](https://img.shields.io/badge/platforms-Windows%20|%20Linux%20-blue)
 ![Language](https://img.shields.io/badge/language-C%23%20|%20.NET-purple)

--- a/scripts/publish-app.ps1
+++ b/scripts/publish-app.ps1
@@ -6,7 +6,7 @@ param(
 )
 
 # AI Usage Tracker - Distribution Packaging Script
-# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.4.2-beta.1 -InstallerCompression balanced
+# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.4.2-beta.2 -InstallerCompression balanced
 
 $isWinPlatform = $Runtime.StartsWith("win-")
 $projectName = if ($isWinPlatform) { "AIUsageTracker" } else { "AIUsageTracker.CLI" }

--- a/scripts/setup.iss
+++ b/scripts/setup.iss
@@ -1,7 +1,7 @@
 ; AI Usage Tracker - Inno Setup Script
 
 #ifndef MyAppVersion
-  #define MyAppVersion "2.4.2-beta.1"
+  #define MyAppVersion "2.4.2-beta.2"
 #endif
 #ifndef SourcePath
   #define SourcePath "..\dist\publish-win-x64"


### PR DESCRIPTION
Fix reset credits tooltip: value was on child burst WindowCard, not parent WindowedProviderUsage. Added ResolveResetCredits helper.