### PR TITLE
style: fix non-test SA1210 using order (Package 01A / Agent A)

### DIFF
--- a/AIUsageTracker.Infrastructure/Configuration/JsonConfigLoader.cs
+++ b/AIUsageTracker.Infrastructure/Configuration/JsonConfigLoader.cs
@@ -5,9 +5,8 @@
 using System.Text.Json;
 using AIUsageTracker.Core.Interfaces;
 using AIUsageTracker.Core.Models;
-using AIUsageTracker.Infrastructure.Helpers;
-using AIUsageTracker.Infrastructure.Providers;
 using AIUsageTracker.Core.Providers;
+using AIUsageTracker.Infrastructure.Helpers;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 

--- a/AIUsageTracker.Infrastructure/Configuration/JsonProviderConfigExportBuilder.cs
+++ b/AIUsageTracker.Infrastructure/Configuration/JsonProviderConfigExportBuilder.cs
@@ -3,9 +3,7 @@
 // </copyright>
 
 using System.Text.Json;
-
 using AIUsageTracker.Core.Models;
-using AIUsageTracker.Infrastructure.Providers;
 using AIUsageTracker.Core.Providers;
 
 namespace AIUsageTracker.Infrastructure.Configuration;

--- a/AIUsageTracker.Infrastructure/Configuration/RooTokenConfigParser.cs
+++ b/AIUsageTracker.Infrastructure/Configuration/RooTokenConfigParser.cs
@@ -3,8 +3,6 @@
 // </copyright>
 
 using System.Text.Json;
-
-using AIUsageTracker.Infrastructure.Providers;
 using AIUsageTracker.Core.Providers;
 
 namespace AIUsageTracker.Infrastructure.Configuration;

--- a/AIUsageTracker.Infrastructure/Configuration/TokenDiscoveryService.cs
+++ b/AIUsageTracker.Infrastructure/Configuration/TokenDiscoveryService.cs
@@ -6,7 +6,6 @@ using System.Collections;
 using System.Text.Json;
 using AIUsageTracker.Core.Interfaces;
 using AIUsageTracker.Core.Models;
-using AIUsageTracker.Infrastructure.Providers;
 using AIUsageTracker.Core.Providers;
 using Microsoft.Extensions.Logging;
 

--- a/AIUsageTracker.Monitor/Services/AuthDiagnosticsSnapshotBuilder.cs
+++ b/AIUsageTracker.Monitor/Services/AuthDiagnosticsSnapshotBuilder.cs
@@ -3,7 +3,6 @@
 // </copyright>
 
 using AIUsageTracker.Core.Models;
-using AIUsageTracker.Infrastructure.Providers;
 using AIUsageTracker.Core.Providers;
 
 namespace AIUsageTracker.Monitor.Services;

--- a/AIUsageTracker.Monitor/Services/ConfigService.cs
+++ b/AIUsageTracker.Monitor/Services/ConfigService.cs
@@ -5,9 +5,8 @@
 using System.Text.Json;
 using AIUsageTracker.Core.Interfaces;
 using AIUsageTracker.Core.Models;
-using AIUsageTracker.Infrastructure.Configuration;
-using AIUsageTracker.Infrastructure.Providers;
 using AIUsageTracker.Core.Providers;
+using AIUsageTracker.Infrastructure.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace AIUsageTracker.Monitor.Services;

--- a/AIUsageTracker.Monitor/Services/GroupedUsageProjectionService.cs
+++ b/AIUsageTracker.Monitor/Services/GroupedUsageProjectionService.cs
@@ -4,7 +4,6 @@
 
 using AIUsageTracker.Core.Models;
 using AIUsageTracker.Core.MonitorClient;
-using AIUsageTracker.Infrastructure.Providers;
 using AIUsageTracker.Core.Providers;
 
 namespace AIUsageTracker.Monitor.Services;

--- a/AIUsageTracker.Monitor/Services/ProviderRefreshCircuitBreakerService.cs
+++ b/AIUsageTracker.Monitor/Services/ProviderRefreshCircuitBreakerService.cs
@@ -3,7 +3,6 @@
 // </copyright>
 
 using AIUsageTracker.Core.Models;
-using AIUsageTracker.Infrastructure.Providers;
 using AIUsageTracker.Core.Providers;
 
 namespace AIUsageTracker.Monitor.Services;

--- a/AIUsageTracker.Monitor/Services/ProviderRefreshService.cs
+++ b/AIUsageTracker.Monitor/Services/ProviderRefreshService.cs
@@ -6,9 +6,8 @@ using System.Diagnostics;
 using System.Text.Json;
 using AIUsageTracker.Core.Interfaces;
 using AIUsageTracker.Core.Models;
-using AIUsageTracker.Core.Services;
-using AIUsageTracker.Infrastructure.Providers;
 using AIUsageTracker.Core.Providers;
+using AIUsageTracker.Core.Services;
 
 namespace AIUsageTracker.Monitor.Services;
 

