### PR TITLE
fix: narrow catch-all exception handlers (Package 03B / Agent F)

### DIFF
--- a/AIUsageTracker.UI.Slim/App.Themes.cs
+++ b/AIUsageTracker.UI.Slim/App.Themes.cs
@@ -489,9 +489,17 @@ public partial class App
                 return value == 1 ? AppTheme.Light : AppTheme.Dark;
             }
         }
-        catch (Exception)
+        catch (System.Security.SecurityException ex)
         {
-            // Registry key not found or inaccessible — fall back to Dark
+            Services.UiDiagnosticFileLog.Write($"[THEME] Registry read denied, falling back to Dark: {ex.Message}");
+        }
+        catch (System.IO.IOException ex)
+        {
+            Services.UiDiagnosticFileLog.Write($"[THEME] Registry read I/O failure, falling back to Dark: {ex.Message}");
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            Services.UiDiagnosticFileLog.Write($"[THEME] Registry access unauthorized, falling back to Dark: {ex.Message}");
         }
 
         return AppTheme.Dark;

--- a/AIUsageTracker.UI.Slim/Services/UpdateInstallerHelper.cs
+++ b/AIUsageTracker.UI.Slim/Services/UpdateInstallerHelper.cs
@@ -16,6 +16,7 @@ internal static class UpdateInstallerHelper
     /// process via taskkill /F. Without this save, any unsaved preference
     /// changes (including UpdateChannel) are lost.
     /// </summary>
+    /// <returns>A task that represents the asynchronous download and install operation.</returns>
     public static async Task DownloadAndInstallAsync(
         Window owner,
         UpdateInfo updateInfo,
@@ -85,9 +86,21 @@ internal static class UpdateInstallerHelper
                 await preferencesStore.SaveAsync(App.Preferences).ConfigureAwait(true);
                 logger.LogInformation("[UPDATE] Preferences force-saved before installer launch");
             }
-            catch (Exception saveEx)
+            catch (InvalidOperationException saveEx)
             {
-                logger.LogWarning(saveEx, "[UPDATE] Failed to force-save preferences before installer launch");
+                logger.LogWarning(saveEx, "[UPDATE] Preferences service unavailable; force-save skipped before installer launch");
+            }
+            catch (System.IO.IOException saveEx)
+            {
+                logger.LogWarning(saveEx, "[UPDATE] Preferences force-save I/O failure before installer launch");
+            }
+            catch (System.Text.Json.JsonException saveEx)
+            {
+                logger.LogWarning(saveEx, "[UPDATE] Preferences force-save serialization failure before installer launch");
+            }
+            catch (UnauthorizedAccessException saveEx)
+            {
+                logger.LogWarning(saveEx, "[UPDATE] Preferences force-save denied by file permissions before installer launch");
             }
 
             UiDiagnosticFileLog.Write($"[UPDATE] Starting download: {updateInfo.DownloadUrl}");


### PR DESCRIPTION
## Summary

Executes **Package 03B / Agent F** from `docs/analyzer-cleanup/03-runtime-correctness.md`. Narrows two `catch (Exception)` blocks to concrete recoverable exception types, logs every failure with context, and preserves the existing product-required fallback behavior. No catch-all suppression; no silent catch blocks.

## Sites (2 live of 3 listed)

| File | Site | Concrete exceptions caught | Fallback preserved |
| --- | --- | --- | --- |
| `UI.Slim/App.Themes.cs` (`ResolveSystemTheme`) | Windows registry read | `SecurityException`, `IOException`, `UnauthorizedAccessException` | Falls back to `AppTheme.Dark` (documented product requirement). **Added logging** (previously the catch was silent — violated `AGENTS.md`'s 'no silent failures' rule). |
| `UI.Slim/Services/UpdateInstallerHelper.cs` (`DownloadAndInstallAsync`) | Preference force-save before installer launch | `InvalidOperationException`, `IOException`, `JsonException`, `UnauthorizedAccessException` | Does NOT abort the installer flow (documented CRITICAL requirement per the comment above the try). Existing warning logging preserved and made context-specific per exception type. |

**Not modified:** `Monitor/Services/UsageDatabase.cs:427` is listed in Package 03B's doc but has **no live CA1031 finding** on the current baseline (`cb78e429`) — the doc is stale. Per the package doc's own instruction ("Re-run the inventory before editing"), it was left untouched. The data-critical `UsageDatabase.cs` was not modified in any way.

## Concrete exception enumeration rationale

- **Registry read** (`RegistryKey.OpenSubKey`/`GetValue`): per Win32 docs, can throw `SecurityException` (no permission), `IOException` (registry I/O), `UnauthorizedAccessException` (write-restricted key). `NullReferenceException` is handled structurally via `key?.GetValue`.
- **Preference force-save** (`GetRequiredService<UiPreferencesStore>()` + `SaveAsync`): `InvalidOperationException` (DI service unregistered), `IOException`/`UnauthorizedAccessException` (file write), `JsonException` (serialization).

## Scope extension: SA1615 (return value doc), incidental

The pre-commit gate runs `dotnet format analyzers` which surfaces `SA1615` ("Element return value should be documented") on `DownloadAndInstallAsync` — a pre-existing doc gap (the method had a `<summary>` but no `<returns>`). This isn't visible in the regular Release build because XML doc analysis is disabled there (`SA0001`). Added a one-line `<returns>` tag to satisfy the gate. No code change.

## Validation

- Non-incremental Release build: **0 errors**. Zero `CA1031` on scoped files.
- `AIUsageTracker.Tests`: **1417 passed, 2 pre-existing skips, 0 failed**.
- `AIUsageTracker.Monitor.Tests`: **140 passed, 0 failed**.
- Pre-commit analyzer gate: **passed** (whitespace, style, analyzers, build, core tests, Monitor tests).

## Out of scope

No `catch (Exception)` left in scope; no silent catch blocks; no `--no-verify`; no `.editorconfig`/`NoWarn`/policy changes. User's local `AGENTS.md` change untouched and unstaged.