### PR TITLE
style: fix Monitor/UI layout analyzer findings (Package 01B / Agent B)

### DIFF
--- a/AIUsageTracker.Monitor/Program.cs
+++ b/AIUsageTracker.Monitor/Program.cs
@@ -13,7 +13,6 @@ using AIUsageTracker.Monitor.Endpoints;
 using AIUsageTracker.Monitor.Hubs;
 using AIUsageTracker.Monitor.Logging;
 using AIUsageTracker.Monitor.Services;
-using AIUsageTracker.Core.Providers;
 
 namespace AIUsageTracker.Monitor;
 
@@ -33,8 +32,12 @@ public partial class Program
         {
             Console.Title = "AI Usage Tracker - Monitor";
         }
-        catch (PlatformNotSupportedException) { /* Console.Title not supported */ }
-        catch (System.IO.IOException) { /* Console.Title I/O failure */ }
+        catch (PlatformNotSupportedException)
+        { /* Console.Title not supported */
+        }
+        catch (System.IO.IOException)
+        { /* Console.Title I/O failure */
+        }
 
         IAppPathProvider pathProvider = new DefaultAppPathProvider();
         var holdsStartupMutex = false;

--- a/AIUsageTracker.Monitor/Services/DatabaseMigrationService.cs
+++ b/AIUsageTracker.Monitor/Services/DatabaseMigrationService.cs
@@ -242,6 +242,7 @@ public class DatabaseMigrationService
         EnsureColumn(connection, TableProviders, "config_json", "TEXT");
         EnsureColumn(connection, TableProviders, "auth_source", "TEXT DEFAULT 'manual'");
         EnsureColumn(connection, TableProviders, "plan_type", "TEXT DEFAULT 'usage'");
+
         // Ensure ALL provider_history columns exist before the timestamp conversion,
         // because the conversion recreates the table and copies all columns.
         EnsureColumn(connection, TableProviderHistory, "next_reset_time", "TEXT");

--- a/AIUsageTracker.Monitor/Services/ProviderUsageProcessingPipeline.cs
+++ b/AIUsageTracker.Monitor/Services/ProviderUsageProcessingPipeline.cs
@@ -3,7 +3,6 @@
 // </copyright>
 
 using AIUsageTracker.Core.Models;
-using AIUsageTracker.Infrastructure.Providers;
 using AIUsageTracker.Core.Providers;
 
 namespace AIUsageTracker.Monitor.Services;
@@ -260,6 +259,7 @@ public class ProviderUsageProcessingPipeline : IProviderUsageProcessingPipeline
         {
             description = "Unavailable";
         }
+
         usage.Description = description;
 
         if (isPrivacyMode)

--- a/AIUsageTracker.Tests/UI/ProviderCardPresentationCatalogTests.cs
+++ b/AIUsageTracker.Tests/UI/ProviderCardPresentationCatalogTests.cs
@@ -334,6 +334,7 @@ public sealed class ProviderCardPresentationCatalogTests
         var usages = GroupedUsageDisplayAdapter.Expand(snapshot);
         var usage = Assert.Single(usages);
         var presentation = MainWindowRuntimeLogic.Create(usage, showUsed: false);
+
         // Codex DualBarLabels: Burst="5h", Rolling="Weekly"
         Assert.Equal("5h 16% remaining | Weekly 84% remaining", presentation.StatusText);
     }

--- a/AIUsageTracker.UI.Slim/GroupedUsageDisplayAdapter.cs
+++ b/AIUsageTracker.UI.Slim/GroupedUsageDisplayAdapter.cs
@@ -9,10 +9,8 @@
 // decide what to render. No .OfType<T>(), no .Where(WindowKind != ...), no
 // hardcoded fallbacks (?? "Burst", ?? false). The definition declares what
 // cards exist; this code passes the Monitor's raw values through to them.
-
 using AIUsageTracker.Core.Models;
 using AIUsageTracker.Core.MonitorClient;
-using AIUsageTracker.Infrastructure.Providers;
 using AIUsageTracker.Core.Providers;
 
 namespace AIUsageTracker.UI.Slim;

--- a/AIUsageTracker.UI.Slim/MainWindowDeterministicFixture.cs
+++ b/AIUsageTracker.UI.Slim/MainWindowDeterministicFixture.cs
@@ -3,8 +3,8 @@
 // </copyright>
 
 using AIUsageTracker.Core.Models;
-using AIUsageTracker.Infrastructure.Providers;
 using AIUsageTracker.Core.Providers;
+using AIUsageTracker.Infrastructure.Providers;
 
 namespace AIUsageTracker.UI.Slim;
 
