### PR TITLE
Release 2.4.6-beta.1: Z.AI empty-data fix + privacy-mode audit trail

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,17 @@ This document provides essential information for agentic coding assistants worki
 - **DO NOT** show only a subset of providers (e.g., only antigravity) on startup
 - The UI must show provider cards immediately, even if data is stale or unavailable
 
+### Privacy Mode Scope (CRITICAL — read before touching privacy code)
+
+**Privacy mode is a UI-only concern. It has NO effect on data recording.**
+
+- `IsPrivacyMode` controls what the **user sees** in the Slim UI: it hides account names, masks usage values, blanks identifiers, etc.
+- It does NOT control database storage. Provider response bodies (`raw_snapshots`), `provider_history`, and `reset_events` MUST be recorded **continuously and unconditionally** regardless of `IsPrivacyMode`.
+- The processing pipeline (`ProviderUsageProcessingPipeline.NormalizeUsage`) redacts only the **display-bound** fields under privacy mode: `AccountName`, `ConfigKey`. Everything else — including `RawJson` — is the audit trail and must be preserved.
+- Rationale: privacy mode is for screen-sharing/UI screenshots; the database is the diagnostic record that backs trend analysis, error investigation, and provider behavior changes. Gaps in that record destroy the product's value.
+- A previous version of the pipeline nulled `RawJson` in privacy mode, which silently disabled `raw_snapshots` writes for the entire duration privacy mode was on (e.g. a 4-day gap with zero snapshots for any provider). **Treat any change that nulls/clears/skips `RawJson` in privacy mode as a regression and revert it.**
+- If you ever genuinely need to redact a field inside `RawJson` for privacy reasons, do it field-by-field with a redaction strategy — never blanket-null.
+
 ### Lean Code Requirement
 - **The goal is to keep as little source code as necessary** to deliver required functionality across these applications.
 - Prefer deleting redundant layers/wrappers over adding new abstraction when behavior can remain clear and testable.

--- a/AIUsageTracker.Core/Models/ProviderUsage.cs
+++ b/AIUsageTracker.Core/Models/ProviderUsage.cs
@@ -39,9 +39,9 @@ public abstract class ProviderUsage
     public double ResponseLatencyMs { get; set; }
 
     /// <summary>
-    /// Gets or sets raw JSON response from the provider API. Intentional audit trail — stored in the database
-    /// and privacy-redacted in the processing pipeline when privacy mode is enabled.
-    /// Not surfaced in the UI; used for diagnostics and post-hoc debugging.
+    /// Gets or sets raw JSON response from the provider API. Intentional audit trail — always
+    /// stored in the database regardless of privacy mode. Privacy mode is UI-only and does not
+    /// affect database recording. Not surfaced in the UI; used for diagnostics and post-hoc debugging.
     /// </summary>
     public string? RawJson { get; set; }
 

--- a/AIUsageTracker.Infrastructure/Providers/ZaiProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/ZaiProvider.cs
@@ -85,7 +85,7 @@ public class ZaiProvider : ProviderBase
 
         if (limits == null || limits.Count == 0)
         {
-            return this.BuildNoLimitsResult(config, responseString, httpStatus);
+            return this.BuildWindowInactiveResult(config, responseString, httpStatus);
         }
 
         foreach (var limit in limits)
@@ -156,6 +156,30 @@ public class ZaiProvider : ProviderBase
                 PlanType = this.Definition.PlanType,
                 RawJson = responseString,
                 HttpStatus = httpStatus,
