### PR TITLE
fix: read limit_window_seconds to detect window type in OpenAI/Codex providers

### DIFF
--- a/AIUsageTracker.Infrastructure/Providers/CodexProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/CodexProvider.cs
@@ -95,6 +95,8 @@ public class CodexProvider : ProviderBase
     private const string JsonKeyResetAt = "reset_at";
     private const string JsonKeyRateLimitResetCredits = "rate_limit_reset_credits";
     private const string JsonKeyAvailableCount = "available_count";
+    private const string JsonKeyLimitWindowSeconds = "limit_window_seconds";
+    private const double WeeklyWindowSeconds = 604800.0;
 
     private readonly HttpClient _httpClient;
     private readonly ILogger<CodexProvider> _logger;
@@ -287,7 +289,7 @@ public class CodexProvider : ProviderBase
         candidates = ParseRateLimitProperties(root);
 
         var preferredRateLimitCandidate = SelectPreferredSparkCandidate(candidates);
-        return preferredRateLimitCandidate ?? new SparkWindow(Label: null, ModelName: null, PrimaryUsedPercent: null, PrimaryResetTime: null, SecondaryUsedPercent: null, SecondaryResetTime: null);
+        return preferredRateLimitCandidate ?? new SparkWindow(Label: null, ModelName: null, PrimaryUsedPercent: null, PrimaryResetTime: null, PrimaryWindowSeconds: null, SecondaryUsedPercent: null, SecondaryResetTime: null, SecondaryWindowSeconds: null);
     }
 
     private static List<SparkWindow> ParseAdditionalRateLimits(JsonElement root)
@@ -358,13 +360,15 @@ public class CodexProvider : ProviderBase
         var primaryResetTime = ResolveWindowResetTime(
             element.ReadDouble(JsonKeyPrimaryWindow, JsonKeyResetAt),
             element.ReadDouble(JsonKeyPrimaryWindow, JsonKeyResetAfterSeconds));
+        var primaryWindowSeconds = element.ReadDouble(JsonKeyPrimaryWindow, JsonKeyLimitWindowSeconds);
         var secondaryUsedPercent = element.ReadDouble(JsonKeySecondaryWindow, JsonKeyUsedPercent);
         var secondaryResetTime = ResolveWindowResetTime(
             element.ReadDouble(JsonKeySecondaryWindow, JsonKeyResetAt),
             element.ReadDouble(JsonKeySecondaryWindow, JsonKeyResetAfterSeconds));
+        var secondaryWindowSeconds = element.ReadDouble(JsonKeySecondaryWindow, JsonKeyLimitWindowSeconds);
         if (primaryUsedPercent.HasValue || primaryResetTime.HasValue || secondaryUsedPercent.HasValue || secondaryResetTime.HasValue)
         {
-            return new SparkWindow(label, modelName, primaryUsedPercent, primaryResetTime, secondaryUsedPercent, secondaryResetTime);
+            return new SparkWindow(label, modelName, primaryUsedPercent, primaryResetTime, primaryWindowSeconds, secondaryUsedPercent, secondaryResetTime, secondaryWindowSeconds);
         }
 
         return null;
