### PR TITLE
style: fix test SA1210 using order (Package 02B / Agent D)

### DIFF
--- a/AIUsageTracker.Monitor.Tests/ConfigServiceScanTests.cs
+++ b/AIUsageTracker.Monitor.Tests/ConfigServiceScanTests.cs
@@ -5,9 +5,8 @@
 using System.Globalization;
 using System.Text.Json;
 using AIUsageTracker.Core.Interfaces;
-using AIUsageTracker.Infrastructure.Providers;
-using AIUsageTracker.Monitor.Services;
 using AIUsageTracker.Core.Providers;
+using AIUsageTracker.Monitor.Services;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace AIUsageTracker.Monitor.Tests;

--- a/AIUsageTracker.Monitor.Tests/ProviderUsageProcessingPipelineTests.cs
+++ b/AIUsageTracker.Monitor.Tests/ProviderUsageProcessingPipelineTests.cs
@@ -3,9 +3,8 @@
 // </copyright>
 
 using AIUsageTracker.Core.Models;
-using AIUsageTracker.Infrastructure.Providers;
-using AIUsageTracker.Monitor.Services;
 using AIUsageTracker.Core.Providers;
+using AIUsageTracker.Monitor.Services;
 using Microsoft.Extensions.Logging;
 using Moq;
 

--- a/AIUsageTracker.Tests/Architecture/CodeGuardrailTests.cs
+++ b/AIUsageTracker.Tests/Architecture/CodeGuardrailTests.cs
@@ -3,7 +3,6 @@
 // </copyright>
 
 using System.Text.RegularExpressions;
-using AIUsageTracker.Infrastructure.Providers;
 using AIUsageTracker.Core.Providers;
 
 namespace AIUsageTracker.Tests.Architecture;

--- a/AIUsageTracker.Tests/Architecture/SlimGroupedUsageGuardrailTests.cs
+++ b/AIUsageTracker.Tests/Architecture/SlimGroupedUsageGuardrailTests.cs
@@ -3,7 +3,6 @@
 // </copyright>
 
 using AIUsageTracker.Core.Models;
-using AIUsageTracker.Infrastructure.Providers;
 using AIUsageTracker.Core.Providers;
 
 namespace AIUsageTracker.Tests.Architecture;

--- a/AIUsageTracker.Tests/Infrastructure/ProviderMetadataCatalogTests.cs
+++ b/AIUsageTracker.Tests/Infrastructure/ProviderMetadataCatalogTests.cs
@@ -5,7 +5,6 @@
 using System.Reflection;
 using AIUsageTracker.Core.Interfaces;
 using AIUsageTracker.Core.Models;
-using AIUsageTracker.Infrastructure.Providers;
 using AIUsageTracker.Core.Providers;
 
 namespace AIUsageTracker.Tests.Infrastructure;

--- a/AIUsageTracker.Tests/Infrastructure/Providers/AntigravityProviderTests.cs
+++ b/AIUsageTracker.Tests/Infrastructure/Providers/AntigravityProviderTests.cs
@@ -5,8 +5,8 @@
 using System.Net;
 using System.Reflection;
 using AIUsageTracker.Core.Models;
-using AIUsageTracker.Infrastructure.Providers;
 using AIUsageTracker.Core.Providers;
+using AIUsageTracker.Infrastructure.Providers;
 
 namespace AIUsageTracker.Tests.Infrastructure.Providers;
 

--- a/AIUsageTracker.Tests/Infrastructure/Providers/OpenCodeZenProviderTests.cs
+++ b/AIUsageTracker.Tests/Infrastructure/Providers/OpenCodeZenProviderTests.cs
@@ -4,8 +4,8 @@
 
 using System.Reflection;
 using AIUsageTracker.Core.Models;
-using AIUsageTracker.Infrastructure.Providers;
 using AIUsageTracker.Core.Providers;
+using AIUsageTracker.Infrastructure.Providers;
 
 namespace AIUsageTracker.Tests.Infrastructure.Providers;
 

--- a/AIUsageTracker.Tests/Services/ConfigServiceSaveValidationTests.cs
+++ b/AIUsageTracker.Tests/Services/ConfigServiceSaveValidationTests.cs
@@ -6,7 +6,6 @@ using AIUsageTracker.Core.Interfaces;
 using AIUsageTracker.Core.Models;
 using AIUsageTracker.Monitor.Services;
 using AIUsageTracker.Tests.Infrastructure;
-using AIUsageTracker.Core.Providers;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 