+            },
+        };
+    }
+
+    private ProviderUsage[] BuildWindowInactiveResult(ProviderConfig config, string responseString, int httpStatus)
+    {
+        this._logger.LogDebug("[ZAI] Response successful but `data` is empty — quota window inactive (5h rolling reset)");
+        var label = ProviderMetadataCatalog.GetConfiguredDisplayName(config.ProviderId);
+        return new[]
+        {
+            new QuotaProviderUsage
+            {
+                ProviderId = this.ProviderId,
+                ProviderName = label,
+                IsAvailable = true,
+                Description = "Quota window inactive (5h rolling)",
+                IsQuotaBased = this.Definition.IsQuotaBased,
+                PlanType = this.Definition.PlanType,
+                UsedPercent = 0,
+                RequestsUsed = 0,
+                RequestsAvailable = 0,
+                RawJson = responseString,
+                HttpStatus = httpStatus,
+                UpstreamResponseValidity = UpstreamResponseValidity.Valid,
             },
         };
     }

--- a/AIUsageTracker.Monitor.Tests/ProviderUsageProcessingPipelineTests.cs
+++ b/AIUsageTracker.Monitor.Tests/ProviderUsageProcessingPipelineTests.cs
@@ -170,8 +170,40 @@ public class ProviderUsageProcessingPipelineTests
         var processed = Assert.Single(result.Usages);
         Assert.Equal(string.Empty, processed.AccountName);
         Assert.Equal(string.Empty, processed.ConfigKey);
-        Assert.Null(processed.RawJson);
+        Assert.Equal("{ \"secret\": \"value\" }", processed.RawJson);
         Assert.Equal(1, result.PrivacyRedactedCount);
+    }
+
+    [Fact]
+    public void Process_WhenPrivacyModeEnabled_PreservesRawJsonAsAuditTrail()
+    {
+        // Per AGENTS.md "Privacy Mode Scope": privacy mode is UI-only.
+        // raw_snapshots MUST keep being written in privacy mode (the audit trail backs
+        // trend analysis and error investigation). Previously the pipeline nulled RawJson
+        // here, which silently disabled snapshot writes for the entire duration privacy
+        // mode was on (4-day gap, 0 snapshots for any provider).
+        var rawJson = "{\"code\":200,\"msg\":\"Operation successful\",\"data\":{\"limits\":[]},\"success\":true}";
+        var usage = new QuotaProviderUsage
+        {
+            ProviderId = "zai-coding-plan",
+            ProviderName = "Z.ai Coding Plan",
+            IsAvailable = true,
+            IsQuotaBased = true,
+            AccountName = "user@example.com",
+            ConfigKey = "zai-config",
+            RawJson = rawJson,
+            HttpStatus = 200,
+        };
+
+        var result = this._pipeline.Process(
+            new[] { usage },
+            new[] { "zai-coding-plan" },
+            isPrivacyMode: true);
+
+        var processed = Assert.Single(result.Usages);
+        Assert.Equal(rawJson, processed.RawJson);
+        Assert.Equal(string.Empty, processed.AccountName);
+        Assert.Equal(string.Empty, processed.ConfigKey);
     }
 
     [Fact]

--- a/AIUsageTracker.Monitor/Services/ProviderUsageProcessingPipeline.cs
+++ b/AIUsageTracker.Monitor/Services/ProviderUsageProcessingPipeline.cs
@@ -264,14 +264,12 @@ public class ProviderUsageProcessingPipeline : IProviderUsageProcessingPipeline
 
         if (isPrivacyMode)
         {
-            if (!string.IsNullOrWhiteSpace(usage.RawJson) ||
-                !string.IsNullOrWhiteSpace(usage.AccountName) ||
+            if (!string.IsNullOrWhiteSpace(usage.AccountName) ||
                 !string.IsNullOrWhiteSpace(usage.ConfigKey))
             {
                 privacyRedactedCount++;
             }
 
-            usage.RawJson = null;
             usage.AccountName = string.Empty;
             usage.ConfigKey = string.Empty;
         }

--- a/AIUsageTracker.Tests/Infrastructure/Providers/ZaiProviderTests.cs
+++ b/AIUsageTracker.Tests/Infrastructure/Providers/ZaiProviderTests.cs
@@ -298,4 +298,35 @@ public class ZaiProviderTests : HttpProviderTestBase<ZaiProvider>
         var hoursUntilReset = (usage.NextResetTime!.Value - DateTime.Now).TotalHours;
         Assert.InRange(hoursUntilReset, 2.5, 3.5);
     }
