### PR TITLE
chore: promote CA1031/CA2024/VSTHRD003/VSTHRD103 to error (Agent H step 3)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,7 +13,8 @@ dotnet_diagnostic.IDE0005.severity = warning
 dotnet_diagnostic.IDE0055.severity = warning
 dotnet_diagnostic.IDE0065.severity = warning
 dotnet_diagnostic.IDE0009.severity = warning
-dotnet_diagnostic.CA1031.severity = warning
+dotnet_diagnostic.CA1031.severity = error
+dotnet_diagnostic.CA2024.severity = error
 # TODO: fix violations then promote to error (was inert due to dot_diagnostic prefix typo)
 dotnet_diagnostic.CA1062.severity = error
 dotnet_diagnostic.CA1307.severity = error
@@ -26,7 +27,8 @@ dotnet_diagnostic.CA2300.severity = warning
 # are enforced in architecture tests because the patterns are project-specific and
 # need tighter control than generic analyzer packages provide.
 dotnet_diagnostic.VSTHRD002.severity = warning
-dotnet_diagnostic.VSTHRD103.severity = warning
+dotnet_diagnostic.VSTHRD003.severity = error
+dotnet_diagnostic.VSTHRD103.severity = error
 dotnet_diagnostic.VSTHRD105.severity = warning
 dotnet_diagnostic.VSTHRD110.severity = warning
 # TODO: fix violations then promote to error (was inert due to dot_diagnostic prefix typo)


### PR DESCRIPTION
## Summary

Executes **Agent H / Package 04, step 3** per `docs/analyzer-cleanup/04-suppression-retirement.md`. Promotes the four Group 3 behavior-sensitive rule families from `warning` to `error` severity now that their live backlog is zero on merged `develop` (after PRs #741 / Agent E, #742 / Agent F, #743 / Agent G).

## Rules promoted

| Rule | Description | Before | After | Test scope |
| --- | --- | --- | --- | --- |
| `CA1031` | Catch a more specific exception type | `warning` | `error` | unchanged `none` (test fixtures legitimately catch `Exception`) |
| `CA2024` | Do not use EndOfStream in async methods / stream disposal | default | explicit `error` | same (no override) |
| `VSTHRD003` | Avoid awaiting foreign tasks | default | explicit `error` | same |
| `VSTHRD103` | Await async methods / no sync-over-async | `warning` | `error` | same (PR #741 cleaned test sites too) |

**Test-scope note:** `CA1031` stays `none` in `AIUsageTracker.Tests`, `AIUsageTracker.Monitor.Tests`, and `AIUsageTracker.Web.Tests` — that's intentional policy (test fixtures catch `Exception` to drive `Assert.Fail` patterns). The test-scope override wins for test files; production code becomes strict.

## Verification (per handoff step 7)

1. **Clean tree builds clean:** Fresh non-incremental Release build → **0 errors**.
2. **Deliberate-violation probe:** Injected `catch (Exception)` in `ProviderUsage.cs`. Build **FAILED** with `error CA1031`. Probe reverted; build clean.
3. **Full suite:** `AIUsageTracker.Tests` 1418 pass / 2 pre-existing skips / 0 fail. `AIUsageTracker.Monitor.Tests` 142 pass.
4. **Pre-commit analyzer gate:** passed.

## Operational effect

CI will reject any PR that reintroduces these four runtime-correctness violations in **production code**. Test fixtures remain free to use `catch (Exception)` per the documented test-scope override.

## Out of scope

`TreatWarningsAsErrors` stays OFF globally. This completes Agent H's Groups 1–3 (the active rules with zero backlog). The plan's Group 4 (currently-suppressed member-ordering rules like `SA1201`) and Group 5 (documentation rules) require a separate repository policy decision per `04-suppression-retirement.md` and are NOT part of this PR. User's local `AGENTS.md` change untouched and unstaged.