### PR TITLE
Prepare v2.4.5-beta.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+## [2.4.5-beta.5] - 2026-07-19
+
+### Fixed
+
+- **OpenAI reset-credit expiration dates now survive monitor persistence** — the monitor now preserves `ResetCreditExpirationsUtc` when reconstructing typed history rows, so the grouped API and tooltip receive and display every stored expiry after refresh or restart.
+- **Monitor startup failure regression test is deterministic** — removed the timed background file replacement race that could leave the suite waiting for 30 seconds.
+
+### Changed
+
+- **Removed redundant framework package references** — .NET framework assemblies now provide JSON, hosting, HTTP, and drawing APIs without duplicate direct package references.
+
 ## [2.4.5-beta.4] - 2026-07-19
 
 ### Changed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TrackerVersion>2.4.5-beta.4</TrackerVersion>
+    <TrackerVersion>2.4.5-beta.5</TrackerVersion>
     <TrackerAssemblyVersion>2.4.5</TrackerAssemblyVersion>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(MSBuildProjectDirectory)\artifacts\**\*</DefaultItemExcludes>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="AIUsageTracker.Web/wwwroot/favicon.png" width="32" height="32" valign="middle"> AI Usage Tracker
 
-![Version](https://img.shields.io/badge/version-2.4.5--beta.4-orange)
+![Version](https://img.shields.io/badge/version-2.4.5--beta.5-orange)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Platforms](https://img.shields.io/badge/platforms-Windows%20|%20Linux%20-blue)
 ![Language](https://img.shields.io/badge/language-C%23%20|%20.NET-purple)

--- a/scripts/publish-app.ps1
+++ b/scripts/publish-app.ps1
@@ -6,7 +6,7 @@ param(
 )
 
 # AI Usage Tracker - Distribution Packaging Script
-# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.4.5-beta.4 -InstallerCompression balanced
+# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.4.5-beta.5 -InstallerCompression balanced
 
 $isWinPlatform = $Runtime.StartsWith("win-")
 $projectName = if ($isWinPlatform) { "AIUsageTracker" } else { "AIUsageTracker.CLI" }

--- a/scripts/setup.iss
+++ b/scripts/setup.iss
@@ -1,7 +1,7 @@
 ; AI Usage Tracker - Inno Setup Script
 
 #ifndef MyAppVersion
-  #define MyAppVersion "2.4.5-beta.4"
+  #define MyAppVersion "2.4.5-beta.5"
 #endif
 #ifndef SourcePath
   #define SourcePath "..\dist\publish-win-x64"


### PR DESCRIPTION
## Summary

- bump the beta version to 2.4.5-beta.5
- document the OpenAI reset-expiration persistence fix
- document the deterministic monitor regression test and package cleanup
- update installer and publishing version references

## Validation

- bash scripts/validate-release-consistency.sh "2.4.5-beta.5"
- dotnet build AIUsageTracker.sln --configuration Release
- dotnet test AIUsageTracker.sln --configuration Release --no-build
- commit-time analyzer gate