+
+    [Fact]
+    public async Task GetUsageAsync_EmptyData_ReturnsSuccessfulWindowInactiveCardAsync()
+    {
+        // Z.AI returns HTTP 200 with `{"code":200,"msg":"Operation successful","data":{},"success":true}`
+        // when the rolling 5h window has just rolled over and no usage has accrued yet.
+        // This is a SUCCESSFUL upstream response — it must NOT be treated as a failure
+        // (which would open the circuit breaker and surface as "Temporarily paused").
+        var responseContent = JsonSerializer.Serialize(new
+        {
+            code = 200,
+            msg = "Operation successful",
+            data = new { },
+            success = true,
+        });
+
+        this.SetupHttpResponse("https://api.z.ai/api/monitor/usage/quota/limit", new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent(responseContent),
+        });
+
+        var result = await this._provider.GetUsageAsync(this.Config);
+
+        var usage = Assert.Single(result.OfType<QuotaProviderUsage>());
+        Assert.True(
+            usage.IsAvailable,
+            "Empty `data:{}` is a successful upstream response — must keep circuit closed and surface as available.");
+        Assert.Equal(200, usage.HttpStatus);
+        Assert.Contains("window", usage.Description, StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [2.4.6-beta.1] - 2026-07-23
+
+### Fixed
+
+- **Z.AI provider stops "Temporarily paused" loop on inactive quota windows** — when the Z.AI API returns HTTP 200 with `{"code":200,"msg":"Operation successful","data":{},"success":true}` (no active 5-hour rolling window yet), the provider now surfaces a successful "Quota window inactive (5h rolling)" card instead of opening the circuit breaker after 15 empty-data failures.
+- **Privacy mode no longer silently disables `raw_snapshots` writes** — the audit trail of provider response bodies is now stored continuously regardless of the UI privacy setting. Privacy mode is documented in `AGENTS.md` as UI-only (it redacts `AccountName` and `ConfigKey` for display, but never suppresses database recording). Previously, any user with `IsPrivacyMode=true` had a complete snapshot gap for the entire duration privacy mode was enabled (e.g. a 4-day gap with zero snapshots for any provider).
+
 ## [2.4.5-beta.5] - 2026-07-19
 
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <TrackerVersion>2.4.5-beta.5</TrackerVersion>
-    <TrackerAssemblyVersion>2.4.5</TrackerAssemblyVersion>
+    <TrackerVersion>2.4.6-beta.1</TrackerVersion>
+    <TrackerAssemblyVersion>2.4.6</TrackerAssemblyVersion>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(MSBuildProjectDirectory)\artifacts\**\*</DefaultItemExcludes>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest</AnalysisLevel>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="AIUsageTracker.Web/wwwroot/favicon.png" width="32" height="32" valign="middle"> AI Usage Tracker
 
-![Version](https://img.shields.io/badge/version-2.4.5--beta.5-orange)
+![Version](https://img.shields.io/badge/version-2.4.6--beta.1-orange)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Platforms](https://img.shields.io/badge/platforms-Windows%20|%20Linux%20-blue)
 ![Language](https://img.shields.io/badge/language-C%23%20|%20.NET-purple)

--- a/scripts/publish-app.ps1
+++ b/scripts/publish-app.ps1
@@ -6,7 +6,7 @@ param(
 )
 
 # AI Usage Tracker - Distribution Packaging Script
-# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.4.5-beta.5 -InstallerCompression balanced
+# Usage: .\scripts\publish-app.ps1 -Runtime win-x64 -Version 2.4.6-beta.1 -InstallerCompression balanced
 
 $isWinPlatform = $Runtime.StartsWith("win-")
 $projectName = if ($isWinPlatform) { "AIUsageTracker" } else { "AIUsageTracker.CLI" }

--- a/scripts/setup.iss
+++ b/scripts/setup.iss
@@ -1,7 +1,7 @@
 ; AI Usage Tracker - Inno Setup Script
 
 #ifndef MyAppVersion
-  #define MyAppVersion "2.4.5-beta.5"
+  #define MyAppVersion "2.4.6-beta.1"
 #endif
 #ifndef SourcePath
   #define SourcePath "..\dist\publish-win-x64"


### PR DESCRIPTION
## Summary

Two bug fixes for issues observed on 2026-07-23 while debugging a stuck Z.AI card:

### Z.AI provider — empty `data` object is a successful response

Z.AI returns HTTP 200 with an empty `data` object when the 5-hour rolling quota window has just rolled over and no usage has accrued yet. The provider was treating this as failure (no `limits` array), which after 15 consecutive empty responses opened the circuit breaker and surfaced the card as **"Temporarily paused — No usage data available"** for the entire window rotation.

Now: `BuildWindowInactiveResult` returns a successful card (`IsAvailable=true`, `HttpStatus=200`, `UpstreamResponseValidity=Valid`, description "Quota window inactive (5h rolling)"). Circuit breaker is no longer tripped by Z.AI's window-inactive signal.

### Privacy mode no longer silently disables `raw_snapshots`

`ProviderUsageProcessingPipeline.NormalizeUsage` was nulling `RawJson` when `IsPrivacyMode=true`, which silently disabled `raw_snapshots` writes for the entire duration privacy mode was enabled. The 4-day gap from 2026-07-19 to 2026-07-23 is the longest observed.

Privacy mode is a UI-only concern. It redacts `AccountName` and `ConfigKey` for display, but it must NEVER suppress database recording. The audit trail of provider response bodies is mandatory regardless of privacy setting.

`AGENTS.md` gets a new **"Privacy Mode Scope (CRITICAL)"** section codifying this so future agents don't regress it again.

## Tests

- **Z.AI**: new `EmptyData_ReturnsSuccessfulWindowInactiveCardAsync` asserts the new successful behavior
- **Pipeline**: `RedactsSensitiveFields` updated to assert `RawJson` preservation; new `PreservesRawJsonAsAuditTrail` documents the privacy contract
- All 1608 existing tests still pass

## Files changed

```
AGENTS.md                                                              | 11 +++++++
AIUsageTracker.Core/Models/ProviderUsage.cs                            |  6 ++--
AIUsageTracker.Infrastructure/Providers/ZaiProvider.cs                 | 26 +++++++++++++-
AIUsageTracker.Monitor/Services/ProviderUsageProcessingPipeline.cs    |  4 +--
AIUsageTracker.Monitor.Tests/ProviderUsageProcessingPipelineTests.cs   | 34 +++++++++++++++++-
AIUsageTracker.Tests/Infrastructure/Providers/ZaiProviderTests.cs     | 31 ++++++++++++++
CHANGELOG.md                                                           |  7 +++++
Directory.Build.props                                                  |  4 +--
README.md                                                              |  2 +-
scripts/publish-app.ps1                                                |  2 +-
scripts/setup.iss                                                      |  2 +-
11 files changed, 116 insertions(+), 13 deletions(-)
```

## Release notes

### Fixed

- **Z.AI provider stops "Temporarily paused" loop on inactive quota windows** — when the Z.AI API returns HTTP 200 with an empty `data` object (no active 5-hour rolling window yet), the provider now surfaces a successful "Quota window inactive (5h rolling)" card instead of opening the circuit breaker after 15 empty-data failures.
- **Privacy mode no longer silently disables `raw_snapshots` writes** — the audit trail of provider response bodies is now stored continuously regardless of the UI privacy setting. Privacy mode is documented in `AGENTS.md` as UI-only.

## Version

`v2.4.6-beta.1` (new patch line; v2.4.5 stable is already shipped, so the next release starts a new patch line per repo convention).
