### PR TITLE
fix: replace sync JSON/file APIs with async (Package 03A / Agent E)

### DIFF
--- a/AIUsageTracker.CLI/Program.cs
+++ b/AIUsageTracker.CLI/Program.cs
@@ -3,14 +3,14 @@
 // </copyright>
 
 using System.Globalization;
+using System.Text;
 using System.Text.Json;
 using AIUsageTracker.Core.Interfaces;
 using AIUsageTracker.Core.Models;
+using AIUsageTracker.Core.Providers;
 using AIUsageTracker.Infrastructure.Configuration;
 using AIUsageTracker.Infrastructure.Extensions;
 using AIUsageTracker.Infrastructure.MonitorClient;
-using AIUsageTracker.Infrastructure.Providers;
-using AIUsageTracker.Core.Providers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -528,7 +528,9 @@ public static class Program
 
         if (json)
         {
-            Console.WriteLine(JsonSerializer.Serialize(usage, AppJsonContext.Default.ListProviderUsage));
+            using var usageStream = new MemoryStream();
+            await JsonSerializer.SerializeAsync(usageStream, usage, AppJsonContext.Default.ListProviderUsage).ConfigureAwait(false);
+            Console.WriteLine(Encoding.UTF8.GetString(usageStream.ToArray()));
         }
         else
         {
@@ -597,7 +599,9 @@ public static class Program
         var configs = await service.GetConfigsAsync().ConfigureAwait(false);
         if (json)
         {
-            Console.WriteLine(JsonSerializer.Serialize(configs, AppJsonContext.Default.ListProviderConfig));
+            using var configStream = new MemoryStream();
+            await JsonSerializer.SerializeAsync(configStream, configs, AppJsonContext.Default.ListProviderConfig).ConfigureAwait(false);
+            Console.WriteLine(Encoding.UTF8.GetString(configStream.ToArray()));
         }
         else
         {

--- a/AIUsageTracker.Monitor.Tests/ConfigServiceExtendedTests.cs
+++ b/AIUsageTracker.Monitor.Tests/ConfigServiceExtendedTests.cs
@@ -174,15 +174,22 @@ public sealed class ConfigServiceExtendedTests : IDisposable
         Assert.Contains("antigravity", loaded.SuppressedProviderIds);
     }
 
+#pragma warning disable MA0004
     private async Task WriteProvidersJsonAsync(object data)
     {
-        var json = data is string s ? s : JsonSerializer.Serialize(data);
-#pragma warning disable MA0004
-        await File.WriteAllTextAsync(
-            Path.Combine(this._tempDir, "providers.json"),
-            json);
-#pragma warning restore MA0004
+        var targetPath = Path.Combine(this._tempDir, "providers.json");
+        if (data is string s)
+        {
+            await File.WriteAllTextAsync(targetPath, s);
+            return;
+        }
+
+        await using (var stream = File.Create(targetPath))
+        {
+            await JsonSerializer.SerializeAsync(stream, data).ConfigureAwait(false);
+        }
     }
+#pragma warning restore MA0004
 
     private sealed class TestPathProvider : IAppPathProvider
     {

--- a/AIUsageTracker.Tests/Infrastructure/Services/GitHubAuthServiceTests.cs
+++ b/AIUsageTracker.Tests/Infrastructure/Services/GitHubAuthServiceTests.cs
@@ -49,7 +49,7 @@ public sealed class GitHubAuthServiceTests : IDisposable
         var appData = Path.Combine(tempRoot, "AppData", "Roaming");
         var hostsPath = Path.Combine(appData, "GitHub CLI", "hosts.yml");
         Directory.CreateDirectory(Path.GetDirectoryName(hostsPath)!);
-        File.WriteAllText(
+        await File.WriteAllTextAsync(
             hostsPath,
             "github.com:\n    git_protocol: https\n    user: rygel\n");
 

--- a/AIUsageTracker.Tests/Infrastructure/Services/ProviderDiscoveryServiceTests.cs
+++ b/AIUsageTracker.Tests/Infrastructure/Services/ProviderDiscoveryServiceTests.cs
@@ -75,7 +75,10 @@ public class ProviderDiscoveryServiceTests : IDisposable
                 },
             },
         };
