### PR TITLE
Fix Codex reset expiration dates after database reload

### DIFF
--- a/AIUsageTracker.CLI/AIUsageTracker.CLI.csproj
+++ b/AIUsageTracker.CLI/AIUsageTracker.CLI.csproj
@@ -10,7 +10,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
-    <PackageReference Include="System.Text.Json" Version="10.0.5" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -25,6 +24,5 @@
   </PropertyGroup>
 
 </Project>
-
 
 

--- a/AIUsageTracker.Monitor.Tests/AIUsageTracker.Monitor.Tests.csproj
+++ b/AIUsageTracker.Monitor.Tests/AIUsageTracker.Monitor.Tests.csproj
@@ -12,7 +12,6 @@
     <PackageReference Include="coverlet.collector" Version="8.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="System.Text.Json" Version="10.0.5" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.analyzers" Version="1.27.0" PrivateAssets="all" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/AIUsageTracker.Monitor/AIUsageTracker.Monitor.csproj
+++ b/AIUsageTracker.Monitor/AIUsageTracker.Monitor.csproj
@@ -18,13 +18,10 @@
     <PackageReference Include="Dapper" Version="2.1.72" />
     <PackageReference Include="Evolve" Version="3.2.0" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
     <PackageReference Include="Microsoft.Win32.SystemEvents" Version="10.0.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" />
-    <PackageReference Include="System.Text.Json" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AIUsageTracker.Monitor/Services/UsageDatabase.cs
+++ b/AIUsageTracker.Monitor/Services/UsageDatabase.cs
@@ -7,7 +7,6 @@ using System.Globalization;
 using System.Text.Json;
 using AIUsageTracker.Core.Interfaces;
 using AIUsageTracker.Core.Models;
-using AIUsageTracker.Infrastructure.Providers;
 using AIUsageTracker.Core.Providers;
 using Dapper;
 using Microsoft.Data.Sqlite;
@@ -398,36 +397,24 @@ public class UsageDatabase : IUsageDatabase
 
     private static string? SerializeResetCreditExpirations(IReadOnlyList<DateTime>? expirations)
     {
-        if (expirations == null || expirations.Count == 0) return null;
-        var ticks = expirations.Select(d => d.ToUniversalTime().Ticks).ToArray();
-        return System.Text.Json.JsonSerializer.Serialize(ticks);
+        return expirations is { Count: > 0 }
+            ? System.Text.Json.JsonSerializer.Serialize(expirations.Select(d => d.ToUniversalTime().Ticks))
+            : null;
     }
 
-    private static bool ExpirationsEqual(IReadOnlyList<DateTime>? a, IReadOnlyList<DateTime>? b)
-    {
-        if (ReferenceEquals(a, b)) return true;
-        if (a == null || b == null) return false;
-        if (a.Count != b.Count) return false;
-        for (var i = 0; i < a.Count; i++)
-        {
-            if (a[i].Ticks != b[i].Ticks) return false;
-        }
-        return true;
-    }
+    private static bool ExpirationsEqual(IReadOnlyList<DateTime>? left, IReadOnlyList<DateTime>? right) =>
+        ReferenceEquals(left, right) || (left != null && right != null && left.SequenceEqual(right));
 
     private static IReadOnlyList<DateTime>? DeserializeResetCreditExpirations(string? raw)
     {
-        if (string.IsNullOrWhiteSpace(raw)) return null;
-        try
-        {
-            var ticks = System.Text.Json.JsonSerializer.Deserialize<long[]>(raw);
-            if (ticks == null || ticks.Length == 0) return null;
-            return ticks.Select(t => new DateTime(t, DateTimeKind.Utc)).ToArray();
-        }
-        catch
+        if (string.IsNullOrWhiteSpace(raw))
         {
             return null;
         }
+
+        return System.Text.Json.JsonSerializer.Deserialize<long[]>(raw)?
+            .Select(ticks => new DateTime(ticks, DateTimeKind.Utc))
+            .ToArray();
     }
 
     private static async Task<Dictionary<string, LastHistoryRow>> LoadLastHistoryRowsAsync(
@@ -710,6 +697,7 @@ public class UsageDatabase : IUsageDatabase
         {
             dto.ResetCreditExpirationsUtc = DeserializeResetCreditExpirations(dto.ResetCreditExpirationsUtcSerialized);
         }
+
         var results = dtoRows.Select(ToTypedUsage).ToList();
 
         var quotaResults = results.OfType<QuotaProviderUsage>().ToList();
@@ -752,18 +740,6 @@ public class UsageDatabase : IUsageDatabase
         return results;
     }
 
