### PR TITLE
fix: aggregate projection sums only latest refresh batch

### DIFF
--- a/AIUsageTracker.Monitor/Services/GroupedUsageProjectionService.cs
+++ b/AIUsageTracker.Monitor/Services/GroupedUsageProjectionService.cs
@@ -55,9 +55,11 @@ public static class GroupedUsageProjectionService
 
         if (availableQuota.Count > 0)
         {
-            var newest = availableQuota.OrderByDescending(q => q.FetchedAt).First();
-            var totalUsed = availableQuota.Sum(q => q.RequestsUsed);
-            var totalAvailable = availableQuota.Sum(q => q.RequestsAvailable);
+            var newestFetchedAt = availableQuota.Max(q => q.FetchedAt.Ticks);
+            var currentBatch = availableQuota.Where(q => q.FetchedAt.Ticks == newestFetchedAt).ToList();
+            var newest = currentBatch.OrderByDescending(q => q.FetchedAt).First();
+            var totalUsed = currentBatch.Sum(q => q.RequestsUsed);
+            var totalAvailable = currentBatch.Sum(q => q.RequestsAvailable);
 
             requestsUsed = totalUsed;
             requestsAvailable = totalAvailable;
@@ -68,7 +70,7 @@ public static class GroupedUsageProjectionService
             state = newest.State;
             planType = newest.PlanType;
             isQuotaBased = newest.IsQuotaBased;
-            nextResetTime = availableQuota
+            nextResetTime = currentBatch
                 .Select(q => q.NextResetTime)
                 .Where(t => t.HasValue)
                 .OrderBy(t => t!.Value)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [2.4.3-beta.8] - 2026-07-13
+
+### Fixed
+- **Aggregate percentage now sums only cards from the latest refresh batch** — When a provider changes plans (e.g., from dual-window burst+weekly to single-window weekly), the old burst card stayed in the 24h database window and was summed into the provider-level aggregate alongside the current card. This caused wrong provider-level percentages (e.g., 44% shown instead of 11%). The projection service now filters to only the most recent `FetchedAt` batch before summing.
+
 ## [2.4.3-beta.7] - 2026-07-13
 
 ### Removed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TrackerVersion>2.4.3-beta.7</TrackerVersion>
+    <TrackerVersion>2.4.3-beta.8</TrackerVersion>
     <TrackerAssemblyVersion>2.4.3</TrackerAssemblyVersion>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(MSBuildProjectDirectory)\artifacts\**\*</DefaultItemExcludes>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="AIUsageTracker.Web/wwwroot/favicon.png" width="32" height="32" valign="middle"> AI Usage Tracker
 
-![Version](https://img.shields.io/badge/version-2.4.3--beta.6-orange)
+![Version](https://img.shields.io/badge/version-2.4.3--beta.8-orange)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Platforms](https://img.shields.io/badge/platforms-Windows%20|%20Linux%20-blue)
 ![Language](https://img.shields.io/badge/language-C%23%20|%20.NET-purple)

--- a/scripts/publish-app.ps1
+++ b/scripts/publish-app.ps1
@@ -6,7 +6,7 @@ param(
 )
 
 # AI Usage Tracker - Distribution Packaging Script
-# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.4.3-beta.6 -InstallerCompression balanced
+# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.4.3-beta.8 -InstallerCompression balanced
 
 $isWinPlatform = $Runtime.StartsWith("win-")
 $projectName = if ($isWinPlatform) { "AIUsageTracker" } else { "AIUsageTracker.CLI" }

--- a/scripts/setup.iss
+++ b/scripts/setup.iss
@@ -1,7 +1,7 @@
 ; AI Usage Tracker - Inno Setup Script
 
 #ifndef MyAppVersion
-  #define MyAppVersion "2.4.3-beta.6"
+  #define MyAppVersion "2.4.3-beta.8"
 #endif
 #ifndef SourcePath
   #define SourcePath "..\dist\publish-win-x64"


### PR DESCRIPTION
## Summary

- When a provider changes plans (e.g., dual-window burst+weekly → single-window weekly), the old burst card stays within the 24h DB window and gets summed into the provider-level aggregate alongside the current card, producing wrong percentages (e.g., 44% instead of 11%).
- BuildProviderGroup now filters vailableQuota to only cards from the most recent FetchedAt batch before summing.
- 
extResetTime also uses the current batch only.

## Test plan

- [x] dotnet build succeeds (0 errors)
- [x] Core tests pass (1412 passed, 2 skipped)
- [x] Monitor tests pass (140 passed)
- [x] Verified live: aggregate shows 13% (13/100) instead of 44% (88/200)