### PR TITLE
Release 2.4.5-beta.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [2.4.5-beta.4] - 2026-07-19
+
+### Changed
+- **Updated the deterministic Windows screenshot baseline** — beta.4 includes the CI-approved reference image produced from the current interface; runtime behavior is otherwise unchanged from beta.3.
+
 ## [2.4.5-beta.3] - 2026-07-19
 
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TrackerVersion>2.4.5-beta.3</TrackerVersion>
+    <TrackerVersion>2.4.5-beta.4</TrackerVersion>
     <TrackerAssemblyVersion>2.4.5</TrackerAssemblyVersion>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(MSBuildProjectDirectory)\artifacts\**\*</DefaultItemExcludes>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="AIUsageTracker.Web/wwwroot/favicon.png" width="32" height="32" valign="middle"> AI Usage Tracker
 
-![Version](https://img.shields.io/badge/version-2.4.5--beta.3-orange)
+![Version](https://img.shields.io/badge/version-2.4.5--beta.4-orange)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Platforms](https://img.shields.io/badge/platforms-Windows%20|%20Linux%20-blue)
 ![Language](https://img.shields.io/badge/language-C%23%20|%20.NET-purple)

--- a/scripts/publish-app.ps1
+++ b/scripts/publish-app.ps1
@@ -6,7 +6,7 @@ param(
 )
 
 # AI Usage Tracker - Distribution Packaging Script
-# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.4.5-beta.3 -InstallerCompression balanced
+# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.4.5-beta.4 -InstallerCompression balanced
 
 $isWinPlatform = $Runtime.StartsWith("win-")
 $projectName = if ($isWinPlatform) { "AIUsageTracker" } else { "AIUsageTracker.CLI" }

--- a/scripts/setup.iss
+++ b/scripts/setup.iss
@@ -1,7 +1,7 @@
 ; AI Usage Tracker - Inno Setup Script
 
 #ifndef MyAppVersion
-  #define MyAppVersion "2.4.5-beta.3"
+  #define MyAppVersion "2.4.5-beta.4"
 #endif
 #ifndef SourcePath
   #define SourcePath "..\dist\publish-win-x64"


### PR DESCRIPTION
## Summary

- bump the beta channel from 2.4.5-beta.3 to 2.4.5-beta.4
- include the CI-approved Windows screenshot baseline committed after beta.3
- keep runtime behavior unchanged from beta.3

## Validation

- release consistency validation passes for 2.4.5-beta.4
- Release solution build succeeds with zero errors
- AIUsageTracker.Tests: 1416 passed, 2 skipped
- AIUsageTracker.Monitor.Tests: 140 passed
- AIUsageTracker.Web.Tests: 46 passed, 6 skipped
- NuGet vulnerability audit: zero vulnerable packages
- tag v2.4.5-beta.4 does not already exist