-    /// <summary>
-    /// Computes a per-provider burn rate (requests/hour) from historical rows and stamps
-    /// it onto the in-memory <see cref="ProviderUsage.UsagePerHour"/> property.
-    /// Uses the row closest to one hour ago (within a 30–120 min window) as the baseline.
-    /// Returns null for a provider when there is insufficient history or the counter reset.
-    /// </summary>
-    /// <summary>
-    /// Dapper-mapped DTO that captures every column from <c>provider_history</c>,
-    /// including the subtype discriminator (<c>card_type</c>) and fields that
-    /// belong to specific subtypes (<c>parent_provider_id</c>, <c>model_name</c>).
-    /// Inherits all quota fields from <see cref="QuotaProviderUsage"/>.
-    /// </summary>
     private sealed class HistoryRowDto : QuotaProviderUsage
     {
         public string? ParentProviderId { get; set; }
@@ -772,9 +748,6 @@ public class UsageDatabase : IUsageDatabase
 
         public string? CardType { get; set; }
 
-        // Raw serialized JSON of per-reset expirations; mapped from reset_credit_expirations_utc.
-        // Dapper binds this string here; we then deserialize into ResetCreditExpirationsUtc
-        // (which is IReadOnlyList<DateTime> on the base class).
         public string? ResetCreditExpirationsUtcSerialized { get; set; }
     }
 
@@ -786,7 +759,8 @@ public class UsageDatabase : IUsageDatabase
         _ => CopyTo(new QuotaProviderUsage(), row),
     };
 
-    private static T CopyTo<T>(T target, HistoryRowDto source) where T : ProviderUsage
+    private static T CopyTo<T>(T target, HistoryRowDto source)
+        where T : ProviderUsage
     {
         target.ProviderId = source.ProviderId;
         target.ProviderName = source.ProviderName;
@@ -817,6 +791,7 @@ public class UsageDatabase : IUsageDatabase
             quota.IsStatusOnly = source.IsStatusOnly;
             quota.NextResetTime = source.NextResetTime;
             quota.ResetCreditsAvailable = source.ResetCreditsAvailable;
+            quota.ResetCreditExpirationsUtc = source.ResetCreditExpirationsUtc;
             quota.UsagePerHour = source.UsagePerHour;
             quota.WindowKind = source.WindowKind;
             quota.Name = source.Name;
@@ -827,7 +802,6 @@ public class UsageDatabase : IUsageDatabase
 
         return target;
     }
-
 
     private static async Task StampUsageRatesAsync(SqliteConnection connection, IReadOnlyList<QuotaProviderUsage> results)
     {

--- a/AIUsageTracker.Tests/AIUsageTracker.Tests.csproj
+++ b/AIUsageTracker.Tests/AIUsageTracker.Tests.csproj
@@ -12,7 +12,6 @@
     <PackageReference Include="coverlet.collector" Version="8.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="System.Text.Json" Version="10.0.5" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.analyzers" Version="1.27.0" PrivateAssets="all" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
@@ -42,4 +41,3 @@
   </ItemGroup>
 
 </Project>
-

--- a/AIUsageTracker.Tests/Core/MonitorProcessServiceTests.cs
+++ b/AIUsageTracker.Tests/Core/MonitorProcessServiceTests.cs
@@ -102,25 +102,25 @@ public sealed class MonitorProcessServiceTests : IDisposable
             Errors = new List<string> { "Startup status: starting" },
         });
 
+        var processChecks = 0;
         var launcher = new MonitorLauncher(
             monitorInfoCandidatePathsOverride: () => new[] { infoPath },
             healthCheckOverride: _ => Task.FromResult(false),
-            processRunningOverride: _ => Task.FromResult(true));
-
-        _ = Task.Run(async () =>
+            processRunningOverride: async _ =>
         {
-            await Task.Delay(250).ConfigureAwait(false);
-            var replacementPath = Path.Combine(this._tempDirectory, $"monitor-{Guid.NewGuid():N}.json");
-            var replacementInfo = new MonitorInfo
+            if (Interlocked.Increment(ref processChecks) == 2)
             {
-                Port = 5000,
-                ProcessId = 9999,
-                Errors = new List<string> { "Startup status: failed: port bind failed" },
-            };
-            await File.WriteAllTextAsync(
-                replacementPath,
-                JsonSerializer.Serialize(replacementInfo)).ConfigureAwait(false);
-            File.Replace(replacementPath, infoPath, destinationBackupFileName: null, ignoreMetadataErrors: true);
+                await File.WriteAllTextAsync(
+                    infoPath,
+                    JsonSerializer.Serialize(new MonitorInfo
+                    {
+                        Port = 5000,
+                        ProcessId = 9999,
+                        Errors = new List<string> { "Startup status: failed: port bind failed" },
+                    })).ConfigureAwait(false);
+            }
+
+            return true;
         });
 
         var service = this.CreateService(launcher: launcher);

--- a/AIUsageTracker.Tests/Services/UsageDatabasePipelineTests.cs
+++ b/AIUsageTracker.Tests/Services/UsageDatabasePipelineTests.cs
@@ -2,10 +2,14 @@
 // Copyright (c) AIUsageTracker. All rights reserved.
 // </copyright>
 
+using System.Text.Json;
+
 using AIUsageTracker.Core.Interfaces;
 using AIUsageTracker.Core.Models;
