### PR TITLE
chore: promote SA1210/SA1101/IDE0009/MA0006 to error (Agent H step 1)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ insert_new_line_at_end_of_file = true
 dotnet_diagnostic.IDE0005.severity = warning
 dotnet_diagnostic.IDE0055.severity = warning
 dotnet_diagnostic.IDE0065.severity = warning
-dotnet_diagnostic.IDE0009.severity = warning
+dotnet_diagnostic.IDE0009.severity = error
 dotnet_diagnostic.CA1031.severity = warning
 # TODO: fix violations then promote to error (was inert due to dot_diagnostic prefix typo)
 dotnet_diagnostic.CA1062.severity = error
@@ -39,7 +39,7 @@ dotnet_diagnostic.CA2254.severity = error
 # Analyzer configurations for mechanical cleanup
 dotnet_diagnostic.MA0002.severity = warning
 dotnet_diagnostic.MA0004.severity = warning
-dotnet_diagnostic.MA0006.severity = warning
+dotnet_diagnostic.MA0006.severity = error
 dotnet_diagnostic.MA0011.severity = warning
 dotnet_diagnostic.MA0016.severity = warning
 dotnet_diagnostic.MA0023.severity = suggestion
@@ -49,7 +49,8 @@ dotnet_diagnostic.MA0048.severity = warning
 dotnet_diagnostic.MA0051.severity = suggestion
 
 # StyleCop analyzers - enabled for mechanical cleanup
-dotnet_diagnostic.SA1101.severity = warning
+dotnet_diagnostic.SA1101.severity = error
+dotnet_diagnostic.SA1210.severity = error
 dotnet_diagnostic.SA1516.severity = warning
 dotnet_diagnostic.SA1000.severity = warning
 dotnet_diagnostic.SA1003.severity = warning
@@ -89,7 +90,7 @@ csharp_style_namespace_declarations = file_scoped:warning
 [AIUsageTracker.Tests/**/*.cs]
 dotnet_diagnostic.MA0074.severity = warning
 dotnet_diagnostic.MA0004.severity = warning
-dotnet_diagnostic.MA0006.severity = warning
+dotnet_diagnostic.MA0006.severity = error
 dotnet_diagnostic.MA0011.severity = warning
 dotnet_diagnostic.MA0016.severity = warning
 dotnet_diagnostic.MA0002.severity = warning
@@ -140,7 +141,7 @@ dotnet_diagnostic.SA1402.severity = none
 # MA0004 (ConfigureAwait) — enabled for Core/Infrastructure/Monitor (library code).
 # Suppressed per-file in UI.Slim .xaml.cs where UI thread affinity is required.
 dotnet_diagnostic.MA0004.severity = warning
-dotnet_diagnostic.MA0006.severity = warning
+dotnet_diagnostic.MA0006.severity = error
 dotnet_diagnostic.MA0016.severity = none
 dotnet_diagnostic.MA0048.severity = none
 dotnet_diagnostic.MA0051.severity = none


### PR DESCRIPTION
## Summary

Executes **Agent H / Package 04, step 1** per `docs/analyzer-cleanup/04-suppression-retirement.md`. Promotes the four Group 1 rule families from `warning` to `error` severity now that their live backlog is zero on merged `develop` (after PRs #736, #738, #739, #740, #745).

## Rules promoted

| Rule | Scope | Before | After |
| --- | --- | --- | --- |
| `SA1210` (using order) | `[*.cs]` | default warning (no entry) | explicit `error` |
| `SA1101` (this. qualification) | `[*.cs]` | warning | error |
| `IDE0009` (this./Me qualification) | `[*.cs]` | warning | error |
| `MA0006` (string.Equals) | `[*.cs]` | warning | error |
| `MA0006` | `[AIUsageTracker.Tests/**/*.cs]` | warning | error |
| `MA0006` | legacy-backlog `[*.cs]` block | warning | error |

## Verification (per the handoff step 7)

1. **Clean tree builds clean:** Fresh non-incremental Release build on the promoted tree → **0 errors**. Confirms the backlog is genuinely zero (not silently suppressed).
2. **Deliberate-violation probe (the gate-rejects test):** Injected a temporary `MA0006` string `==` in `ProviderUsage.cs`. The build correctly **FAILED** with `error MA0006` (not warning), exit code 1. Proves the promotion actually bites. Probe reverted immediately; build clean again.
3. **Full suite:** `AIUsageTracker.Tests` 1418 pass / 2 pre-existing skips / 0 fail. `AIUsageTracker.Monitor.Tests` 142 pass / 0 fail.
4. **Pre-commit analyzer gate:** passed (whitespace, style, analyzers, build, core tests, monitor tests).

## What this changes operationally

CI will now **reject** any PR that reintroduces `SA1210`, `SA1101`, `IDE0009`, or `MA0006` — they fail the build instead of producing warnings. Per the plan's repo-configuration target, `TreatWarningsAsErrors` stays OFF globally; promotion is per-rule so the contract is stable and reviewable, and unrelated SDK/package warnings can't block emergency builds.

## Notes on the flaky tests encountered during validation

While validating, two pre-existing flaky tests intermittently failed under full-suite load:
- `UpdateChannelConfigurationEndToEndTests.GenerateAppcastScript_*` — spawns `generate-appcast.sh` as a subprocess; intermittently hits `STATUS_DLL_INIT_FAILED` (`0xC0000142`) on this Windows machine under load.
- `UpdatePipelineEndToEndTests.BetaDownloadUrl_ForEachArchitecture_ReturnsHttp200` — live-network integration test.

Both pass reliably in isolation (3/3 runs each) and are unrelated to this `.editorconfig` change. They're pre-existing environmental flakiness, not regressions from this PR.

## Out of scope

- `TreatWarningsAsErrors` left OFF (per plan).
- Groups 2 and 3 (layout rules, behavior-sensitive rules) are separate PRs per the plan's "one rule family at a time" guidance.
- The flaky tests are noted but not addressed (they're their own follow-up).
- User's local `AGENTS.md` change untouched and unstaged.