--- a/AIUsageTracker.Monitor/Services/ProviderUsagePersistenceService.cs
+++ b/AIUsageTracker.Monitor/Services/ProviderUsagePersistenceService.cs
@@ -3,7 +3,6 @@
 // </copyright>
 
 using AIUsageTracker.Core.Models;
-using AIUsageTracker.Infrastructure.Providers;
 using AIUsageTracker.Core.Providers;
 
 namespace AIUsageTracker.Monitor.Services;

--- a/AIUsageTracker.Monitor/Services/UsageAlertsService.cs
+++ b/AIUsageTracker.Monitor/Services/UsageAlertsService.cs
@@ -4,7 +4,6 @@
 
 using AIUsageTracker.Core.Interfaces;
 using AIUsageTracker.Core.Models;
-using AIUsageTracker.Infrastructure.Providers;
 using AIUsageTracker.Core.Providers;
 
 namespace AIUsageTracker.Monitor.Services;

--- a/AIUsageTracker.UI.Slim/App.TrayIcon.cs
+++ b/AIUsageTracker.UI.Slim/App.TrayIcon.cs
@@ -8,7 +8,6 @@ using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using AIUsageTracker.Core.Models;
-using AIUsageTracker.Infrastructure.Providers;
 using AIUsageTracker.Core.Providers;
 using CommunityToolkit.Mvvm.Input;
 using Hardcodet.Wpf.TaskbarNotification;

--- a/AIUsageTracker.UI.Slim/FlatWindowCardBuilder.cs
+++ b/AIUsageTracker.UI.Slim/FlatWindowCardBuilder.cs
@@ -4,7 +4,6 @@
 
 using AIUsageTracker.Core.Models;
 using AIUsageTracker.Core.MonitorClient;
-using AIUsageTracker.Infrastructure.Providers;
 using AIUsageTracker.Core.Providers;
 
 namespace AIUsageTracker.UI.Slim;

--- a/AIUsageTracker.UI.Slim/MainWindow.Rendering.cs
+++ b/AIUsageTracker.UI.Slim/MainWindow.Rendering.cs
@@ -8,7 +8,6 @@ using System.Windows.Input;
 using System.Windows.Media;
 using AIUsageTracker.Core.Models;
 using AIUsageTracker.Core.MonitorClient;
-using AIUsageTracker.Infrastructure.Providers;
 using AIUsageTracker.Core.Providers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;

--- a/AIUsageTracker.UI.Slim/Services/WpfProviderIconService.cs
+++ b/AIUsageTracker.UI.Slim/Services/WpfProviderIconService.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
-using AIUsageTracker.Infrastructure.Providers;
 using AIUsageTracker.Core.Providers;
 using Microsoft.Extensions.Logging;
 using SharpVectors.Converters;

--- a/AIUsageTracker.UI.Slim/SettingsWindow.Providers.cs
+++ b/AIUsageTracker.UI.Slim/SettingsWindow.Providers.cs
@@ -10,9 +10,8 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
 using AIUsageTracker.Core.Models;
-using AIUsageTracker.Infrastructure.Helpers;
-using AIUsageTracker.Infrastructure.Providers;
 using AIUsageTracker.Core.Providers;
+using AIUsageTracker.Infrastructure.Helpers;
 
 namespace AIUsageTracker.UI.Slim;
 

--- a/AIUsageTracker.UI.Slim/SettingsWindowDeterministicFixture.cs
+++ b/AIUsageTracker.UI.Slim/SettingsWindowDeterministicFixture.cs
@@ -3,8 +3,8 @@
 // </copyright>
 
 using AIUsageTracker.Core.Models;
-using AIUsageTracker.Infrastructure.Providers;
 using AIUsageTracker.Core.Providers;
+using AIUsageTracker.Infrastructure.Providers;
 
 namespace AIUsageTracker.UI.Slim;
 

--- a/AIUsageTracker.Web/Services/WebProviderDisplayNameMapper.cs
+++ b/AIUsageTracker.Web/Services/WebProviderDisplayNameMapper.cs
@@ -3,7 +3,6 @@
 // </copyright>
 
 using AIUsageTracker.Core.Models;
-using AIUsageTracker.Infrastructure.Providers;
 using AIUsageTracker.Core.Providers;
 
 namespace AIUsageTracker.Web.Services;


### PR DESCRIPTION
## Summary

Executes **Package 01A / Agent A** from `docs/analyzer-cleanup/01-mechanical-style.md`. Reorders `using` directives to satisfy `SA1210` (Using directives should be ordered alphabetically) across non-test files. Import-only changes; no control flow, public contracts, database queries, provider parsing, or UI behavior touched.

## Scoped files (18 of 24 in Package 01A)

This PR lands the 18 files whose only live findings were `SA1210`. The remaining 6 files from Package 01A are deferred because they carry **pre-existing, co-located warnings from other packages' rule families** — including them would require fixing those other packages' findings too, violating the one-package-per-PR constraint the cleanup plan enforces.

