### PR TITLE
Release v2.4.2-beta.3: Proper fix - propagate reset credits to parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [2.4.2-beta.3] - 2026-07-04
+
+### Fixed
+- **Reset credits propagation to parent instead of child-digging**: The beta.2 fix added `ResolveResetCredits` — a helper that dug into `WindowCards` to find the burst card's value. This was the same bad pattern of parent-reaching-into-child we'd explicitly decided to eliminate. Proper fix: `GroupedUsageDisplayAdapter.Expand` now propagates `ResetCreditsAvailable` to the `WindowedProviderUsage` parent at construction time. The tooltip code uses the simple `usage.ResetCreditsAvailable` check like every other provider.
+
 ## [2.4.2-beta.2] - 2026-07-04
 
 ### Fixed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TrackerVersion>2.4.2-beta.2</TrackerVersion>
+    <TrackerVersion>2.4.2-beta.3</TrackerVersion>
     <TrackerAssemblyVersion>2.4.2</TrackerAssemblyVersion>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(MSBuildProjectDirectory)\artifacts\**\*</DefaultItemExcludes>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="AIUsageTracker.Web/wwwroot/favicon.png" width="32" height="32" valign="middle"> AI Usage Tracker
 
-![Version](https://img.shields.io/badge/version-2.4.2--beta.2-orange)
+![Version](https://img.shields.io/badge/version-2.4.2--beta.3-orange)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Platforms](https://img.shields.io/badge/platforms-Windows%20|%20Linux%20-blue)
 ![Language](https://img.shields.io/badge/language-C%23%20|%20.NET-purple)

--- a/scripts/publish-app.ps1
+++ b/scripts/publish-app.ps1
@@ -6,7 +6,7 @@ param(
 )
 
 # AI Usage Tracker - Distribution Packaging Script
-# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.4.2-beta.2 -InstallerCompression balanced
+# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.4.2-beta.3 -InstallerCompression balanced
 
 $isWinPlatform = $Runtime.StartsWith("win-")
 $projectName = if ($isWinPlatform) { "AIUsageTracker" } else { "AIUsageTracker.CLI" }

--- a/scripts/setup.iss
+++ b/scripts/setup.iss
@@ -1,7 +1,7 @@
 ; AI Usage Tracker - Inno Setup Script
 
 #ifndef MyAppVersion
-  #define MyAppVersion "2.4.2-beta.2"
+  #define MyAppVersion "2.4.2-beta.3"
 #endif
 #ifndef SourcePath
   #define SourcePath "..\dist\publish-win-x64"


### PR DESCRIPTION
## What changed

The beta.2 fix had the right diagnosis but wrong cure — it added a helper digging into `WindowCards` to find the burst card's value. This is the exact parent-reaching-into-child pattern we've been told to eliminate.

**Proper fix**: `GroupedUsageDisplayAdapter.Expand` propagates `ResetCreditsAvailable` to the `WindowedProviderUsage` parent at construction time. The tooltip code just checks `usage.ResetCreditsAvailable` like every other provider.

## Files
- `GroupedUsageDisplayAdapter.cs`: +propagation of burst card's ResetCreditsAvailable to parent
- `MainWindowRuntimeLogic.cs`: -ResolveResetCredits, back to simple property check
- Version bumps + CHANGELOG
