### PR TITLE
Release v2.4.2-beta.6

### DIFF
--- a/AIUsageTracker.Infrastructure/Providers/ClaudeCodeProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/ClaudeCodeProvider.cs
@@ -320,7 +320,9 @@ public class ClaudeCodeProvider : ProviderBase
         // All-models 7-day rolling quota
         if (response.SevenDay != null)
         {
-            var desc = $"5h: {(response.FiveHour?.Utilization ?? 0).ToString("F0", CultureInfo.InvariantCulture)}% | 7d: {response.SevenDay.Utilization.ToString("F0", CultureInfo.InvariantCulture)}% used";
+            var desc = response.FiveHour != null
+                ? $"5h: {response.FiveHour.Utilization.ToString("F0", CultureInfo.InvariantCulture)}% | 7d: {response.SevenDay.Utilization.ToString("F0", CultureInfo.InvariantCulture)}% used"
+                : $"7d: {response.SevenDay.Utilization.ToString("F0", CultureInfo.InvariantCulture)}% used";
             if (response.ExtraUsage?.IsEnabled == true)
             {
                 desc += " | Extra usage enabled";

--- a/AIUsageTracker.Infrastructure/Providers/CodexProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/CodexProvider.cs
@@ -480,7 +480,7 @@ public class CodexProvider : ProviderBase
     {
         var providerLabel = ProviderMetadataCatalog.GetConfiguredDisplayName(this.ProviderId);
         var planType = root.ReadString("plan_type") ?? jwtPlanType ?? "unknown";
-        var primaryUsedPercent = root.ReadDouble(JsonKeyRateLimit, JsonKeyPrimaryWindow, JsonKeyUsedPercent) ?? 0.0;
+        var primaryUsedPercent = root.ReadDouble(JsonKeyRateLimit, JsonKeyPrimaryWindow, JsonKeyUsedPercent);
         var primaryResetSeconds = root.ReadDouble(JsonKeyRateLimit, JsonKeyPrimaryWindow, JsonKeyResetAfterSeconds);
         var secondaryUsedPercent = root.ReadDouble(JsonKeyRateLimit, JsonKeySecondaryWindow, JsonKeyUsedPercent);
         var secondaryResetSeconds = root.ReadDouble(JsonKeyRateLimit, JsonKeySecondaryWindow, JsonKeyResetAfterSeconds);
@@ -494,32 +494,46 @@ public class CodexProvider : ProviderBase
             ? (double?)Math.Max(sparkWindow.PrimaryUsedPercent ?? 0.0, sparkWindow.SecondaryUsedPercent ?? 0.0)
             : null;
 
-        // Primary card: 5-hour burst
+        var usages = new List<ProviderUsage>();
+
+        // Primary card: 5-hour burst — only emit when window data is present
         var burstResetTime = ResolveWindowResetTime(
             root.ReadDouble(JsonKeyRateLimit, JsonKeyPrimaryWindow, JsonKeyResetAt),
             primaryResetSeconds);
-        var burstCard = CreateModelScopedUsage(config);
-        burstCard.ProviderName = providerLabel;
-        burstCard.CardId = "burst";
-        burstCard.GroupId = config.ProviderId;
-        burstCard.Name = "5h";
-        burstCard.WindowKind = WindowKind.Burst;
-        burstCard.UsedPercent = primaryUsedPercent;
-        burstCard.RequestsUsed = primaryUsedPercent;
-        burstCard.RequestsAvailable = 100.0;
-        burstCard.IsQuotaBased = this.Definition.IsQuotaBased;
-        burstCard.PlanType = this.Definition.PlanType;
-        burstCard.IsAvailable = true;
-        burstCard.Description = $"{Math.Clamp(100.0 - primaryUsedPercent, 0.0, 100.0).ToString("F0", CultureInfo.InvariantCulture)}% remaining | Plan: {planType}";
-        burstCard.AccountName = accountIdentity ?? string.Empty;
-        burstCard.AuthSource = AuthSource.CodexNative(planType);
-        burstCard.NextResetTime = burstResetTime;
-        burstCard.PeriodDuration = TimeSpan.FromHours(5);
-        burstCard.ResetCreditsAvailable = resetCreditsAvailable;
-        burstCard.RawJson = rawJson;
-        burstCard.HttpStatus = httpStatus;
+        if (primaryUsedPercent.HasValue || burstResetTime.HasValue)
+        {
+            var burstPct = primaryUsedPercent ?? 0.0;
+            var burstCard = CreateModelScopedUsage(config);
+            burstCard.ProviderName = providerLabel;
+            burstCard.CardId = "burst";
+            burstCard.GroupId = config.ProviderId;
+            burstCard.Name = "5h";
+            burstCard.WindowKind = WindowKind.Burst;
+            burstCard.UsedPercent = burstPct;
+            burstCard.RequestsUsed = burstPct;
+            burstCard.RequestsAvailable = 100.0;
+            burstCard.IsQuotaBased = this.Definition.IsQuotaBased;
+            burstCard.PlanType = this.Definition.PlanType;
+            burstCard.IsAvailable = true;
+            burstCard.Description = $"{Math.Clamp(100.0 - burstPct, 0.0, 100.0).ToString("F0", CultureInfo.InvariantCulture)}% remaining | Plan: {planType}";
+            burstCard.AccountName = accountIdentity ?? string.Empty;
+            burstCard.AuthSource = AuthSource.CodexNative(planType);
+            burstCard.NextResetTime = burstResetTime;
+            burstCard.PeriodDuration = TimeSpan.FromHours(5);
+            burstCard.ResetCreditsAvailable = resetCreditsAvailable;
+            burstCard.RawJson = rawJson;
+            burstCard.HttpStatus = httpStatus;
+            usages.Add(burstCard);
+        }
 
-        var usages = new List<ProviderUsage> { burstCard };
+        if (usages.Count == 0 && !secondaryUsedPercent.HasValue && !sparkWindow.HasWindowData)
+        {
+            this._logger.LogWarning("[CODEX] No usage window data in response — returning error");
+            return new List<ProviderUsage>
+            {
+                this.CreateUnavailableUsageWithIdentity("No usage window data in response", accountIdentity, httpStatus),
+            };
+        }
 
         // Weekly card when secondary window data is present
         if (secondaryUsedPercent.HasValue)

--- a/AIUsageTracker.Infrastructure/Providers/OpenAIProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/OpenAIProvider.cs
@@ -370,9 +370,15 @@ public class OpenAIProvider : ProviderBase
 
         if (results.Count == 0)
         {
-            var primaryUsed = doc.RootElement.ReadDouble(JsonKeyRateLimit, JsonKeyPrimaryWindow, JsonKeyUsedPercent) ?? 0.0;
-            var secondaryUsed = doc.RootElement.ReadDouble(JsonKeyRateLimit, JsonKeySecondaryWindow, JsonKeyUsedPercent) ?? 0.0;
-            var used = Math.Max(primaryUsed, secondaryUsed);
+            var primaryUsed = doc.RootElement.ReadDouble(JsonKeyRateLimit, JsonKeyPrimaryWindow, JsonKeyUsedPercent);
+            var secondaryUsed = doc.RootElement.ReadDouble(JsonKeyRateLimit, JsonKeySecondaryWindow, JsonKeyUsedPercent);
+
+            if (!primaryUsed.HasValue && !secondaryUsed.HasValue)
+            {
+                return new[] { this.CreateUnavailableUsage("No usage window data in response", httpStatus) };
+            }
+
+            var used = Math.Max(primaryUsed ?? 0.0, secondaryUsed ?? 0.0);
             var remaining = Math.Clamp(100.0 - used, 0.0, 100.0);
             var usage = CreateWindowedUsage(config);
             usage.ProviderName = providerLabel;

--- a/AIUsageTracker.Infrastructure/Providers/ZaiProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/ZaiProvider.cs
@@ -58,8 +58,6 @@ public class ZaiProvider : ProviderBase
             throw new ArgumentException("API Key not found for Z.AI provider.", nameof(config));
         }
 
-        var providerLabel = ProviderMetadataCatalog.GetConfiguredDisplayName(config.ProviderId);
-
         using var request = new HttpRequestMessage(HttpMethod.Get, QuotaLimitEndpoint);
 
         // Z.AI uses raw key in Authorization header without "Bearer" prefix based on Swift ref
@@ -87,7 +85,7 @@ public class ZaiProvider : ProviderBase
 
         if (limits == null || limits.Count == 0)
         {
-            return this.BuildNoLimitsResult(providerLabel, responseString, httpStatus);
+            return this.BuildNoLimitsResult(config, responseString, httpStatus);
         }
 
         foreach (var limit in limits)
@@ -102,39 +100,56 @@ public class ZaiProvider : ProviderBase
                 limit.NextResetTime);
         }
 
-        var (tokenLimit, mcpLimit) = this.SelectLimits(limits);
+        var results = new List<ProviderUsage>();
 
-        this._logger.LogDebug(
-            "[ZAI] Found token limit: {Found}, mcp limit: {McpFound}",
-            tokenLimit != null,
-            mcpLimit != null);
-
-        var tokenResult = this.ProcessTokenLimit(tokenLimit);
-        tokenResult = this.ApplyMcpAdjustment(tokenResult, mcpLimit);
-
-        var tokenWindowDuration = tokenLimit?.Unit == 3 && tokenLimit.Number.HasValue
-            ? TimeSpan.FromHours(tokenLimit.Number.Value)
-            : (TimeSpan?)null;
-
-        var (nextResetTime, resetStr) = this.ResolveResetTimeInfo(tokenLimit, tokenWindowDuration, limits);
-
-        if (!tokenResult.RemainingPercent.HasValue)
+        // Process TOKENS_LIMIT (coding plan tokens, 5h rolling window)
+        var tokenLimit = this.SelectTokenLimit(limits);
+        if (tokenLimit != null)
         {
-            return this.BuildUnknownUsageResult(providerLabel, responseString, httpStatus, tokenResult);
+            this._logger.LogDebug("[ZAI] Processing TOKENS_LIMIT as main card");
+            var tokenResult = this.ProcessTokenLimit(tokenLimit);
+            if (tokenResult.RemainingPercent.HasValue)
+            {
+                var windowDuration = tokenLimit.Unit == 3 && tokenLimit.Number.HasValue
+                    ? TimeSpan.FromHours(tokenLimit.Number.Value)
+                    : (TimeSpan?)null;
+                var (nextReset, resetStr) = this.ResolveResetTimeInfo(tokenLimit, windowDuration, limits);
+                results.Add(this.BuildTokenUsageResult(tokenResult, config, responseString, httpStatus, nextReset, resetStr));
+            }
+            else
+            {
+                results.AddRange(this.BuildUnknownUsageResult(config, responseString, httpStatus));
+            }
         }
 
-        return new[] { this.BuildUsageResult(tokenResult, providerLabel, responseString, httpStatus, nextResetTime, resetStr) };
+        // Process TIME_LIMIT (monthly web search / reader / zread quota) as separate card using "zai" provider ID
+        var timeLimit = limits.FirstOrDefault(static l =>
+            l.Type != null && (l.Type.Equals("TIME_LIMIT", StringComparison.OrdinalIgnoreCase) ||
+                                l.Type.Equals("Time", StringComparison.OrdinalIgnoreCase)));
+        if (timeLimit != null && timeLimit.Percentage.HasValue)
+        {
+            this._logger.LogDebug("[ZAI] Processing TIME_LIMIT as separate card");
+            results.Add(this.BuildTimeLimitResult(timeLimit, config, responseString, httpStatus));
+        }
+
+        if (results.Count == 0)
+        {
+            return this.BuildUnknownUsageResult(config, responseString, httpStatus);
+        }
+
+        return results;
     }
 