**Included (18 files, this PR):**
- `AIUsageTracker.Infrastructure/Configuration/`: JsonConfigLoader, JsonProviderConfigExportBuilder, RooTokenConfigParser, TokenDiscoveryService
- `AIUsageTracker.Monitor/Services/`: AuthDiagnosticsSnapshotBuilder, ConfigService, GroupedUsageProjectionService, ProviderRefreshCircuitBreakerService, ProviderRefreshService, ProviderUsagePersistenceService, UsageAlertsService
- `AIUsageTracker.UI.Slim/`: App.TrayIcon, FlatWindowCardBuilder, MainWindow.Rendering, Services/WpfProviderIconService, SettingsWindow.Providers, SettingsWindowDeterministicFixture
- `AIUsageTracker.Web/Services/`: WebProviderDisplayNameMapper

**Deferred to other agents' PRs (6 files):**
| File | Co-located warning | Owning package |
| --- | --- | --- |
| `AIUsageTracker.CLI/Program.cs` | `VSTHRD103` ×2 | 03A / Agent E |
| `AIUsageTracker.Monitor/Program.cs` | `SA1501` ×2 | 01B / Agent B |
| `AIUsageTracker.Monitor/Services/ProviderUsageProcessingPipeline.cs` | `SA1513` | 01B / Agent B |
| `AIUsageTracker.UI.Slim/GroupedUsageDisplayAdapter.cs` | `SA1512` | 01B / Agent B |
| `AIUsageTracker.UI.Slim/MainWindowRuntimeLogic.Presentation.cs` | `SA1512` | 01B / Agent B |
| `AIUsageTracker.UI.Slim/MainWindowDeterministicFixture.cs` | `SA1515` | 01B / Agent B |

The `SA1210` findings on those 6 files still exist and will be resolved when Agents B and E address the co-located warnings in their own scoped PRs.

## Scope extension: IDE0005 (redundant usings), owner-authorized

The pre-commit analyzer gate (`scripts/pre-commit-analyzer-gate.ps1`) runs `dotnet format style --severity warn` across all rules on every changed file. The 18 files in this PR also carried pre-existing `IDE0005` warnings (genuinely-unused `using` directives — same family of issue that produced PR #736's redundant-namespace-usings). Without resolving them, no commit touching these files could pass the gate.

Per owner authorization, this PR also removes those redundant `using` directives. Every removal is behavior-neutral — the directive was genuinely unused (verified by `dotnet format --diagnostics IDE0005` and a clean Release build with 0 errors).

## Before / after counts

Solution-wide `SA1210` files:

| | Before (baseline `cb78e429`) | After |
| --- | ---: | ---: |
| `SA1210` unique non-test files | 24 | 6 (the deferred set above) |
| `SA1210` unique test files (Package 02B / Agent D) | 12 | 12 (untouched) |

On the 18 scoped files: `SA1210` **24 → 0**, `IDE0005` **18 → 0**.

## Validation

All marked with `AGENT_OWNER` / `AGENT_TASK` per `AGENTS.md`.

- Non-incremental Release build of `AIUsageTracker.sln`: **0 errors**, scoped files emit zero `SA1210` / `IDE0005`.
- `AIUsageTracker.Tests`: **1417 passed, 2 pre-existing skips, 0 failed**.
- `AIUsageTracker.Monitor.Tests`: **140 passed, 0 failed**.
- `dotnet format --verify-no-changes --diagnostics SA1210` on the 18 files: no further changes.
- Pre-commit analyzer gate (`scripts/pre-commit-analyzer-gate.ps1`): **passed** — whitespace, style, analyzers, Release build, core tests, Monitor tests all green.

## Diff integrity

Every changed line across the 18 files was diffed against baseline. **100% of changed lines are `using` directives or blank lines adjacent to using blocks.** Zero non-using lines changed. Verified with:
```sh
for each file: diff baseline current | grep '^[<>]' | grep -vE '^[<>] *using ' | grep -vE '^[<>] *$'
# output: empty
```

## Out of scope (not touched)

- No `.editorconfig`, `NoWarn`, analyzer packages, rule severity, or gate script changes.
- No `#pragma`, `SuppressMessage`, exclusions, baselines, or generated-code markers.
- No production logic, control flow, dependencies, database queries, provider parsing, or UI behavior changes.
- No `--no-verify`.
- The user's pre-existing local `AGENTS.md` change was left untouched and unstaged.

## Known structural issue (for follow-up)

The pre-commit gate applies all style rules to every changed file, but the cleanup plan decomposes cleanup by rule family per agent. This makes single-package PRs landable only when a file's co-located warnings all belong to the same package. Three PRs so far (#736, this one, and the scoping work behind them) have hit this fork. A plan-level follow-up (e.g., narrow the gate's changed-file check to the assigned rule family, or re-decompose packages to be file-complete) would unblock the remaining mechanical packages.