### PR TITLE
test: fix provider analyzer findings (Package 02A / Agent C)

### DIFF
--- a/AIUsageTracker.Tests/Infrastructure/Providers/AnthropicUsageProviderTests.cs
+++ b/AIUsageTracker.Tests/Infrastructure/Providers/AnthropicUsageProviderTests.cs
@@ -5,7 +5,6 @@
 using System.Net;
 using AIUsageTracker.Core.Models;
 using AIUsageTracker.Infrastructure.Providers;
-using AIUsageTracker.Tests.Infrastructure;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace AIUsageTracker.Tests.Infrastructure.Providers;
@@ -21,7 +20,7 @@ public class AnthropicUsageProviderTests : HttpProviderTestBase<AnthropicUsagePr
 
     public AnthropicUsageProviderTests()
     {
-        _config = new ProviderConfig
+        this._config = new ProviderConfig
         {
             ProviderId = "anthropic-usage",
             ApiKey = TestAdminKey,
@@ -54,7 +53,7 @@ public class AnthropicUsageProviderTests : HttpProviderTestBase<AnthropicUsagePr
             r => r.RequestUri != null && r.RequestUri.ToString().StartsWith(CostUrl, StringComparison.Ordinal),
             errorResponse);
 
-        var results = await this._provider.GetUsageAsync(_config);
+        var results = await this._provider.GetUsageAsync(this._config);
 
         var usage = Assert.Single(results);
         Assert.False(usage.IsAvailable);
@@ -83,18 +82,18 @@ public class AnthropicUsageProviderTests : HttpProviderTestBase<AnthropicUsagePr
             r => r.RequestUri != null && r.RequestUri.ToString().StartsWith(UsageUrl, StringComparison.Ordinal),
             usageResponse);
 
-        var results = (await this._provider.GetUsageAsync(_config))
+        var results = (await this._provider.GetUsageAsync(this._config))
             .Cast<QuotaProviderUsage>()
             .ToList();
 
         Assert.Equal(2, results.Count);
 
-        var costCard = results.FirstOrDefault(c => c.CardId == "daily-cost");
+        var costCard = results.FirstOrDefault(c => string.Equals(c.CardId, "daily-cost", StringComparison.Ordinal));
         Assert.NotNull(costCard);
         Assert.True(costCard!.IsAvailable);
         Assert.Contains("$5.42", costCard.Description, StringComparison.Ordinal);
 
-        var tokenCard = results.FirstOrDefault(c => c.CardId == "daily-tokens");
+        var tokenCard = results.FirstOrDefault(c => string.Equals(c.CardId, "daily-tokens", StringComparison.Ordinal));
         Assert.NotNull(tokenCard);
         Assert.True(tokenCard!.IsAvailable);
         Assert.Contains("20,000 tokens", tokenCard.Description, StringComparison.Ordinal);
@@ -122,7 +121,7 @@ public class AnthropicUsageProviderTests : HttpProviderTestBase<AnthropicUsagePr
             r => r.RequestUri != null && r.RequestUri.ToString().StartsWith(UsageUrl, StringComparison.Ordinal),
             usageResponse);
 
-        var results = await this._provider.GetUsageAsync(_config);
+        var results = await this._provider.GetUsageAsync(this._config);
 
         var usage = Assert.Single(results);
         Assert.True(usage.IsAvailable);
@@ -150,7 +149,7 @@ public class AnthropicUsageProviderTests : HttpProviderTestBase<AnthropicUsagePr
             r => r.RequestUri != null && r.RequestUri.ToString().StartsWith(UsageUrl, StringComparison.Ordinal),
             usageResponse);
 
-        var results = (await this._provider.GetUsageAsync(_config))
+        var results = (await this._provider.GetUsageAsync(this._config))
             .Cast<QuotaProviderUsage>()
             .ToList();
 
@@ -198,7 +197,7 @@ public class AnthropicUsageProviderTests : HttpProviderTestBase<AnthropicUsagePr
             r => r.RequestUri != null && r.RequestUri.ToString().StartsWith(UsageUrl, StringComparison.Ordinal),
             usageResponse);
 
-        await this._provider.GetUsageAsync(_config);
+        await this._provider.GetUsageAsync(this._config);
 
         Assert.NotNull(capturedRequest);
         Assert.Null(capturedRequest!.Headers.Authorization);

--- a/AIUsageTracker.Tests/Infrastructure/Providers/GroqProviderTests.cs
+++ b/AIUsageTracker.Tests/Infrastructure/Providers/GroqProviderTests.cs
@@ -5,7 +5,6 @@
 using System.Net;
 using AIUsageTracker.Core.Models;
 using AIUsageTracker.Infrastructure.Providers;