-        File.WriteAllText(authFilePath, JsonSerializer.Serialize(authContent));
+        await using (var authStream = File.Create(authFilePath))
+        {
+            await JsonSerializer.SerializeAsync(authStream, authContent);
+        }
 
         var definition = new ProviderDefinition(
             "github-copilot",

--- a/AIUsageTracker.Web.Tests/TestWebHost.cs
+++ b/AIUsageTracker.Web.Tests/TestWebHost.cs
@@ -28,7 +28,10 @@ internal sealed class TestWebHost : IDisposable
         var tempDirectory = TestTempPaths.CreateDirectory("aiusagetracker-webtests");
 
         var scenarioPath = Path.Combine(tempDirectory, "monitor-scenario.json");
-        await File.WriteAllTextAsync(scenarioPath, JsonSerializer.Serialize(scenario)).ConfigureAwait(false);
+        using (var scenarioStream = File.Create(scenarioPath))
+        {
+            await JsonSerializer.SerializeAsync(scenarioStream, scenario).ConfigureAwait(false);
+        }
 
         var factory = new KestrelWebApplicationFactory<Program>(new Dictionary<string, string>(StringComparer.Ordinal)
         {


### PR DESCRIPTION
## Summary

Executes **Package 03A / Agent E** from `docs/analyzer-cleanup/03-runtime-correctness.md`. Replaces synchronous JSON/file APIs with their true async equivalents and propagates `await`. No `Task.Run`, no `VSTHRD103` suppression.

## Sites (5)

| File | Was | Now |
| --- | --- | --- |
| `CLI/Program.cs:531` | `JsonSerializer.Serialize(usage, AppJsonContext.Default.ListProviderUsage)` | `SerializeAsync` to `MemoryStream`, then `Console.WriteLine` of the UTF-8 string |
| `CLI/Program.cs:600` | `JsonSerializer.Serialize(configs, AppJsonContext.Default.ListProviderConfig)` | Same pattern |
| `Web.Tests/TestWebHost.cs:31` | `File.WriteAllTextAsync(path, Serialize(scenario))` | `SerializeAsync` directly into `FileStream` |
| `Monitor.Tests/ConfigServiceExtendedTests.cs:179` | `Serialize` to string then `WriteAllTextAsync` | `SerializeAsync` into `FileStream`; string branch preserved verbatim |
| `Tests/.../GitHubAuthServiceTests.cs:52` | `File.WriteAllText` | `await File.WriteAllTextAsync` |
| `Tests/.../ProviderDiscoveryServiceTests.cs:78` | `Serialize` then `WriteAllText` | `SerializeAsync` into a `FileStream` wrapped in a `using` block |

## Behavior preservation

- **CLI output:** `System.Text.Json`'s sync and async serializers emit byte-identical JSON for the same `JsonTypeInfo`, so stdout output is unchanged.
- **Test files:** the resulting JSON written to disk is identical; only the API path changed.
- **ProviderDiscoveryServiceTests:** required the `using` **block** form (not `using var`) so the stream closes and releases the exclusive file lock *before* the production `DiscoverAuthAsync` reads the file. The `using var` form failed with `Assert.NotNull` because `File.Create` held the lock through the subsequent read. Caught and fixed during focused test runs.

## Regression coverage

- The modified test files **are** the regression tests for their own paths: if async serialization produces invalid JSON or holds a file lock, those tests fail because the production code cannot read what they wrote. The `ProviderDiscoveryServiceTests` failure-and-fix cycle is direct evidence.
- The CLI production path has no dedicated test project and its `Program`/`AppJsonContext` are `internal`. Its output contract is preserved because `System.Text.Json` guarantees byte-identical output across sync/async paths for the same `JsonTypeInfo`.

## Scope extension: IDE0005 (redundant usings), pre-authorized

Same pattern as PRs #736, #738, #739, #740: the pre-commit gate runs `dotnet format style --severity warn` on changed files. Pre-existing `IDE0005` warnings on these files (unused `using` directives) were removed so the commit could land. Behavior-neutral.

## Validation

- Non-incremental Release build: **0 errors**. Zero `VSTHRD103` on scoped files.
- Focused tests (`GitHubAuthServiceTests` + `ProviderDiscoveryServiceTests` + `ConfigServiceExtendedTests`): **24 passed, 2 pre-existing skips, 0 failed** (after the using-block fix).
- `AIUsageTracker.Tests`: **1417 passed, 2 pre-existing skips, 0 failed**.
- `AIUsageTracker.Monitor.Tests`: **140 passed, 0 failed**.
- Pre-commit analyzer gate: **passed** (whitespace, style, analyzers, build, core tests, Monitor tests).

## Out of scope

No `Task.Run`, no `VSTHRD103` suppression, no `ConfigureAwait(false)` added to UI-affine work, no `.editorconfig`/`NoWarn`/policy changes, no `--no-verify`. User's local `AGENTS.md` change untouched and unstaged.