@@ -480,53 +484,134 @@ public class CodexProvider : ProviderBase
     {
         var providerLabel = ProviderMetadataCatalog.GetConfiguredDisplayName(this.ProviderId);
         var planType = root.ReadString("plan_type") ?? jwtPlanType ?? "unknown";
+
+        // Read limit_window_seconds to determine actual window type
+        var primaryLimit = root.ReadDouble(JsonKeyRateLimit, JsonKeyPrimaryWindow, JsonKeyLimitWindowSeconds);
+        var hasSecondaryWindow = root.TryGetProperty(JsonKeyRateLimit, out var rateLimitObj) &&
+                                 rateLimitObj.TryGetProperty(JsonKeySecondaryWindow, out var secondaryWin) &&
+                                 secondaryWin.ValueKind == JsonValueKind.Object;
+
         var primaryUsedPercent = root.ReadDouble(JsonKeyRateLimit, JsonKeyPrimaryWindow, JsonKeyUsedPercent);
         var primaryResetSeconds = root.ReadDouble(JsonKeyRateLimit, JsonKeyPrimaryWindow, JsonKeyResetAfterSeconds);
-        var secondaryUsedPercent = root.ReadDouble(JsonKeyRateLimit, JsonKeySecondaryWindow, JsonKeyUsedPercent);
-        var secondaryResetSeconds = root.ReadDouble(JsonKeyRateLimit, JsonKeySecondaryWindow, JsonKeyResetAfterSeconds);
+        var secondaryUsedPercent = hasSecondaryWindow
+            ? root.ReadDouble(JsonKeyRateLimit, JsonKeySecondaryWindow, JsonKeyUsedPercent)
+            : (double?)null;
+        var secondaryResetSeconds = hasSecondaryWindow
+            ? root.ReadDouble(JsonKeyRateLimit, JsonKeySecondaryWindow, JsonKeyResetAfterSeconds)
+            : (double?)null;
+
         var sparkWindow = ExtractSparkWindow(root);
         var accountIdentity = ResolveAccountIdentity(root, jwtEmail, authIdentity, accountId);
 
         var resetCreditsDouble = root.ReadDouble(JsonKeyRateLimitResetCredits, JsonKeyAvailableCount);
         int? resetCreditsAvailable = resetCreditsDouble.HasValue ? (int)resetCreditsDouble.Value : (int?)null;
 
-        var effectiveSparkPercent = sparkWindow.HasWindowData
-            ? (double?)Math.Max(sparkWindow.PrimaryUsedPercent ?? 0.0, sparkWindow.SecondaryUsedPercent ?? 0.0)
-            : null;
-
         var usages = new List<ProviderUsage>();
 
-        // Primary card: 5-hour burst — only emit when window data is present
-        var burstResetTime = ResolveWindowResetTime(
-            root.ReadDouble(JsonKeyRateLimit, JsonKeyPrimaryWindow, JsonKeyResetAt),
-            primaryResetSeconds);
-        if (primaryUsedPercent.HasValue || burstResetTime.HasValue)
+        // Determine if primary window is weekly (new unified-window format)
+        var primaryIsWeekly = primaryLimit.HasValue && Math.Abs(primaryLimit.Value - WeeklyWindowSeconds) < 1;
+
+        if (primaryIsWeekly)
         {
-            var burstPct = primaryUsedPercent ?? 0.0;
-            var burstCard = CreateModelScopedUsage(config);
-            burstCard.ProviderName = providerLabel;
-            burstCard.CardId = "burst";
-            burstCard.GroupId = config.ProviderId;
-            burstCard.Name = "5h";
-            burstCard.WindowKind = WindowKind.Burst;
-            burstCard.UsedPercent = burstPct;
-            burstCard.RequestsUsed = burstPct;
-            burstCard.RequestsAvailable = 100.0;
-            burstCard.IsQuotaBased = this.Definition.IsQuotaBased;
-            burstCard.PlanType = this.Definition.PlanType;
-            burstCard.IsAvailable = true;
-            burstCard.Description = $"{Math.Clamp(100.0 - burstPct, 0.0, 100.0).ToString("F0", CultureInfo.InvariantCulture)}% remaining | Plan: {planType}";
-            burstCard.AccountName = accountIdentity ?? string.Empty;
-            burstCard.AuthSource = AuthSource.CodexNative(planType);
-            burstCard.NextResetTime = burstResetTime;
-            burstCard.PeriodDuration = TimeSpan.FromHours(5);
-            burstCard.ResetCreditsAvailable = resetCreditsAvailable;
-            burstCard.RawJson = rawJson;
-            burstCard.HttpStatus = httpStatus;
-            usages.Add(burstCard);
+            // New format: primary_window IS the weekly window, secondary_window is null
+            var weeklyResetTime = ResolveWindowResetTime(
+                root.ReadDouble(JsonKeyRateLimit, JsonKeyPrimaryWindow, JsonKeyResetAt),
+                primaryResetSeconds);
+            if (primaryUsedPercent.HasValue || weeklyResetTime.HasValue)
+            {
+                var weeklyPct = primaryUsedPercent ?? 0.0;
+                var weeklyCard = CreateModelScopedUsage(config);
+                weeklyCard.ProviderName = providerLabel;
+                weeklyCard.CardId = "weekly";
+                weeklyCard.GroupId = config.ProviderId;
+                weeklyCard.Name = WeeklyWindowLabel;
+                weeklyCard.WindowKind = WindowKind.Rolling;
+                weeklyCard.UsedPercent = weeklyPct;
+                weeklyCard.RequestsUsed = weeklyPct;
+                weeklyCard.RequestsAvailable = 100.0;
+                weeklyCard.IsQuotaBased = this.Definition.IsQuotaBased;
+                weeklyCard.PlanType = this.Definition.PlanType;
+                weeklyCard.IsAvailable = true;
+                weeklyCard.Description = $"{Math.Clamp(100.0 - weeklyPct, 0.0, 100.0).ToString("F0", CultureInfo.InvariantCulture)}% remaining | Plan: {planType}";
+                weeklyCard.AccountName = accountIdentity ?? string.Empty;
+                weeklyCard.AuthSource = AuthSource.CodexNative(planType);
+                weeklyCard.NextResetTime = weeklyResetTime;
+                weeklyCard.PeriodDuration = TimeSpan.FromDays(7);
+                weeklyCard.ResetCreditsAvailable = resetCreditsAvailable;
+                weeklyCard.RawJson = rawJson;
+                weeklyCard.HttpStatus = httpStatus;
+                usages.Add(weeklyCard);
+            }
+        }
+        else
+        {
+            // Old format: primary_window is burst (5h), secondary_window is weekly
+            var burstResetTime = ResolveWindowResetTime(
+                root.ReadDouble(JsonKeyRateLimit, JsonKeyPrimaryWindow, JsonKeyResetAt),
+                primaryResetSeconds);
+            if (primaryUsedPercent.HasValue || burstResetTime.HasValue)
+            {
+                var burstPct = primaryUsedPercent ?? 0.0;
+                var burstCard = CreateModelScopedUsage(config);
+                burstCard.ProviderName = providerLabel;
+                burstCard.CardId = "burst";
+                burstCard.GroupId = config.ProviderId;
+                burstCard.Name = "5h";
+                burstCard.WindowKind = WindowKind.Burst;
+                burstCard.UsedPercent = burstPct;
+                burstCard.RequestsUsed = burstPct;
+                burstCard.RequestsAvailable = 100.0;
+                burstCard.IsQuotaBased = this.Definition.IsQuotaBased;
+                burstCard.PlanType = this.Definition.PlanType;
+                burstCard.IsAvailable = true;
+                burstCard.Description = $"{Math.Clamp(100.0 - burstPct, 0.0, 100.0).ToString("F0", CultureInfo.InvariantCulture)}% remaining | Plan: {planType}";
+                burstCard.AccountName = accountIdentity ?? string.Empty;
+                burstCard.AuthSource = AuthSource.CodexNative(planType);
+                burstCard.NextResetTime = burstResetTime;
+                burstCard.PeriodDuration = TimeSpan.FromHours(5);
+                burstCard.ResetCreditsAvailable = resetCreditsAvailable;
+                burstCard.RawJson = rawJson;
+                burstCard.HttpStatus = httpStatus;
+                usages.Add(burstCard);
+            }
+
+            // Weekly card from secondary_window (old format)
+            if (secondaryUsedPercent.HasValue)
+            {
+                var weeklyResetTime = ResolveWindowResetTime(
+                    root.ReadDouble(JsonKeyRateLimit, JsonKeySecondaryWindow, JsonKeyResetAt),
+                    secondaryResetSeconds);
+                var weeklyRemaining = Math.Clamp(100.0 - secondaryUsedPercent.Value, 0.0, 100.0);
+                var effectiveSparkPercent = sparkWindow.HasWindowData
+                    ? (double?)Math.Max(sparkWindow.PrimaryUsedPercent ?? 0.0, sparkWindow.SecondaryUsedPercent ?? 0.0)
+                    : null;
+                var weeklyDesc = sparkWindow.HasWindowData && effectiveSparkPercent.HasValue
+                    ? $"{weeklyRemaining.ToString("F0", CultureInfo.InvariantCulture)}% remaining | Plan: {planType} | Spark: {effectiveSparkPercent.Value.ToString("F0", CultureInfo.InvariantCulture)}% used"
+                    : $"{weeklyRemaining.ToString("F0", CultureInfo.InvariantCulture)}% remaining | Plan: {planType}";
+                var weeklyCard = CreateModelScopedUsage(config);
+                weeklyCard.ProviderName = providerLabel;
+                weeklyCard.CardId = "weekly";
+                weeklyCard.GroupId = config.ProviderId;
+                weeklyCard.Name = WeeklyWindowLabel;
+                weeklyCard.WindowKind = WindowKind.Rolling;
+                weeklyCard.UsedPercent = secondaryUsedPercent.Value;
+                weeklyCard.RequestsUsed = secondaryUsedPercent.Value;
+                weeklyCard.RequestsAvailable = 100.0;
+                weeklyCard.IsQuotaBased = this.Definition.IsQuotaBased;
+                weeklyCard.PlanType = this.Definition.PlanType;
+                weeklyCard.IsAvailable = true;
+                weeklyCard.Description = weeklyDesc;
+                weeklyCard.AccountName = accountIdentity ?? string.Empty;
+                weeklyCard.AuthSource = AuthSource.CodexNative(planType);
+                weeklyCard.NextResetTime = weeklyResetTime;
+                weeklyCard.PeriodDuration = TimeSpan.FromDays(7);
+                weeklyCard.RawJson = rawJson;
+                weeklyCard.HttpStatus = httpStatus;
+                usages.Add(weeklyCard);
+            }
         }
 
-        if (usages.Count == 0 && !secondaryUsedPercent.HasValue && !sparkWindow.HasWindowData)
+        if (usages.Count == 0 && !sparkWindow.HasWindowData)
         {
             this._logger.LogWarning("[CODEX] No usage window data in response — returning error");
             return new List<ProviderUsage>
@@ -535,92 +620,95 @@ public class CodexProvider : ProviderBase
             };
         }
 
