### PR TITLE
chore: remove dead S1075 pragma; document cleanup execution status

### DIFF
--- a/AIUsageTracker.Infrastructure/Constants/ProviderEndpoints.cs
+++ b/AIUsageTracker.Infrastructure/Constants/ProviderEndpoints.cs
@@ -2,8 +2,6 @@
 // Copyright (c) AIUsageTracker. All rights reserved.
 // </copyright>
 
-#pragma warning disable S1075 // URIs are provider endpoint constants
-
 namespace AIUsageTracker.Infrastructure.Constants;
 
 public static class ProviderEndpoints

--- a/docs/analyzer-cleanup/README.md
+++ b/docs/analyzer-cleanup/README.md
@@ -1,5 +1,26 @@
 # Analyzer Cleanup Work Packages
 
+## Status
+
+Execution against the 2026-07-19 baseline (`cb78e429`), targeting `develop`:
+
+| Agent | Package | PR | State |
+| --- | --- | --- | --- |
+| C | 02A — provider tests | #736 | open |
+| A | 01A — non-test using order | #738 | open (6 files deferred to B/E) |
+| D | 02B — test using order | #739 | open |
+| B | 01B — Monitor/UI layout | #740 | open (picks up 01A's deferred SA1210/IDE0005) |
+| E | 03A — async serialization | #741 | open |
+| F | 03B — exception handling | #742 | open |
+| G | 03C–F — runtime correctness | #743 | open (4 atomic commits) |
+| — | IDE0009/SA1101 — Gemini production site | #745 | open |
+
+Agent H (rule promotion, Package 04) is **blocked** until A–G merge — it can only promote rule families whose live backlog is zero across the merged tree.
+
+**Known structural issue (#744):** the pre-commit analyzer gate runs all style/analyzer rules on every changed file, but this plan decomposes work by rule family per agent. Single-package PRs are landable only when a file's co-located warnings all belong to the same agent's scope. See issue #744 for options.
+
+The `file:line` references in `01-mechanical-style.md`, `02-test-project-findings.md`, and `03-runtime-correctness.md` are baseline-relative and will shift as the PRs above merge. Re-derive them with the inventory command below; do not trust the literal numbers post-merge.
+
 ## Purpose
 
 These documents divide the remaining analyzer backlog into non-overlapping assignments. They are designed for agents to execute after the beta release without mixing cleanup with product changes.


### PR DESCRIPTION
## Summary

Two small cleanup items surfaced by a post-execution scan of the analyzer-cleanup plan, after PRs #736–#743 and #745 were opened.

## 1. Remove dead `S1075` pragma

`AIUsageTracker.Infrastructure/Constants/ProviderEndpoints.cs:5` had:

```csharp
#pragma warning disable S1075 // URIs are provider endpoint constants
```

with no matching `restore`. Investigation shows this pragma is **dead code**:

- SonarQube analyzers are **not installed** in this project (no `SonarAnalyzer` package reference in any `.csproj` or `Directory.Build.props`).
- `S1075` does **not appear in any build output** — the rule isn't active.
- There is **no `.editorconfig` entry** for `S1075`.

Removing it changes nothing about what the compiler/analyzer pipeline enforces. Per `AGENTS.md`'s Lean Code Requirement ("Prefer deleting redundant layers/wrappers"), dead defensive code should be deleted, not maintained. **Verified:** a fresh non-incremental Release build emits zero `S1075` warnings and zero new warnings on the file.

(The other production `#pragma` sites — `CA1031` in `CLI/Program.cs`, `MA0004` in `PreferencesStore.cs`, `S107` in `MonitorLauncherProcessController.cs` — are scoped with matching restores and were left untouched. They're inventory for a future Agent H suppression-retirement pass, not defects.)

## 2. Document cleanup execution status

`docs/analyzer-cleanup/README.md` gained a **Status** section listing:

- The 8 executing PRs (#736, #738, #739, #740, #741, #742, #743, #745) and their states.
- The Agent H (rule promotion) blocker — it depends on A–G merging.
- A pointer to issue #744 (the gate-vs-plan structural mismatch).
- An explicit note that the `file:line` references in the sibling planning docs (`01-mechanical-style.md`, `02-test-project-findings.md`, `03-runtime-correctness.md`) are **baseline-relative** and will shift as the PRs merge — readers should re-derive them with the inventory command in the README.

This is the minimum doc edit so a reader landing on these planning docs knows what's done vs. pending. No rewrite of the baseline content (the snapshot counts and inventory command stay — they're the baseline-of-record).

## Validation

- Non-incremental Release build: **0 errors**, zero new warnings, zero `S1075` anywhere.
- Pre-commit analyzer gate: **passed** (whitespace, style, analyzers, build, core tests 1417 pass / 2 skip, Monitor tests 140 pass).

## Out of scope

No code behavior change. No `.editorconfig`/`NoWarn` policy change (the dead pragma wasn't a policy — it was targeting a non-existent rule). No other pragma sites touched. User's local `AGENTS.md` change untouched and unstaged.