-    private ProviderUsage[] BuildNoLimitsResult(string providerLabel, string responseString, int httpStatus)
+    private ProviderUsage[] BuildNoLimitsResult(ProviderConfig config, string responseString, int httpStatus)
     {
         this._logger.LogDebug("[ZAI] No limits found in response");
+        var label = ProviderMetadataCatalog.GetConfiguredDisplayName(config.ProviderId);
         return new[]
         {
             new QuotaProviderUsage
             {
                 ProviderId = this.ProviderId,
-                ProviderName = providerLabel,
+                ProviderName = label,
                 IsAvailable = false,
                 Description = "No usage data available",
                 IsQuotaBased = this.Definition.IsQuotaBased,
@@ -145,7 +160,7 @@ public class ZaiProvider : ProviderBase
         };
     }
 
-    private (ZaiQuotaLimitItem? TokenLimit, ZaiQuotaLimitItem? McpLimit) SelectLimits(List<ZaiQuotaLimitItem> limits)
+    private ZaiQuotaLimitItem? SelectTokenLimit(List<ZaiQuotaLimitItem> limits)
     {
         var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
         var nowSec = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
@@ -154,47 +169,23 @@ public class ZaiProvider : ProviderBase
             l.Type != null && (l.Type.Equals("TOKENS_LIMIT", StringComparison.OrdinalIgnoreCase) ||
                                l.Type.Equals("Tokens", StringComparison.OrdinalIgnoreCase))).ToList();
 
-        var tokenLimit = tokenLimits.Where(l => IsFutureTimestamp(l.NextResetTime, nowMs, nowSec))
-                                    .OrderBy(l => l.Remaining ?? long.MaxValue)
-                                    .FirstOrDefault()
-                          ?? tokenLimits.FirstOrDefault();
-
-        var mcpLimit = limits.FirstOrDefault(l =>
-            l.Type != null && (l.Type.Equals("TIME_LIMIT", StringComparison.OrdinalIgnoreCase) ||
-                               l.Type.Equals("Time", StringComparison.OrdinalIgnoreCase)));
-
-        return (tokenLimit, mcpLimit);
+        return tokenLimits.Where(l => IsFutureTimestamp(l.NextResetTime, nowMs, nowSec))
+                          .OrderBy(l => l.Remaining ?? long.MaxValue)
+                          .FirstOrDefault()
+                ?? tokenLimits.FirstOrDefault();
     }
 