-        // Weekly card when secondary window data is present
-        if (secondaryUsedPercent.HasValue)
-        {
-            var weeklyResetTime = ResolveWindowResetTime(
-                root.ReadDouble(JsonKeyRateLimit, JsonKeySecondaryWindow, JsonKeyResetAt),
-                secondaryResetSeconds);
-            var weeklyRemaining = Math.Clamp(100.0 - secondaryUsedPercent.Value, 0.0, 100.0);
-            var weeklyDesc = sparkWindow.HasWindowData && effectiveSparkPercent.HasValue
-                ? $"{weeklyRemaining.ToString("F0", CultureInfo.InvariantCulture)}% remaining | Plan: {planType} | Spark: {effectiveSparkPercent.Value.ToString("F0", CultureInfo.InvariantCulture)}% used"
-                : $"{weeklyRemaining.ToString("F0", CultureInfo.InvariantCulture)}% remaining | Plan: {planType}";
-            var weeklyCard = CreateModelScopedUsage(config);
-            weeklyCard.ProviderName = providerLabel;
-            weeklyCard.CardId = "weekly";
-            weeklyCard.GroupId = config.ProviderId;
-            weeklyCard.Name = WeeklyWindowLabel;
-            weeklyCard.WindowKind = WindowKind.Rolling;
-            weeklyCard.UsedPercent = secondaryUsedPercent.Value;
-            weeklyCard.RequestsUsed = secondaryUsedPercent.Value;
-            weeklyCard.RequestsAvailable = 100.0;
-            weeklyCard.IsQuotaBased = this.Definition.IsQuotaBased;
-            weeklyCard.PlanType = this.Definition.PlanType;
-            weeklyCard.IsAvailable = true;
-            weeklyCard.Description = weeklyDesc;
-            weeklyCard.AccountName = accountIdentity ?? string.Empty;
-            weeklyCard.AuthSource = AuthSource.CodexNative(planType);
-            weeklyCard.NextResetTime = weeklyResetTime;
-            weeklyCard.PeriodDuration = TimeSpan.FromDays(7);
-            weeklyCard.RawJson = rawJson;
-            weeklyCard.HttpStatus = httpStatus;
-            usages.Add(weeklyCard);
-        }
-
-        // Spark burst + rolling cards — same pattern as the main Codex cards so
-        // the "OpenAI (GPT-5.3 Codex Spark)" card is dual-bar capable.
+        // Spark cards — check limit_window_seconds to determine window type
         if (sparkWindow.HasWindowData)
         {
             var sparkDisplayName = ProviderMetadataCatalog.GetConfiguredDisplayName(CodexSparkProviderId);
-            var sparkBurstUsed = sparkWindow.PrimaryUsedPercent ?? 0.0;
-            var sparkBurstResetTime = sparkWindow.PrimaryResetTime;
+            var sparkPrimaryIsWeekly = sparkWindow.PrimaryWindowSeconds.HasValue &&
+                                       Math.Abs(sparkWindow.PrimaryWindowSeconds.Value - WeeklyWindowSeconds) < 1;
+            if (sparkPrimaryIsWeekly)
+            {
+                // New format: spark primary is weekly, secondary is null
+                var sparkWeeklyUsed = sparkWindow.PrimaryUsedPercent ?? 0.0;
+                var sparkWeeklyResetTime = sparkWindow.PrimaryResetTime;
 
-            var sparkBurstCard = CreateModelScopedUsage(config);
-            sparkBurstCard.ProviderId = CodexSparkProviderId;
-            sparkBurstCard.ProviderName = sparkDisplayName;
-            sparkBurstCard.CardId = "spark.burst";
-            sparkBurstCard.GroupId = this.ProviderId;
-            sparkBurstCard.Name = "5h";
-            sparkBurstCard.WindowKind = WindowKind.Burst;
-            sparkBurstCard.UsedPercent = sparkBurstUsed;
-            sparkBurstCard.RequestsUsed = sparkBurstUsed;
-            sparkBurstCard.RequestsAvailable = 100.0;
-            sparkBurstCard.IsQuotaBased = this.Definition.IsQuotaBased;
-            sparkBurstCard.PlanType = this.Definition.PlanType;
-            sparkBurstCard.IsAvailable = true;
-            sparkBurstCard.Description = $"{Math.Clamp(100.0 - sparkBurstUsed, 0.0, 100.0).ToString("F0", CultureInfo.InvariantCulture)}% remaining | Plan: {planType}";
-            sparkBurstCard.AccountName = accountIdentity ?? string.Empty;
-            sparkBurstCard.AuthSource = AuthSource.CodexNative(planType);
-            sparkBurstCard.NextResetTime = sparkBurstResetTime;
-            sparkBurstCard.PeriodDuration = TimeSpan.FromHours(5);
-            sparkBurstCard.RawJson = rawJson;
-            sparkBurstCard.HttpStatus = httpStatus;
-            usages.Add(sparkBurstCard);
+                var sparkWeeklyCard = CreateModelScopedUsage(config);
+                sparkWeeklyCard.ProviderId = CodexSparkProviderId;
+                sparkWeeklyCard.ProviderName = sparkDisplayName;
+                sparkWeeklyCard.CardId = "spark.weekly";
+                sparkWeeklyCard.GroupId = this.ProviderId;
+                sparkWeeklyCard.Name = WeeklyWindowLabel;
+                sparkWeeklyCard.WindowKind = WindowKind.Rolling;
+                sparkWeeklyCard.UsedPercent = sparkWeeklyUsed;
+                sparkWeeklyCard.RequestsUsed = sparkWeeklyUsed;
+                sparkWeeklyCard.RequestsAvailable = 100.0;
+                sparkWeeklyCard.IsQuotaBased = this.Definition.IsQuotaBased;
+                sparkWeeklyCard.PlanType = this.Definition.PlanType;
+                sparkWeeklyCard.IsAvailable = true;
+                sparkWeeklyCard.Description = $"{Math.Clamp(100.0 - sparkWeeklyUsed, 0.0, 100.0).ToString("F0", CultureInfo.InvariantCulture)}% remaining | Plan: {planType}";
+                sparkWeeklyCard.AccountName = accountIdentity ?? string.Empty;
+                sparkWeeklyCard.AuthSource = AuthSource.CodexNative(planType);
+                sparkWeeklyCard.NextResetTime = sparkWeeklyResetTime;
+                sparkWeeklyCard.PeriodDuration = TimeSpan.FromDays(7);
+                sparkWeeklyCard.RawJson = rawJson;
+                sparkWeeklyCard.HttpStatus = httpStatus;
+                usages.Add(sparkWeeklyCard);
+            }
+            else
+            {
+                // Old format: spark burst from primary, weekly from secondary
+                var sparkBurstUsed = sparkWindow.PrimaryUsedPercent ?? 0.0;
+                var sparkBurstResetTime = sparkWindow.PrimaryResetTime;
 
-            var sparkWeeklyUsed = sparkWindow.SecondaryUsedPercent ?? 0.0;
-            var sparkWeeklyResetTime = sparkWindow.SecondaryResetTime;
+                var sparkBurstCard = CreateModelScopedUsage(config);
+                sparkBurstCard.ProviderId = CodexSparkProviderId;
+                sparkBurstCard.ProviderName = sparkDisplayName;
+                sparkBurstCard.CardId = "spark.burst";
+                sparkBurstCard.GroupId = this.ProviderId;
+                sparkBurstCard.Name = "5h";
+                sparkBurstCard.WindowKind = WindowKind.Burst;
+                sparkBurstCard.UsedPercent = sparkBurstUsed;
+                sparkBurstCard.RequestsUsed = sparkBurstUsed;
+                sparkBurstCard.RequestsAvailable = 100.0;
+                sparkBurstCard.IsQuotaBased = this.Definition.IsQuotaBased;
+                sparkBurstCard.PlanType = this.Definition.PlanType;
+                sparkBurstCard.IsAvailable = true;
+                sparkBurstCard.Description = $"{Math.Clamp(100.0 - sparkBurstUsed, 0.0, 100.0).ToString("F0", CultureInfo.InvariantCulture)}% remaining | Plan: {planType}";
+                sparkBurstCard.AccountName = accountIdentity ?? string.Empty;
+                sparkBurstCard.AuthSource = AuthSource.CodexNative(planType);
+                sparkBurstCard.NextResetTime = sparkBurstResetTime;
+                sparkBurstCard.PeriodDuration = TimeSpan.FromHours(5);
+                sparkBurstCard.RawJson = rawJson;
+                sparkBurstCard.HttpStatus = httpStatus;
+                usages.Add(sparkBurstCard);
 
-            var sparkWeeklyCard = CreateModelScopedUsage(config);
-            sparkWeeklyCard.ProviderId = CodexSparkProviderId;
-            sparkWeeklyCard.ProviderName = sparkDisplayName;
-            sparkWeeklyCard.CardId = "spark.weekly";
-            sparkWeeklyCard.GroupId = this.ProviderId;
-            sparkWeeklyCard.Name = WeeklyWindowLabel;
-            sparkWeeklyCard.WindowKind = WindowKind.Rolling;
-            sparkWeeklyCard.UsedPercent = sparkWeeklyUsed;
-            sparkWeeklyCard.RequestsUsed = sparkWeeklyUsed;
-            sparkWeeklyCard.RequestsAvailable = 100.0;
-            sparkWeeklyCard.IsQuotaBased = this.Definition.IsQuotaBased;
-            sparkWeeklyCard.PlanType = this.Definition.PlanType;
-            sparkWeeklyCard.IsAvailable = true;
-            sparkWeeklyCard.Description = $"{Math.Clamp(100.0 - sparkWeeklyUsed, 0.0, 100.0).ToString("F0", CultureInfo.InvariantCulture)}% remaining | Plan: {planType}";
-            sparkWeeklyCard.AccountName = accountIdentity ?? string.Empty;
-            sparkWeeklyCard.AuthSource = AuthSource.CodexNative(planType);
-            sparkWeeklyCard.NextResetTime = sparkWeeklyResetTime;
-            sparkWeeklyCard.PeriodDuration = TimeSpan.FromDays(7);
-            sparkWeeklyCard.RawJson = rawJson;
-            sparkWeeklyCard.HttpStatus = httpStatus;
-            usages.Add(sparkWeeklyCard);
+                {
+                    var sparkWeeklyUsed = sparkWindow.SecondaryUsedPercent ?? 0.0;
+                    var sparkWeeklyResetTime = sparkWindow.SecondaryResetTime;
+
+                    var sparkWeeklyCard = CreateModelScopedUsage(config);
+                    sparkWeeklyCard.ProviderId = CodexSparkProviderId;
+                    sparkWeeklyCard.ProviderName = sparkDisplayName;
+                    sparkWeeklyCard.CardId = "spark.weekly";
+                    sparkWeeklyCard.GroupId = this.ProviderId;
+                    sparkWeeklyCard.Name = WeeklyWindowLabel;
+                    sparkWeeklyCard.WindowKind = WindowKind.Rolling;
+                    sparkWeeklyCard.UsedPercent = sparkWeeklyUsed;
+                    sparkWeeklyCard.RequestsUsed = sparkWeeklyUsed;
+                    sparkWeeklyCard.RequestsAvailable = 100.0;
+                    sparkWeeklyCard.IsQuotaBased = this.Definition.IsQuotaBased;
+                    sparkWeeklyCard.PlanType = this.Definition.PlanType;
+                    sparkWeeklyCard.IsAvailable = true;
+                    sparkWeeklyCard.Description = $"{Math.Clamp(100.0 - sparkWeeklyUsed, 0.0, 100.0).ToString("F0", CultureInfo.InvariantCulture)}% remaining | Plan: {planType}";
+                    sparkWeeklyCard.AccountName = accountIdentity ?? string.Empty;
+                    sparkWeeklyCard.AuthSource = AuthSource.CodexNative(planType);
+                    sparkWeeklyCard.NextResetTime = sparkWeeklyResetTime;
+                    sparkWeeklyCard.PeriodDuration = TimeSpan.FromDays(7);
+                    sparkWeeklyCard.RawJson = rawJson;
+                    sparkWeeklyCard.HttpStatus = httpStatus;
+                    usages.Add(sparkWeeklyCard);
+                }
+            }
         }
 
         return usages;
