### PR TITLE
fix: qualify Gemini BuildModelQuotaCards call (IDE0009/SA1101)

### DIFF
--- a/AIUsageTracker.Infrastructure/Providers/GeminiProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/GeminiProvider.cs
@@ -116,7 +116,7 @@ public class GeminiProvider : ProviderBase
                 var accessToken = await this.RefreshTokenAsync(account.RefreshToken).ConfigureAwait(false);
                 var buckets = await this.FetchQuotaAsync(accessToken, account.ProjectId).ConfigureAwait(false);
                 var allBuckets = buckets ?? new List<Bucket>();
-                var modelQuotaCards = BuildModelQuotaCards(config, providerLabel, allBuckets, account.Email);
+                var modelQuotaCards = this.BuildModelQuotaCards(config, providerLabel, allBuckets, account.Email);
                 this._logger.LogDebug(
                     "Gemini quota received {BucketCount} bucket(s) and resolved {ModelCount} model card(s): {BucketSummary}",
                     allBuckets.Count,


### PR DESCRIPTION
## Summary

Closes the one remaining `IDE0009`/`SA1101` site not covered by any of the open cleanup PRs (#736–#743). `Provider-Test Agent C` (PR #736) scoped only the three provider **test** files; the corresponding production site in `GeminiProvider.cs` was missed.

## Change

`AIUsageTracker.Infrastructure/Providers/GeminiProvider.cs:119` called the private instance method `BuildModelQuotaCards` without `this.` qualification. Added `this.` to match the surrounding instance-method calls in the same statement block (`this._logger`, `this.RefreshTokenAsync`, `this.FetchQuotaAsync`).

One-character-class fix; no behavior change.

## Why a separate PR

This file is not in any of the seven open cleanup PRs' file lists. Adding it to one of them now would re-trigger CI on a PR that's already green and force a re-review. A separate small PR is cheaper.

## Validation

- Non-incremental Release build: 0 errors, **zero `IDE0009`/`SA1101` on `GeminiProvider.cs`**.
- Pre-commit analyzer gate: **passed** (whitespace, style, analyzers, build, core tests, Monitor tests). No co-located findings on this file, so the gate passed on the first attempt — unlike the cross-package-blocked PRs.

## Out of scope

No other changes. User's local `AGENTS.md` change untouched and unstaged.