-using AIUsageTracker.Tests.Infrastructure;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace AIUsageTracker.Tests.Infrastructure.Providers;
@@ -20,7 +19,7 @@ public class GroqProviderTests : HttpProviderTestBase<GroqProvider>
 
     public GroqProviderTests()
     {
-        _config = new ProviderConfig
+        this._config = new ProviderConfig
         {
             ProviderId = "groq",
             ApiKey = TestApiKey,
@@ -57,7 +56,7 @@ public class GroqProviderTests : HttpProviderTestBase<GroqProvider>
 
         this.SetupHttpResponse(ModelsUrl, response);
 
-        var results = await this._provider.GetUsageAsync(_config);
+        var results = await this._provider.GetUsageAsync(this._config);
         var cards = results.ToList();
 
         Assert.Equal(2, cards.Count);
@@ -66,14 +65,14 @@ public class GroqProviderTests : HttpProviderTestBase<GroqProvider>
         Assert.All(cards, c => Assert.IsType<QuotaProviderUsage>(c));
 
         var dailyRequests = Assert.IsType<QuotaProviderUsage>(
-            cards.First(c => c is QuotaProviderUsage q && q.CardId == "daily-requests"));
+            cards.First(c => c is QuotaProviderUsage q && string.Equals(q.CardId, "daily-requests", StringComparison.Ordinal)));
         Assert.Equal(14400, dailyRequests.RequestsAvailable);
         Assert.Equal(30, dailyRequests.RequestsUsed);
         Assert.True(dailyRequests.UsedPercent < 1);
         Assert.NotNull(dailyRequests.NextResetTime);
 
         var perMinuteTokens = Assert.IsType<QuotaProviderUsage>(
-            cards.First(c => c is QuotaProviderUsage q && q.CardId == "per-minute-tokens"));
+            cards.First(c => c is QuotaProviderUsage q && string.Equals(q.CardId, "per-minute-tokens", StringComparison.Ordinal)));
         Assert.Equal(18000, perMinuteTokens.RequestsAvailable);
         Assert.Equal(3, perMinuteTokens.RequestsUsed);
         Assert.NotNull(perMinuteTokens.NextResetTime);
@@ -89,7 +88,7 @@ public class GroqProviderTests : HttpProviderTestBase<GroqProvider>
 
         this.SetupHttpResponse(ModelsUrl, response);
 
-        var results = await this._provider.GetUsageAsync(_config);
+        var results = await this._provider.GetUsageAsync(this._config);
         var usage = Assert.Single(results);
 
         Assert.True(usage.IsAvailable);
@@ -107,7 +106,7 @@ public class GroqProviderTests : HttpProviderTestBase<GroqProvider>
 
         this.SetupHttpResponse(ModelsUrl, response);
 
-        var results = await this._provider.GetUsageAsync(_config);
+        var results = await this._provider.GetUsageAsync(this._config);
         var usage = Assert.Single(results);
 
         Assert.False(usage.IsAvailable);
@@ -127,7 +126,7 @@ public class GroqProviderTests : HttpProviderTestBase<GroqProvider>
 
         this.SetupHttpResponse(ModelsUrl, response);
 
-        var results = await this._provider.GetUsageAsync(_config);
+        var results = await this._provider.GetUsageAsync(this._config);
         var card = Assert.IsType<QuotaProviderUsage>(Assert.Single(results));
 
         Assert.Equal("daily-requests", card.CardId);

--- a/AIUsageTracker.Tests/Infrastructure/Providers/ZaiProviderTests.cs
+++ b/AIUsageTracker.Tests/Infrastructure/Providers/ZaiProviderTests.cs
@@ -243,13 +243,13 @@ public class ZaiProviderTests : HttpProviderTestBase<ZaiProvider>
         Assert.Equal(2, cards.Count);
 
         // Card 1: TOKENS_LIMIT (zai-coding-plan) — 3% used
-        var tokenCard = cards.Single(c => c.ProviderId == "zai-coding-plan");
+        var tokenCard = cards.Single(c => string.Equals(c.ProviderId, "zai-coding-plan", StringComparison.Ordinal));
         Assert.True(tokenCard.IsAvailable);
         Assert.InRange(tokenCard.UsedPercent, 2.5, 3.5); // 3% used, 97% remaining
         Assert.Contains("Coding Plan", tokenCard.Description, StringComparison.Ordinal);
 
         // Card 2: TIME_LIMIT (zai) — 11% used