-    private TokenLimitResult ApplyMcpAdjustment(TokenLimitResult tokenResult, ZaiQuotaLimitItem? mcpLimit)
+    private ProviderUsage[] BuildUnknownUsageResult(ProviderConfig config, string responseString, int httpStatus)
     {
-        if (mcpLimit?.Percentage is not double mcpPercentage || mcpPercentage <= 0)
-        {
-            return tokenResult;
-        }
-
-        this._logger.LogDebug("[ZAI] Processing TIME_LIMIT - Percentage: {Percentage}", mcpPercentage);
-        double mcpRemainingPercent = Math.Max(0, 100 - mcpPercentage);
-        var adjusted = tokenResult with
-        {
-            RemainingPercent = tokenResult.RemainingPercent.HasValue
-                ? Math.Min(tokenResult.RemainingPercent.Value, mcpRemainingPercent)
-                : mcpRemainingPercent,
-        };
-        this._logger.LogDebug("[ZAI] MCP remaining percent: {McpRemainingPercent}", mcpRemainingPercent);
-        return adjusted;
-    }
-
-    private ProviderUsage[] BuildUnknownUsageResult(string providerLabel, string responseString, int httpStatus, TokenLimitResult tokenResult)
-    {
+        var label = ProviderMetadataCatalog.GetConfiguredDisplayName(config.ProviderId);
         return new[]
         {
             new QuotaProviderUsage
             {
                 ProviderId = this.ProviderId,
-                ProviderName = providerLabel,
+                ProviderName = label,
                 IsAvailable = false,
-                Description = FormatDescription("Usage unknown (missing quota metrics)", tokenResult.PlanDescription),
+                Description = "Usage unknown (missing quota metrics)",
                 IsQuotaBased = this.Definition.IsQuotaBased,
                 PlanType = this.Definition.PlanType,
                 RawJson = responseString,
@@ -203,14 +194,15 @@ public class ZaiProvider : ProviderBase
         };
     }
 
-    private ProviderUsage BuildUsageResult(
+    private ProviderUsage BuildTokenUsageResult(
         TokenLimitResult tokenResult,
-        string providerLabel,
+        ProviderConfig config,
         string responseString,
         int httpStatus,
         DateTime? nextResetTime,
         string resetStr)
     {
+        var label = ProviderMetadataCatalog.GetConfiguredDisplayName(config.ProviderId);
         var finalRemainingPercent = Math.Min(tokenResult.RemainingPercent!.Value, 100);
         var finalUsedPercent = Math.Max(0, 100.0 - finalRemainingPercent);
 
@@ -227,18 +219,15 @@ public class ZaiProvider : ProviderBase
             : tokenResult.DetailInfo) + resetStr;
 
         this._logger.LogInformation(
-            "Z.AI Provider Usage - ProviderId: {ProviderId}, ProviderName: {ProviderName}, UsedPercent: {UsedPercent}%, RequestsUsed: {RequestsUsed}%, Description: {Description}, IsAvailable: {IsAvailable}",
-            this.ProviderId,
-            providerLabel,
+            "Z.AI TOKENS_LIMIT - UsedPercent: {UsedPercent}%, RequestsUsed: {RequestsUsed}%, Description: {Description}",
             finalUsedPercent,
             tokenResult.RequestsUsed,
-            finalDescription,
-            true);
+            finalDescription);
 
         return new QuotaProviderUsage
         {
             ProviderId = this.ProviderId,
-            ProviderName = providerLabel,
+            ProviderName = label,
             UsedPercent = finalUsedPercent,
             RequestsUsed = tokenResult.RequestsUsed,
             RequestsAvailable = tokenResult.RequestsAvailable,
@@ -246,6 +235,56 @@ public class ZaiProvider : ProviderBase
             PlanType = this.Definition.PlanType,
             DisplayAsFraction = tokenResult.RequestsAvailable > 100,
             Description = FormatDescription(finalDescription, tokenResult.PlanDescription),
+            NextResetTime = nextResetTime,
+            IsAvailable = true,
+            RawJson = responseString,
+            HttpStatus = httpStatus,
+        };
+    }
+
+    private ProviderUsage BuildTimeLimitResult(ZaiQuotaLimitItem timeLimit, ProviderConfig config, string responseString, int httpStatus)
+    {
+        var label = ProviderMetadataCatalog.GetConfiguredDisplayName("zai");
+        double usedPercent = timeLimit.Percentage!.Value;
+        double remainingPercent = Math.Max(0, 100 - usedPercent);
+
+        var usageSummary = timeLimit.UsageDetails != null && timeLimit.UsageDetails.Count > 0
+            ? string.Join(", ", timeLimit.UsageDetails.Select(d =>
+                $"{d.ModelCode}: {d.Usage}"))
+            : null;
+
+        DateTime? nextResetTime = null;
+        string resetStr;
+        if (timeLimit.NextResetTime.HasValue && timeLimit.NextResetTime.Value > 0)
+        {
+            nextResetTime = ParseTimestamp(timeLimit.NextResetTime.Value);
+            resetStr = $" (Resets: {nextResetTime!.Value.ToString("MMM dd, yyyy HH:mm", CultureInfo.InvariantCulture)} Local)";
+        }
+        else
+        {
+            resetStr = string.Empty;
+        }
+
+        var detailLine = usageSummary != null
+            ? $"Web Search & Reader: {remainingPercent.ToString("F1", CultureInfo.InvariantCulture)}% remaining ({timeLimit.CurrentValue ?? 0}/{timeLimit.Total ?? 0}){resetStr}"
+            : $"Monthly quota: {remainingPercent.ToString("F1", CultureInfo.InvariantCulture)}% remaining{resetStr}";
+
+        this._logger.LogInformation(
+            "Z.AI TIME_LIMIT - UsedPercent: {UsedPercent}%, Description: {Description}",
+            usedPercent,
+            detailLine);
+
+        return new QuotaProviderUsage
+        {
+            ProviderId = "zai",
+            ProviderName = label,
+            UsedPercent = usedPercent,
+            RequestsUsed = timeLimit.CurrentValue ?? 0,
+            RequestsAvailable = timeLimit.Total ?? 0,
+            IsQuotaBased = true,
+            PlanType = PlanType.Usage,
+            DisplayAsFraction = (timeLimit.Total ?? 0) > 100,
+            Description = detailLine,
             NextResetTime = nextResetTime,
             IsAvailable = true,
             RawJson = responseString,
@@ -439,5 +478,17 @@ public class ZaiProvider : ProviderBase
         /// <summary>Gets or sets number of units in the window duration (e.g. 5 for a 5-hour window).</summary>
         [JsonPropertyName("number")]
         public long? Number { get; set; }
+
+        [JsonPropertyName("usageDetails")]
+        public List<ZaiUsageDetail>? UsageDetails { get; set; }
+    }
+
+    private sealed class ZaiUsageDetail
+    {
+        [JsonPropertyName("modelCode")]
+        public string ModelCode { get; set; } = string.Empty;
+
+        [JsonPropertyName("usage")]
+        public long Usage { get; set; }
     }
 }