@@ -675,8 +763,10 @@ public class CodexProvider : ProviderBase
         string? ModelName,
         double? PrimaryUsedPercent,
         DateTime? PrimaryResetTime,
+        double? PrimaryWindowSeconds,
         double? SecondaryUsedPercent,
-        DateTime? SecondaryResetTime)
+        DateTime? SecondaryResetTime,
+        double? SecondaryWindowSeconds)
     {
         /// <summary>
         /// Gets a value indicating whether true when any meaningful window data is present — usage percentages or reset timers.

--- a/AIUsageTracker.Infrastructure/Providers/OpenAIProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/OpenAIProvider.cs
@@ -24,6 +24,8 @@ public class OpenAIProvider : ProviderBase
     private const string JsonKeySecondaryWindow = "secondary_window";
     private const string JsonKeyUsedPercent = "used_percent";
     private const string JsonKeyResetAfterSeconds = "reset_after_seconds";
+    private const string JsonKeyLimitWindowSeconds = "limit_window_seconds";
+    private const double WeeklyWindowSeconds = 604800.0;
 
     private readonly HttpClient _httpClient;
     private readonly ILogger<OpenAIProvider> _logger;
@@ -131,6 +133,10 @@ public class OpenAIProvider : ProviderBase
 
     private static (DateTime? BurstResetTime, double? BurstUsed, string BurstDesc, DateTime? WeeklyResetTime, double? WeeklyUsed, string WeeklyDesc, string? CreditsDesc) ParseOpenAiSessionWindows(JsonElement root)
     {
+        // Read limit_window_seconds to determine if primary is weekly (new format)
+        var primaryLimitSeconds = root.ReadDouble(JsonKeyRateLimit, JsonKeyPrimaryWindow, JsonKeyLimitWindowSeconds);
+        var primaryIsWeekly = primaryLimitSeconds.HasValue && Math.Abs(primaryLimitSeconds.Value - WeeklyWindowSeconds) < 1;
+
         var primaryUsed = root.ReadDouble(JsonKeyRateLimit, JsonKeyPrimaryWindow, JsonKeyUsedPercent);
         var primaryReset = root.ReadDouble(JsonKeyRateLimit, JsonKeyPrimaryWindow, JsonKeyResetAfterSeconds);
         var primaryResetTime = ResolveWindowResetTime(root, JsonKeyPrimaryWindow);
@@ -139,26 +145,41 @@ public class OpenAIProvider : ProviderBase
         double? burstUsed = null;
         string burstDesc = string.Empty;
 
-        if (primaryUsed.HasValue || primaryResetTime.HasValue)
-        {
-            burstUsed = Math.Clamp(primaryUsed ?? 0.0, 0.0, 100.0);
-            burstDesc = FormatResetDescription(primaryReset);
-            burstResetTime = primaryResetTime;
-        }
-
-        var weeklyUsedVal = root.ReadDouble(JsonKeyRateLimit, JsonKeySecondaryWindow, JsonKeyUsedPercent);
-        var weeklyReset = root.ReadDouble(JsonKeyRateLimit, JsonKeySecondaryWindow, JsonKeyResetAfterSeconds);
-        var weeklyResetTime = ResolveWindowResetTime(root, JsonKeySecondaryWindow);
-
         DateTime? weeklyResetTimeParsed = null;
         double? weeklyUsed = null;
         string weeklyDesc = string.Empty;
 
-        if (weeklyUsedVal.HasValue || weeklyResetTime.HasValue)
+        if (primaryIsWeekly)
         {
-            weeklyUsed = Math.Clamp(weeklyUsedVal ?? 0.0, 0.0, 100.0);
-            weeklyDesc = FormatResetDescription(weeklyReset);
-            weeklyResetTimeParsed = weeklyResetTime;
+            // New format: primary_window IS the weekly window
+            if (primaryUsed.HasValue || primaryResetTime.HasValue)
+            {
+                weeklyUsed = Math.Clamp(primaryUsed ?? 0.0, 0.0, 100.0);
+                weeklyDesc = FormatResetDescription(primaryReset);
+                weeklyResetTimeParsed = primaryResetTime;
+            }
+        }
+        else
+        {
+            // Old format: primary_window is burst (5h)
+            if (primaryUsed.HasValue || primaryResetTime.HasValue)
+            {
+                burstUsed = Math.Clamp(primaryUsed ?? 0.0, 0.0, 100.0);
+                burstDesc = FormatResetDescription(primaryReset);
+                burstResetTime = primaryResetTime;
+            }
+
+            // Secondary window is weekly in old format
+            var weeklyUsedVal = root.ReadDouble(JsonKeyRateLimit, JsonKeySecondaryWindow, JsonKeyUsedPercent);
+            var weeklyReset = root.ReadDouble(JsonKeyRateLimit, JsonKeySecondaryWindow, JsonKeyResetAfterSeconds);
+            var weeklyResetTime = ResolveWindowResetTime(root, JsonKeySecondaryWindow);
+
+            if (weeklyUsedVal.HasValue || weeklyResetTime.HasValue)
+            {
+                weeklyUsed = Math.Clamp(weeklyUsedVal ?? 0.0, 0.0, 100.0);
+                weeklyDesc = FormatResetDescription(weeklyReset);
+                weeklyResetTimeParsed = weeklyResetTime;
+            }
         }
 
         var credits = root.ReadDouble("credits", "balance");

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [2.4.3-beta.6] - 2026-07-12
+
+### Fixed
+- **OpenAI/Codex providers now detect window type from `limit_window_seconds`** — The API changed its response format: for some plans (e.g. "prolite"), `primary_window` now has `limit_window_seconds: 604800` (7-day weekly window) and `secondary_window` is `null`. Both `CodexProvider` and `OpenAIProvider` previously hardcoded `primary_window` = 5h burst and `secondary_window` = weekly, causing the weekly data to be shown as a burst card with wrong remaining percentage and missing reset time. Now `limit_window_seconds` is read from the JSON to determine the actual window type dynamically, supporting both the old dual-window format (burst + weekly) and the new unified weekly format. The same fix applies to spark windows in `additional_rate_limits`.
+
 ## [2.4.3-beta.5] - 2026-07-11
 
 ### Changed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TrackerVersion>2.4.3-beta.5</TrackerVersion>
+    <TrackerVersion>2.4.3-beta.6</TrackerVersion>
     <TrackerAssemblyVersion>2.4.3</TrackerAssemblyVersion>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(MSBuildProjectDirectory)\artifacts\**\*</DefaultItemExcludes>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="AIUsageTracker.Web/wwwroot/favicon.png" width="32" height="32" valign="middle"> AI Usage Tracker
 
-![Version](https://img.shields.io/badge/version-2.4.3--beta.5-orange)
+![Version](https://img.shields.io/badge/version-2.4.3--beta.6-orange)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Platforms](https://img.shields.io/badge/platforms-Windows%20|%20Linux%20-blue)
 ![Language](https://img.shields.io/badge/language-C%23%20|%20.NET-purple)

--- a/scripts/publish-app.ps1
+++ b/scripts/publish-app.ps1
@@ -6,7 +6,7 @@ param(
 )
 
 # AI Usage Tracker - Distribution Packaging Script
-# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.4.3-beta.5 -InstallerCompression balanced
+# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.4.3-beta.6 -InstallerCompression balanced
 
 $isWinPlatform = $Runtime.StartsWith("win-")
 $projectName = if ($isWinPlatform) { "AIUsageTracker" } else { "AIUsageTracker.CLI" }

--- a/scripts/setup.iss
+++ b/scripts/setup.iss
@@ -1,7 +1,7 @@
 ; AI Usage Tracker - Inno Setup Script
 
 #ifndef MyAppVersion
-  #define MyAppVersion "2.4.3-beta.5"
+  #define MyAppVersion "2.4.3-beta.6"
 #endif
 #ifndef SourcePath
   #define SourcePath "..\dist\publish-win-x64"


### PR DESCRIPTION
## Problem

The OpenAI/Codex API changed its response format for some plans (e.g. 'prolite'): \primary_window\ now has \limit_window_seconds: 604800\ (7-day weekly window) with \secondary_window: null\. Both \CodexProvider\ and \OpenAIProvider\ hardcoded \primary_window\ = 5h burst and \secondary_window\ = weekly, causing the weekly data to be shown as a burst card with wrong percentage and missing reset time.

## Fix

Read \limit_window_seconds\ from the JSON to determine the actual window type dynamically:

- **New format** (\limit_window_seconds: 604800\ on primary, \secondary_window: null\): creates a single weekly card from primary
- **Old format** (\limit_window_seconds: 18000\ on primary, \secondary_window\ present): burst from primary + weekly from secondary

Same logic applied to spark windows (\dditional_rate_limits\) via \SparkWindow.PrimaryWindowSeconds\.

## Testing

- 1420 core tests + 140 Monitor tests pass (1560 total)
- Manual verification: live API response now parsed correctly