--- a/AIUsageTracker.Tests/UI/MainWindowDeterministicFixtureTests.cs
+++ b/AIUsageTracker.Tests/UI/MainWindowDeterministicFixtureTests.cs
@@ -4,7 +4,6 @@
 
 using System.Reflection;
 using AIUsageTracker.Core.Models;
-using AIUsageTracker.Infrastructure.Providers;
 using AIUsageTracker.Core.Providers;
 
 namespace AIUsageTracker.Tests.UI;

--- a/AIUsageTracker.Tests/UI/ProviderKeyDeletionEndToEndTests.cs
+++ b/AIUsageTracker.Tests/UI/ProviderKeyDeletionEndToEndTests.cs
@@ -3,9 +3,9 @@
 // </copyright>
 
 using AIUsageTracker.Core.Models;
+using AIUsageTracker.Core.Providers;
 using AIUsageTracker.Infrastructure.Providers;
 using AIUsageTracker.UI.Slim;
-using AIUsageTracker.Core.Providers;
 
 namespace AIUsageTracker.Tests.UI;
 

--- a/AIUsageTracker.Tests/UI/ProviderVisualCatalogTests.cs
+++ b/AIUsageTracker.Tests/UI/ProviderVisualCatalogTests.cs
@@ -2,7 +2,6 @@
 // Copyright (c) AIUsageTracker. All rights reserved.
 // </copyright>
 
-using AIUsageTracker.Infrastructure.Providers;
 using AIUsageTracker.Core.Providers;
 
 namespace AIUsageTracker.Tests.UI;

--- a/AIUsageTracker.Tests/UI/SettingsWindowDeterministicFixtureTests.cs
+++ b/AIUsageTracker.Tests/UI/SettingsWindowDeterministicFixtureTests.cs
@@ -4,7 +4,6 @@
 
 using System.Reflection;
 using AIUsageTracker.Core.Models;
-using AIUsageTracker.Infrastructure.Providers;
 using AIUsageTracker.Core.Providers;
 
 namespace AIUsageTracker.Tests.UI;


### PR DESCRIPTION
## Summary

Executes **Package 02B / Agent D** from `docs/analyzer-cleanup/02-test-project-findings.md`. Reorders `using` directives to satisfy `SA1210` across 12 test files. Import-only changes; no behavior, fixtures, expected values, or assertion strength touched.

## Scoped files (12)

- `AIUsageTracker.Monitor.Tests/`: ConfigServiceScanTests, ProviderUsageProcessingPipelineTests
- `AIUsageTracker.Tests/Architecture/`: CodeGuardrailTests, SlimGroupedUsageGuardrailTests
- `AIUsageTracker.Tests/Infrastructure/`: ProviderMetadataCatalogTests, Providers/AntigravityProviderTests, Providers/OpenCodeZenProviderTests
- `AIUsageTracker.Tests/Services/`: ConfigServiceSaveValidationTests
- `AIUsageTracker.Tests/UI/`: MainWindowDeterministicFixtureTests, ProviderKeyDeletionEndToEndTests, ProviderVisualCatalogTests, SettingsWindowDeterministicFixtureTests

## Scope extension: IDE0005 (redundant usings), owner-authorized

Same pattern as PRs #736 and #738: the pre-commit analyzer gate runs `dotnet format style --severity warn` on changed files, which fails on pre-existing `IDE0005` warnings co-located on these files. Per owner authorization, this PR also removes those redundant `using` directives. Behavior-neutral; verified by clean Release build with 0 errors.

## Before / after

- `SA1210` on scoped files: **12 → 0**
- `IDE0005` on scoped files: **12 → 0**
- Net LOC: **−9**

## Validation

- Non-incremental Release build: **0 errors**, scoped files emit zero `SA1210`/`IDE0005`.
- `AIUsageTracker.Tests`: **1417 passed, 2 pre-existing skips, 0 failed**.
- `AIUsageTracker.Monitor.Tests`: **140 passed, 0 failed**.
- Pre-commit analyzer gate: **passed** (whitespace, style, analyzers, build, core tests, Monitor tests).
- Diff integrity: 100% of changed lines are `using` directives or adjacent blank lines (verified by diffing every line against baseline).

## Out of scope

No `.editorconfig`/`NoWarn`/suppression/policy changes. No `#pragma`/`SuppressMessage`. No production code, fixtures, or assertion changes. No `--no-verify`. User's local `AGENTS.md` change untouched and unstaged.