### PR TITLE
fix: show per-window tooltip lines for Codex/OpenAI dual-bar providers

### DIFF
--- a/AIUsageTracker.UI.Slim/MainWindowRuntimeLogic.cs
+++ b/AIUsageTracker.UI.Slim/MainWindowRuntimeLogic.cs
@@ -489,7 +489,7 @@ internal static partial class MainWindowRuntimeLogic
         ProviderUsage? windowCard,
         bool useRelativeResetTime)
     {
-        if (windowCard is not WindowedProviderUsage wc || string.IsNullOrWhiteSpace(wc.Name))
+        if (windowCard is not QuotaProviderUsage wc || string.IsNullOrWhiteSpace(wc.Name))
         {
             return;
         }


### PR DESCRIPTION
`AppendWindowLine` checks `windowCard is not WindowedProviderUsage wc`, but Codex creates `ModelScopedProviderUsage` objects for its window cards (burst/rolling). Since `ModelScopedProviderUsage` inherits from `QuotaProviderUsage` (not `WindowedProviderUsage`), the type check rejects them and the per-window tooltip lines ("5h limit: X% remaining", "5h resets: ...", "Weekly limit: ...") are silently skipped. All properties used (`Name`, `UsedPercent`, `NextResetTime`, `WindowKind`) are on the common base class `QuotaProviderUsage`, so widening the check fixes it.