### PR TITLE
fix(codex): propagate reset credits to weekly window card

### DIFF
--- a/AIUsageTracker.Infrastructure/Providers/CodexProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/CodexProvider.cs
@@ -443,6 +443,7 @@ public class CodexProvider : ProviderBase
             weeklyCard.AuthSource = AuthSource.CodexNative(planType);
             weeklyCard.NextResetTime = weeklyResetTime;
             weeklyCard.PeriodDuration = TimeSpan.FromDays(7);
+            weeklyCard.ResetCreditsAvailable = resetCreditsAvailable;
             weeklyCard.RawJson = rawJson;
             weeklyCard.HttpStatus = httpStatus;
             usages.Add(weeklyCard);


### PR DESCRIPTION
The Codex weekly window card was missing `ResetCreditsAvailable` because `CodexProvider.BuildUsageAsync` only assigned it to the primary card. When the burst fetch is stale or failing, users only see the fresh weekly card, so the tooltip "Reset credits available" line silently disappeared. Mirror the root-level `rate_limit_reset_credits` value onto the secondary card as well.