### PR TITLE
Fix reset credits propagation: lift to parent instead of digging into child cards

### DIFF
--- a/AIUsageTracker.UI.Slim/GroupedUsageDisplayAdapter.cs
+++ b/AIUsageTracker.UI.Slim/GroupedUsageDisplayAdapter.cs
@@ -43,6 +43,7 @@ internal static class GroupedUsageDisplayAdapter
             }
             else
             {
+                var windowCards = provider.ProviderDetails.Cast<QuotaProviderUsage>().ToList();
                 usages.Add(new WindowedProviderUsage
                 {
                     ProviderId = provider.ProviderId,
@@ -59,8 +60,11 @@ internal static class GroupedUsageDisplayAdapter
                     Description = provider.Description,
                     FetchedAt = provider.FetchedAt,
                     NextResetTime = provider.NextResetTime,
+                    ResetCreditsAvailable = windowCards
+                        .FirstOrDefault(c => c.WindowKind == WindowKind.Burst)?
+                        .ResetCreditsAvailable,
                     PeriodDuration = FlatWindowCardBuilder.ResolvePeriodDuration(provider.ProviderId),
-                    WindowCards = provider.ProviderDetails.Cast<QuotaProviderUsage>().ToList(),
+                    WindowCards = windowCards,
                 });
             }
         }

--- a/AIUsageTracker.UI.Slim/MainWindowRuntimeLogic.cs
+++ b/AIUsageTracker.UI.Slim/MainWindowRuntimeLogic.cs
@@ -364,10 +364,9 @@ internal static partial class MainWindowRuntimeLogic
             tooltipBuilder.AppendLine($"Description: {usage.Description}");
         }
 
-        var resetCredits = ResolveResetCredits(usage);
-        if (resetCredits.HasValue)
+        if (usage is QuotaProviderUsage qReset && qReset.ResetCreditsAvailable.HasValue)
         {
-            tooltipBuilder.AppendLine($"Reset credits available: {resetCredits.Value}");
+            tooltipBuilder.AppendLine($"Reset credits available: {qReset.ResetCreditsAvailable.Value}");
         }
 
         if (ShouldRenderDerivedUsageDetails(usage))
@@ -407,26 +406,6 @@ internal static partial class MainWindowRuntimeLogic
     private static bool ShouldRenderDerivedUsageDetails(ProviderUsage usage)
     {
         return usage.IsAvailable && usage.State == ProviderUsageState.Available;
-    }
-
-    /// <summary>
-    /// Resolves reset credits from the usage or its burst window card (dual-bar layout).
-    /// </summary>
-    private static int? ResolveResetCredits(ProviderUsage usage)
-    {
-        if (usage is QuotaProviderUsage q && q.ResetCreditsAvailable.HasValue)
-        {
-            return q.ResetCreditsAvailable;
-        }
-
-        if (usage is WindowedProviderUsage wu && wu.WindowCards != null)
-        {
-            return wu.WindowCards
-                .FirstOrDefault(c => c.WindowKind == WindowKind.Burst)?
-                .ResetCreditsAvailable;
-        }
-
-        return null;
     }
 
     private static void AppendWindowLimitLines(


### PR DESCRIPTION
## Problem

The previous fix (PR #706) added a `ResolveResetCredits` method that dug into `WindowCards` to find the burst card's `ResetCreditsAvailable`. This is the exact same pattern of parent-reaching-into-child we've explicitly been told to avoid.

## Fix

**Root cause**: `GroupedUsageDisplayAdapter.Expand` creates a `WindowedProviderUsage` but never propagates `ResetCreditsAvailable` from the child burst card to the parent.

**Solution**: Set `ResetCreditsAvailable` on the `WindowedProviderUsage` parent at construction time in the adapter. The tooltip code now just checks `usage.ResetCreditsAvailable` like every other provider — no child-digging needed.

**Changed files**:
- `GroupedUsageDisplayAdapter.cs`: Propagate burst card's `ResetCreditsAvailable` to parent `WindowedProviderUsage`
- `MainWindowRuntimeLogic.cs`: Revert `ResolveResetCredits`, go back to simple `usage is QuotaProviderUsage qReset` check