@@ -62,6 +62,7 @@ internal static class MainWindowDeterministicFixture
     {
         var codexProviderId = CodexProvider.StaticDefinition.ProviderId;
         var codexDisplayName = CodexProvider.StaticDefinition.DisplayName;
+
         // provider-id-guardrail-allow: deterministic fixture uses provider metadata constants
         yield return new WindowedProviderUsage
         {

--- a/AIUsageTracker.UI.Slim/MainWindowRuntimeLogic.Presentation.cs
+++ b/AIUsageTracker.UI.Slim/MainWindowRuntimeLogic.Presentation.cs
@@ -8,12 +8,10 @@
 // rendered. Never use card.Name ?? "Burst" or any hardcoded fallback. Always
 // read from the definition. No filtering by type (.OfType<WindowedProviderUsage>).
 // All QuotaProviderUsage subtypes are valid window cards.
-
 using System.Globalization;
 using AIUsageTracker.Core.Models;
-using AIUsageTracker.Infrastructure.Helpers;
-using AIUsageTracker.Infrastructure.Providers;
 using AIUsageTracker.Core.Providers;
+using AIUsageTracker.Infrastructure.Helpers;
 
 namespace AIUsageTracker.UI.Slim;
 


### PR DESCRIPTION
## Summary

Executes **Package 01B / Agent B** from `docs/analyzer-cleanup/01-mechanical-style.md`. Resolves layout/brace StyleCop findings (`SA1501`, `SA1512`, `SA1513`, `SA1515`) by adding braces and blank lines only. No control-flow, database, or provider-parsing changes.

## Scoped files (7 modified of 8 listed)

| File | Fix | Notes |
| --- | --- | --- |
| `Monitor/Program.cs` | SA1501 ×2 | Expanded two single-line `catch` bodies into braced form; in-body comment preserved. |
| `Monitor/Services/DatabaseMigrationService.cs` | SA1515 | Added blank line above existing comment. **Database statements untouched.** |
| `Monitor/Services/ProviderUsageProcessingPipeline.cs` | SA1513 | Added blank line after closing brace. |
| `UI.Slim/GroupedUsageDisplayAdapter.cs` | SA1512 | Removed blank line between comment block and `using`. |
| `UI.Slim/MainWindowRuntimeLogic.Presentation.cs` | SA1512 | Same as above. |
| `UI.Slim/MainWindowDeterministicFixture.cs` | SA1515 | Added blank line before comment. |
| `Tests/UI/ProviderCardPresentationCatalogTests.cs` | SA1515 | Added blank line before comment. |

**Not modified:** `Monitor/Services/UsageDatabase.cs` is listed in Package 01B's doc but has **zero live findings** on the current baseline (`cb78e429`) — the doc is stale. Per the package doc's own instruction ("Re-run the inventory before editing; do not assume line numbers remain stable"), I left it untouched.

## Scope extension: SA1210 + IDE0005 on the same files (pre-authorized)

Several of these 7 files were in the **deferred set from PR #738** (Package 01A) — they were excluded there because they were blocked by the very SA15xx warnings this PR fixes. The `dotnet format` pass that resolved the layout findings also picked up co-located `SA1210` (using order) and `IDE0005` (unused using) findings on these same files. Per the now-established pattern (PRs #736, #738, #739), these are included:
- `SA1210` reorders: 5 files (using blocks put into alphabetical order).
- `IDE0005` removals: redundant `using` directives removed where genuinely unused.

All such changes are using-directive-only and behavior-neutral. Together with the layout fixes, this means these 7 files are now **fully analyzer-clean** at warning severity, not just for the SA15xx family.

## Critical-data safety

Per `AGENTS.md`'s "NEVER Cause Data Loss in Migrations" rule, I inspected `DatabaseMigrationService.cs` carefully. The change there is a **single blank line** added above an existing comment (`// Ensure ALL provider_history columns exist...`). No `EnsureColumn` call, no `CREATE TABLE`, no `INSERT INTO` was touched. `UsageDatabase.cs` (the other data-critical file) had no findings and was not modified.

## Validation

- Non-incremental Release build: **0 errors**, scoped files emit zero `SA1501`/`SA1503`/`SA1507`/`SA1512`/`SA1513`/`SA1515`/`SA1127`/`SA1210`/`IDE0005` warnings.
- `AIUsageTracker.Tests`: **1417 passed, 2 pre-existing skips, 0 failed**.
- `AIUsageTracker.Monitor.Tests`: **140 passed, 0 failed**.
- Pre-commit analyzer gate: **passed** (whitespace, style, analyzers, build, core tests, Monitor tests all green).

## Out of scope

No `.editorconfig`/`NoWarn`/suppression/policy changes. No `#pragma`/`SuppressMessage`. No production logic, control flow, database statements, provider parsing, or UI behavior changes. No `--no-verify`. User's local `AGENTS.md` change untouched and unstaged.