--- a/AIUsageTracker.Tests/Infrastructure/Providers/ZaiProviderTests.cs
+++ b/AIUsageTracker.Tests/Infrastructure/Providers/ZaiProviderTests.cs
@@ -188,6 +188,75 @@ public class ZaiProviderTests : HttpProviderTestBase<ZaiProvider>
     }
 
     [Fact]
+    public async Task GetUsageAsync_BothTokenAndTimeLimits_ReturnsTwoCardsAsync()
+    {
+        // Regression: TIME_LIMIT (monthly search/reader/zread quota) must be its own card,
+        // not merged into the TOKENS_LIMIT card via MCP adjustment.
+        var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        var futureMs = nowMs + 3600000L; // 1 hour from now
+
+        var responseContent = JsonSerializer.Serialize(new
+        {
+            data = new
+            {
+                limits = new object[]
+                {
+                    new
+                    {
+                        type = "TIME_LIMIT",
+                        unit = 5,
+                        number = 1L,
+                        usage = 1000L,      // total
+                        currentValue = 117, // used
+                        remaining = 883,
+                        percentage = 11.0,
+                        nextResetTime = nowMs + 2592000000L, // ~30 days
+                        usageDetails = new[]
+                        {
+                            new { modelCode = "search-prime", usage = 82L },
+                            new { modelCode = "web-reader", usage = 35L },
+                            new { modelCode = "zread", usage = 0L },
+                        },
+                    },
+                    new
+                    {
+                        type = "TOKENS_LIMIT",
+                        percentage = 3.0,
+                        unit = 3,
+                        number = 5L,
+                        nextResetTime = futureMs,
+                    },
+                },
+            },
+        });
+
+        this.SetupHttpResponse("https://api.z.ai/api/monitor/usage/quota/limit", new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent(responseContent),
+        });
+
+        var result = await this._provider.GetUsageAsync(this.Config);
+
+        // Must produce exactly 2 cards — one per limit type
+        var cards = result.OfType<QuotaProviderUsage>().ToList();
+        Assert.Equal(2, cards.Count);
+
+        // Card 1: TOKENS_LIMIT (zai-coding-plan) — 3% used
+        var tokenCard = cards.Single(c => c.ProviderId == "zai-coding-plan");
+        Assert.True(tokenCard.IsAvailable);
+        Assert.InRange(tokenCard.UsedPercent, 2.5, 3.5); // 3% used, 97% remaining
+        Assert.Contains("Coding Plan", tokenCard.Description, StringComparison.Ordinal);
+
+        // Card 2: TIME_LIMIT (zai) — 11% used
+        var timeCard = cards.Single(c => c.ProviderId == "zai");
+        Assert.True(timeCard.IsAvailable);
+        Assert.InRange(timeCard.UsedPercent, 10.5, 11.5); // 11% used, 89% remaining
+        Assert.Contains("Web Search & Reader", timeCard.Description, StringComparison.Ordinal);
+        Assert.NotNull(timeCard.NextResetTime);
+    }
+
+    [Fact]
     public async Task GetUsageAsync_ActiveTokenLimit_ShowsActualWindowResetTimeAsync()
     {
         // When percentage > 0 the API returns the current 5h window's close time as nextResetTime.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [2.4.2-beta.6] - 2026-07-06
+
+### Fixed
+- **Silent-zero bugs in OpenAI, Codex, ClaudeCode providers**: When API responses lack usage data (missing `rate_limit` windows, missing `used_percent`, null `FiveHour` quotas), providers now return error cards instead of showing 0%.
+- **ZaiProvider merged quotas**: Z.AI's TOKENS_LIMIT (5h coding plan, 3% used) and TIME_LIMIT (monthly search/reader quota, 11% used) are now separate cards instead of being merged into one via `ApplyMcpAdjustment`.
+
 ## [2.4.2-beta.5] - 2026-07-05
 
 ### Fixed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TrackerVersion>2.4.2-beta.5</TrackerVersion>
+    <TrackerVersion>2.4.2-beta.6</TrackerVersion>
     <TrackerAssemblyVersion>2.4.2</TrackerAssemblyVersion>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(MSBuildProjectDirectory)\artifacts\**\*</DefaultItemExcludes>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="AIUsageTracker.Web/wwwroot/favicon.png" width="32" height="32" valign="middle"> AI Usage Tracker
 
-![Version](https://img.shields.io/badge/version-2.4.2--beta.5-orange)
+![Version](https://img.shields.io/badge/version-2.4.2--beta.6-orange)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Platforms](https://img.shields.io/badge/platforms-Windows%20|%20Linux%20-blue)
 ![Language](https://img.shields.io/badge/language-C%23%20|%20.NET-purple)

--- a/scripts/publish-app.ps1
+++ b/scripts/publish-app.ps1
@@ -6,7 +6,7 @@ param(
 )
 
 # AI Usage Tracker - Distribution Packaging Script
-# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.4.2-beta.3 -InstallerCompression balanced
+# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.4.2-beta.6 -InstallerCompression balanced
 
 $isWinPlatform = $Runtime.StartsWith("win-")
 $projectName = if ($isWinPlatform) { "AIUsageTracker" } else { "AIUsageTracker.CLI" }

--- a/scripts/setup.iss
+++ b/scripts/setup.iss
@@ -1,7 +1,7 @@
 ; AI Usage Tracker - Inno Setup Script
 
 #ifndef MyAppVersion
-  #define MyAppVersion "2.4.2-beta.5"
+  #define MyAppVersion "2.4.2-beta.6"
 #endif
 #ifndef SourcePath
   #define SourcePath "..\dist\publish-win-x64"


### PR DESCRIPTION
## Summary

Fixes silent-zero bugs and splits ZaiProvider merged quotas into separate cards.

### Fixed
- **Silent-zero bugs in OpenAI, Codex, ClaudeCode providers**: When API responses lack usage data, providers now return error cards instead of showing 0%.
- **ZaiProvider merged quotas**: Z.AI's TOKENS_LIMIT (5h coding plan, 3% used) and TIME_LIMIT (monthly search/reader quota, 11% used) are now separate cards.

### Changelog
- [Unreleased] -> [2.4.2-beta.6] - 2026-07-06
- Version bumped to 2.4.2-beta.6