-        var timeCard = cards.Single(c => c.ProviderId == "zai");
+        var timeCard = cards.Single(c => string.Equals(c.ProviderId, "zai", StringComparison.Ordinal));
         Assert.True(timeCard.IsAvailable);
         Assert.InRange(timeCard.UsedPercent, 10.5, 11.5); // 11% used, 89% remaining
         Assert.Contains("Web Search & Reader", timeCard.Description, StringComparison.Ordinal);


### PR DESCRIPTION
## Summary

Executes **Package 02A / Agent C** from `docs/analyzer-cleanup/02-test-project-findings.md`. Removes the remaining `IDE0009`, `SA1101`, and `MA0006` findings from the three scoped provider test files without changing production behavior, weakening assertions, altering fixture data, or suppressing analyzer rules.

## Scoped files

- `AIUsageTracker.Tests/Infrastructure/Providers/AnthropicUsageProviderTests.cs`
- `AIUsageTracker.Tests/Infrastructure/Providers/GroqProviderTests.cs`
- `AIUsageTracker.Tests/Infrastructure/Providers/ZaiProviderTests.cs`

## Changes

- **`IDE0009` / `SA1101` (11 locations):** Qualified the instance `_config` field with `this.` where required in `AnthropicUsageProviderTests` (6 locations) and `GroqProviderTests` (5 locations).
- **`MA0006` (6 locations):** Replaced string `==` with explicit `string.Equals(..., StringComparison.Ordinal)` for `CardId`/`ProviderId` comparisons. This preserves the existing case-sensitive test contract (C# `==` on `string` is ordinal, byte-identical semantics). 2 locations each in Anthropic, Groq, and Zai.
- **`IDE0005` (2 lines, pre-existing on baseline):** Removed the redundant `using AIUsageTracker.Tests.Infrastructure;` from the Anthropic and Groq test files. This parent namespace is already in scope via each file's own `namespace AIUsageTracker.Tests.Infrastructure.Providers;` declaration, so the directive was a no-op. This is a minor scope extension beyond the strict `IDE0009`/`SA1101`/`MA0006` rule list — it was required because the pre-commit analyzer gate runs `dotnet format style --severity warn` on changed files and was failing on this pre-existing warning for *any* commit touching these files (verified by running the gate on the baseline versions). Behavior-neutral: `HttpProviderTestBase` still resolves through the implicit parent namespace.

## Before / after counts

Scoped-file findings (`IDE0009` /`SA1101` /`MA0006` only), from a non-incremental `dotnet build AIUsageTracker.Tests --configuration Release --no-incremental`:

| File | Before (unique locations) | After |
| --- | ---: | ---: |
| `AnthropicUsageProviderTests.cs` | 6 IDE0009/SA1101 + 2 MA0006 = 8 | 0 |
| `GroqProviderTests.cs` | 5 IDE0009/SA1101 + 2 MA0006 = 7 | 0 |
| `ZaiProviderTests.cs` | 2 MA0006 = 2 | 0 |
| **Total unique locations** | **17** | **0** |

`IDE0009` and `SA1101` overlap on every "this." location, so the raw warning line count is higher; the 17 figure is unique source locations, matching the handoff baseline.

## Validation

All marked with `AGENT_OWNER` / `AGENT_TASK` per `AGENTS.md`.

- Focused tests (`AnthropicUsageProviderTests` |`GroqProviderTests` |`ZaiProviderTests`): **19 passed, 0 failed**.
- Full `AIUsageTracker.Tests` project: **1417 passed, 2 skipped (pre-existing), 0 failed**.
- `AIUsageTracker.Monitor.Tests` project (run by the pre-commit gate): **140 passed, 0 failed**.
- `dotnet format --verify-no-changes --severity warn` on the three changed files: exit 0, no changes required.
- Non-incremental Release build of `AIUsageTracker.Tests`: 0 errors, 0 warnings on the scoped files.
- Pre-commit analyzer gate (`scripts/pre-commit-analyzer-gate.ps1`): **passed** — whitespace, style, analyzers, Release build, core tests, Monitor tests all green.

## Out of scope (not touched)

- No `.editorconfig`, `NoWarn`, analyzer packages, rule severity, or gate script changes.
- No `#pragma`, `SuppressMessage`, exclusions, baselines, or generated-code markers.
- No production code, fixtures, expected values, test inputs, or assertion strength changes.
- No repository-wide formatting.
- No `--no-verify`.
- The user's pre-existing local `AGENTS.md` change was left untouched and unstaged.