+using AIUsageTracker.Core.MonitorClient;
 using AIUsageTracker.Monitor.Services;
 using AIUsageTracker.Tests.Infrastructure;
+using AIUsageTracker.UI.Slim;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace AIUsageTracker.Tests.Services;
@@ -174,6 +178,53 @@ public sealed class UsageDatabasePipelineTests : IDisposable
         Assert.Equal("burst", codex.CardId);
         Assert.Equal("5-hour quota", codex.Name);
         Assert.Equal(50.0, codex.UsedPercent, precision: 5);
+    }
+
+    [Fact]
+    public async Task Pipeline_ResetCreditExpirations_ReachTooltipAfterDatabaseRoundTripAsync()
+    {
+        var db = await this.CreateDatabaseAsync();
+        DateTime[] expirations =
+        [
+            new(2026, 7, 26, 22, 55, 46, DateTimeKind.Utc),
+            new(2026, 7, 31, 19, 47, 35, DateTimeKind.Utc),
+            new(2026, 8, 12, 17, 25, 15, DateTimeKind.Utc),
+        ];
+        var usage = new ModelScopedProviderUsage
+        {
+            ProviderId = "codex",
+            ProviderName = "OpenAI (Codex)",
+            CardId = "weekly",
+            GroupId = "codex",
+            Name = "Weekly",
+            WindowKind = WindowKind.Rolling,
+            RequestsUsed = 32,
+            RequestsAvailable = 100,
+            UsedPercent = 32,
+            IsAvailable = true,
+            IsQuotaBased = true,
+            Description = "68% remaining",
+            HttpStatus = 200,
+            FetchedAt = DateTime.UtcNow.AddMinutes(-1),
+            ResetCreditsAvailable = 3,
+            ResetCreditExpirationsUtc = expirations,
+        };
+
+        var processed = this._pipeline.Process([usage], activeProviderIds: ["codex"], isPrivacyMode: false);
+        await db.StoreHistoryAsync(processed.Usages);
+
+        var persisted = Assert.IsType<ModelScopedProviderUsage>(Assert.Single(await db.GetLatestHistoryAsync()));
+        Assert.Equal(expirations, persisted.ResetCreditExpirationsUtc);
+
+        var snapshot = GroupedUsageProjectionService.Build([persisted]);
+        var json = JsonSerializer.Serialize(snapshot, MonitorJsonSerializer.DefaultOptions);
+        var clientSnapshot = JsonSerializer.Deserialize<AgentGroupedUsageSnapshot>(json, MonitorJsonSerializer.DefaultOptions);
+        var displayUsage = Assert.Single(GroupedUsageDisplayAdapter.Expand(clientSnapshot));
+        Assert.Equal(expirations, displayUsage.ResetCreditExpirationsUtc);
+
+        var tooltip = MainWindowRuntimeLogic.BuildTooltipContent(displayUsage, "OpenAI (Codex)");
+        Assert.NotNull(tooltip);
+        Assert.Equal(expirations.Length, tooltip.Split("  - Expires ", StringSplitOptions.None).Length - 1);
     }
 
     [Fact]

--- a/AIUsageTracker.UI.Slim/AIUsageTracker.UI.Slim.csproj
+++ b/AIUsageTracker.UI.Slim/AIUsageTracker.UI.Slim.csproj
@@ -26,10 +26,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.5" />
-    <PackageReference Include="System.Text.Json" Version="10.0.5" />
     <PackageReference Include="Hardcodet.NotifyIcon.Wpf" Version="2.0.1" />
     <PackageReference Include="SharpVectors.Wpf" Version="1.8.5" />
-    <PackageReference Include="System.Drawing.Common" Version="10.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.25" />
   </ItemGroup>
 
@@ -52,4 +50,3 @@
   </ItemGroup>
 
 </Project>
-

--- a/AIUsageTracker.Web/AIUsageTracker.Web.csproj
+++ b/AIUsageTracker.Web/AIUsageTracker.Web.csproj
@@ -14,7 +14,6 @@
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.10" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageReference Include="System.Text.Json" Version="10.0.5" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" />
   </ItemGroup>
 


### PR DESCRIPTION
## What changed
- preserve Codex reset-credit expiration timestamps when database rows are reconstructed
- add a real SQLite-to-grouped-JSON-to-tooltip regression test
- remove the silent expiration-deserialization fallback and redundant framework package references
- make the monitor startup failure test deterministic

## Root cause
The reset-credit detail endpoint returned and stored the expiration timestamps, but `UsageDatabase.CopyTo` copied the reset-credit count without copying `ResetCreditExpirationsUtc`. The grouped API therefore removed the timestamps before the UI received them.

## User impact
The OpenAI Codex tooltip can now list each reset credit expiration date after data is loaded from persisted monitor history.

## Validation
- Release solution build passed
- 1,417 core tests passed (2 skipped)
- 140 monitor tests passed
- 46 web tests passed (6 skipped)
- changed-file analyzer gate passed