### PR TITLE
fix: stop writing port: 0 to monitor.json on suspend/resume

### DIFF
--- a/AIUsageTracker.Monitor/Services/PowerStateListener.cs
+++ b/AIUsageTracker.Monitor/Services/PowerStateListener.cs
@@ -115,13 +115,11 @@ public sealed class PowerStateListener : IHostedService, IDisposable
     {
         this._logger.LogInformation("System suspend detected — pausing scheduler");
         this._onSuspend();
-        MonitorInfoPersistence.SaveMonitorInfo(port: 0, debug: false, logger: this._logger, pathProvider: this._pathProvider, startupStatus: "suspended");
     }
 
     private void HandleResume()
     {
         this._logger.LogInformation("System resume detected — resuming scheduler");
         this._onResume();
-        MonitorInfoPersistence.SaveMonitorInfo(port: 0, debug: false, logger: this._logger, pathProvider: this._pathProvider, startupStatus: "running");
     }
 }


### PR DESCRIPTION
Removes the SaveMonitorInfo(port: 0) calls in HandleSuspend and HandleResume. Writing port: 0 to monitor.json after resume causes the Slim UI to lose its connection to the Monitor, showing zeros until the polling timer re-discovers the correct port. The Monitor's port doesn't change across hibernate — it's still listening on the same port.