### PR TITLE
feat(providers): add Grok CLI usage provider

### DIFF
--- a/AIUsageTracker.Core/Models/QuotaWindowDefinition.cs
+++ b/AIUsageTracker.Core/Models/QuotaWindowDefinition.cs
@@ -14,10 +14,12 @@ namespace AIUsageTracker.Core.Models;
 /// <param name="SettingsLabel">Human-readable label for the settings show/hide list. Falls back to <see cref="DualBarLabel"/> when null.</param>
 /// <param name="DetailName">Reserved for legacy compatibility. No longer used for runtime matching.</param>
 /// <param name="PeriodDuration">Duration of this quota window (e.g. <c>TimeSpan.FromHours(5)</c> for a burst window, <c>TimeSpan.FromDays(7)</c> for a weekly window). Used by the UI and alert service to compute time-adjusted pace so that progress-bar colours and threshold notifications are not false-positive when the user is under pace.</param>
+/// <param name="DisplayAsFraction">Whether this card displays raw used/available values instead of percentages.</param>
 public sealed record QuotaWindowDefinition(
     WindowKind Kind,
     string DualBarLabel,
     string? ChildProviderId = null,
     string? SettingsLabel = null,
     string? DetailName = null,
-    TimeSpan? PeriodDuration = null);
+    TimeSpan? PeriodDuration = null,
+    bool DisplayAsFraction = false);

--- a/AIUsageTracker.Core/MonitorClient/AgentGroupedModelUsage.cs
+++ b/AIUsageTracker.Core/MonitorClient/AgentGroupedModelUsage.cs
@@ -14,6 +14,10 @@ public sealed class AgentGroupedModelUsage
 
     public double? RemainingPercentage { get; set; }
 
+    public double RequestsUsed { get; set; }
+
+    public double RequestsAvailable { get; set; }
+
     public DateTime? NextResetTime { get; set; }
 
     /// <summary>

--- a/AIUsageTracker.Infrastructure/Configuration/ProviderAuthFileSchemaReader.cs
+++ b/AIUsageTracker.Infrastructure/Configuration/ProviderAuthFileSchemaReader.cs
@@ -16,41 +16,41 @@ internal static class ProviderAuthFileSchemaReader
     {
         foreach (var schema in schemas)
         {
-            if (!TryResolveSchemaRoot(root, schema.RootProperty, out var sessionRoot) ||
-                sessionRoot.ValueKind != JsonValueKind.Object)
+            foreach (var sessionRoot in ResolveSchemaRoots(root, schema.RootProperty))
             {
-                continue;
+                if (sessionRoot.ValueKind != JsonValueKind.Object)
+                {
+                    continue;
+                }
+
+                var accessToken = sessionRoot.ReadString(schema.AccessTokenProperty);
+                if (string.IsNullOrWhiteSpace(accessToken))
+                {
+                    continue;
+                }
+
+                var accountId = !string.IsNullOrWhiteSpace(schema.AccountIdProperty)
+                    ? sessionRoot.ReadString(schema.AccountIdProperty)
+                    : null;
+
+                var identityToken = !string.IsNullOrWhiteSpace(schema.IdentityTokenProperty)
+                    ? sessionRoot.ReadString(schema.IdentityTokenProperty)
+                    : null;
+
+                return new ProviderAuthData(accessToken, accountId, identityToken);
             }
-
-            var accessToken = sessionRoot.ReadString(schema.AccessTokenProperty);
-            if (string.IsNullOrWhiteSpace(accessToken))
-            {
-                continue;
-            }
-
-            var accountId = !string.IsNullOrWhiteSpace(schema.AccountIdProperty)
-                ? sessionRoot.ReadString(schema.AccountIdProperty)
-                : null;
-
-            var identityToken = !string.IsNullOrWhiteSpace(schema.IdentityTokenProperty)
-                ? sessionRoot.ReadString(schema.IdentityTokenProperty)
-                : null;
-
-            return new ProviderAuthData(accessToken, accountId, identityToken);
         }
 
         return null;
     }
 
-    private static bool TryResolveSchemaRoot(
+    private static IEnumerable<JsonElement> ResolveSchemaRoots(
         JsonElement root,
-        string rootProperty,
-        out JsonElement sessionRoot)
+        string rootProperty)
     {
         if (root.ValueKind != JsonValueKind.Object)
         {
-            sessionRoot = default;
-            return false;
+            yield break;
         }
 
         // Wildcard schemas ("<prefix>*") match any root property by prefix. This supports
@@ -65,13 +65,11 @@ internal static class ProviderAuthFileSchemaReader
                 if (property.Name.StartsWith(prefix, StringComparison.Ordinal) &&
                     property.Value.ValueKind == JsonValueKind.Object)
                 {
-                    sessionRoot = property.Value;
-                    return true;
+                    yield return property.Value;
                 }
             }
 
-            sessionRoot = default;
-            return false;
+            yield break;
         }
 
         var parts = rootProperty.Split('.');
@@ -91,7 +89,9 @@ internal static class ProviderAuthFileSchemaReader
                     : next;
             });
 
-        sessionRoot = navigated ?? default;
-        return navigated.HasValue;
+        if (navigated.HasValue)
+        {
+            yield return navigated.Value;
+        }
     }
 }

--- a/AIUsageTracker.Infrastructure/Configuration/ProviderAuthFileSchemaReader.cs
+++ b/AIUsageTracker.Infrastructure/Configuration/ProviderAuthFileSchemaReader.cs
@@ -47,6 +47,27 @@ internal static class ProviderAuthFileSchemaReader
         string rootProperty,
         out JsonElement sessionRoot)
     {
+        // Wildcard schemas ("<prefix>*") match any root property by prefix. This supports
+        // issuer-scoped auth stores (e.g. "https://auth.x.ai::*" for the Grok CLI) whose
+        // property names embed a dynamic segment (the OIDC client id). Such names contain
+        // dots and must be matched whole instead of being dot-navigated.
+        if (rootProperty.EndsWith("*", StringComparison.Ordinal))
+        {
+            var prefix = rootProperty[..^1];
+            foreach (var property in root.EnumerateObject())
+            {
+                if (property.Name.StartsWith(prefix, StringComparison.Ordinal) &&
+                    property.Value.ValueKind == JsonValueKind.Object)
+                {
+                    sessionRoot = property.Value;
+                    return true;
+                }
+            }
+
+            sessionRoot = default;
+            return false;
+        }
+
         var parts = rootProperty.Split('.');
         var lastPart = parts[^1];
 

--- a/AIUsageTracker.Infrastructure/Configuration/ProviderAuthFileSchemaReader.cs
+++ b/AIUsageTracker.Infrastructure/Configuration/ProviderAuthFileSchemaReader.cs
@@ -47,6 +47,12 @@ internal static class ProviderAuthFileSchemaReader
         string rootProperty,
         out JsonElement sessionRoot)
     {
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            sessionRoot = default;
+            return false;
+        }
+
         // Wildcard schemas ("<prefix>*") match any root property by prefix. This supports
         // issuer-scoped auth stores (e.g. "https://auth.x.ai::*" for the Grok CLI) whose
         // property names embed a dynamic segment (the OIDC client id). Such names contain

--- a/AIUsageTracker.Infrastructure/Providers/GrokProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/GrokProvider.cs
@@ -1,0 +1,371 @@
+// <copyright file="GrokProvider.cs" company="AIUsageTracker">
+// Copyright (c) AIUsageTracker. All rights reserved.
+// </copyright>
+
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using AIUsageTracker.Core.Models;
+using AIUsageTracker.Core.Providers;
+using AIUsageTracker.Infrastructure.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace AIUsageTracker.Infrastructure.Providers;
+
+/// <summary>
+/// Usage provider for the xAI Grok CLI (SuperGrok subscription). Reads the weekly credit
+/// usage from the CLI's billing endpoint using the OIDC session stored in the CLI's own
+/// auth file (<c>~/.grok/auth.json</c>).
+/// </summary>
+public class GrokProvider : ProviderBase
+{
+    private const string BillingEndpoint = "https://cli-chat-proxy.grok.com/v1/billing?format=credits";
+    private const string AuthScopePrefix = "https://auth.x.ai::";
+
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<GrokProvider> _logger;
+    private readonly string? _authFilePath;
+
+    public GrokProvider(HttpClient httpClient, ILogger<GrokProvider> logger, string? authFilePath = null)
+    {
+        this._httpClient = httpClient;
+        this._logger = logger;
+        this._authFilePath = authFilePath;
+    }
+
+    public static ProviderDefinition StaticDefinition { get; } = new(
+        "grok",
+        "Grok CLI",
+        PlanType.Coding,
+        isQuotaBased: true)
+    {
+        AdditionalHandledProviderIds = new[] { "grok-cli" },
+        SettingsMode = ProviderSettingsMode.SessionAuthStatus,
+        SessionStatusLabel = "Grok CLI",
+        IconAssetName = "grok",
+        BadgeColorHex = "#1A1A1A",
+        BadgeInitial = "G",
+        AuthIdentityCandidatePathTemplates = new[]
+        {
+            "%USERPROFILE%\\.grok\\auth.json",
+        },
+        SessionAuthFileSchemas = new[]
+        {
+            // The Grok CLI stores sessions under an issuer-scoped root property whose name
+            // embeds the OIDC client id ("https://auth.x.ai::<client-id>"), so the schema
+            // uses a wildcard root that matches any client id.
+            new ProviderAuthFileSchema("https://auth.x.ai::*", "key", "user_id"),
+        },
+        QuotaWindows = new QuotaWindowDefinition[]
+        {
+            new(WindowKind.Rolling, "Weekly", PeriodDuration: TimeSpan.FromDays(7)),
+        },
+    };
+
+    public override ProviderDefinition Definition => StaticDefinition;
+
+    public override string ProviderId => StaticDefinition.ProviderId;
+
+    public override async Task<IEnumerable<ProviderUsage>> GetUsageAsync(
+        ProviderConfig config,
+        Action<ProviderUsage>? progressCallback = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        // The Grok CLI rotates its OIDC access token every few hours and rewrites the auth
+        // file on each run, so prefer a live read over the token captured at discovery time.
+        var token = await this.LoadNativeTokenAsync(cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            token = config.ApiKey;
+        }
+
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return new[]
+            {
+                this.CreateUnavailableUsage(
+                    "Grok CLI session missing - run grok login",
+                    authSource: config.AuthSource,
+                    state: ProviderUsageState.Missing),
+            };
+        }
+
+        var effectiveConfig = string.Equals(token, config.ApiKey, StringComparison.Ordinal)
+            ? config
+            : new ProviderConfig
+            {
+                ProviderId = config.ProviderId,
+                ApiKey = token,
+                AuthSource = config.AuthSource ?? "Grok CLI session auth",
+                Description = config.Description,
+            };
+
+        var fetchResult = await this.FetchJsonAsync<GrokBillingResponse>(
+            BillingEndpoint,
+            effectiveConfig,
+            this._httpClient,
+            this._logger,
+            cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!fetchResult.IsSuccess)
+        {
+            return new[] { fetchResult.FailureUsage! };
+        }
+
+        var data = fetchResult.Data!;
+        var providerLabel = ProviderMetadataCatalog.GetConfiguredDisplayName(config.ProviderId);
+
+        if (data.Config == null)
+        {
+            return new[] { this.CreateUnavailableUsage("No billing data available", authSource: config.AuthSource) };
+        }
+
+        return this.BuildUsageCards(data.Config, fetchResult.RawContent, fetchResult.HttpStatus, config.AuthSource, providerLabel);
+    }
+
+    private IEnumerable<ProviderUsage> BuildUsageCards(
+        GrokBillingConfig billing,
+        string rawJson,
+        int httpStatus,
+        string? authSource,
+        string providerLabel)
+    {
+        var cards = new List<ProviderUsage>();
+
+        var resetTime = TryReadIsoTimestamp(billing.CurrentPeriod?.End ?? billing.BillingPeriodEnd, out var parsedReset)
+            ? (DateTime?)parsedReset.ToLocalTime()
+            : null;
+
+        if (billing.CreditUsagePercent.HasValue)
+        {
+            var usedPercent = UsageMath.ClampPercent(billing.CreditUsagePercent.Value);
+            var remainingPercent = Math.Max(0.0, 100.0 - usedPercent);
+            var productSummary = FormatProductSummary(billing.ProductUsage);
+
+            var description = $"{remainingPercent.ToString("F0", CultureInfo.InvariantCulture)}% weekly credits remaining";
+            if (!string.IsNullOrEmpty(productSummary))
+            {
+                description += $" | {productSummary}";
+            }
+
+            if (resetTime.HasValue)
+            {
+                description += $" | resets {resetTime.Value.ToString("MMM dd HH:mm", CultureInfo.InvariantCulture)}";
+            }
+
+            cards.Add(new QuotaProviderUsage
+            {
+                ProviderId = this.ProviderId,
+                ProviderName = providerLabel,
+                Name = "Weekly",
+                CardId = "weekly-credits",
+                GroupId = this.ProviderId,
+                IsAvailable = true,
+                UsedPercent = usedPercent,
+                WindowKind = WindowKind.Rolling,
+                PeriodDuration = TimeSpan.FromDays(7),
+                NextResetTime = resetTime,
+                PlanType = this.Definition.PlanType,
+                IsQuotaBased = this.Definition.IsQuotaBased,
+                Description = description,
+                RawJson = rawJson,
+                HttpStatus = httpStatus,
+            });
+        }
+
+        if (billing.OnDemandCap is { Val: > 0 })
+        {
+            var cap = billing.OnDemandCap.Val;
+            var used = billing.OnDemandUsed?.Val ?? 0;
+            var onDemandPercent = UsageMath.ClampPercent(cap > 0 ? used * 100.0 / cap : 0);
+
+            cards.Add(new QuotaProviderUsage
+            {
+                ProviderId = this.ProviderId,
+                ProviderName = providerLabel,
+                Name = "On-Demand",
+                CardId = "on-demand-credits",
+                GroupId = this.ProviderId,
+                IsAvailable = true,
+                UsedPercent = onDemandPercent,
+                RequestsUsed = used,
+                RequestsAvailable = cap,
+                DisplayAsFraction = true,
+                PlanType = this.Definition.PlanType,
+                IsQuotaBased = this.Definition.IsQuotaBased,
+                Description = $"{(cap - used).ToString(CultureInfo.InvariantCulture)} / {cap.ToString(CultureInfo.InvariantCulture)} on-demand credits remaining",
+                RawJson = rawJson,
+                HttpStatus = httpStatus,
+            });
+        }
+
+        if (cards.Count == 0)
+        {
+            cards.Add(new StatusProviderUsage
+            {
+                ProviderId = this.ProviderId,
+                ProviderName = providerLabel,
+                IsAvailable = true,
+                Description = "Connected (no billing data reported)",
+                RawJson = rawJson,
+                HttpStatus = httpStatus,
+            });
+        }
+
+        return cards;
+    }
+
+    private static string? FormatProductSummary(List<GrokProductUsage>? productUsage)
+    {
+        if (productUsage is not { Count: > 0 })
+        {
+            return null;
+        }
+
+        var parts = productUsage
+            .Where(product => !string.IsNullOrWhiteSpace(product.Product))
+            .Select(product => $"{product.Product} {product.UsagePercent?.ToString("F0", CultureInfo.InvariantCulture) ?? "?"}%");
+        var summary = string.Join(", ", parts);
+        return string.IsNullOrEmpty(summary) ? null : summary;
+    }
+
+    private async Task<string?> LoadNativeTokenAsync(CancellationToken cancellationToken)
+    {
+        foreach (var path in this.GetAuthFileCandidates())
+        {
+            if (!File.Exists(path))
+            {
+                continue;
+            }
+
+            try
+            {
+                var json = await File.ReadAllTextAsync(path, cancellationToken).ConfigureAwait(false);
+                using var doc = JsonDocument.Parse(json);
+                foreach (var scope in doc.RootElement.EnumerateObject())
+                {
+                    if (!scope.Name.StartsWith(AuthScopePrefix, StringComparison.Ordinal) ||
+                        scope.Value.ValueKind != JsonValueKind.Object)
+                    {
+                        continue;
+                    }
+
+                    if (scope.Value.TryGetProperty("key", out var keyElement) &&
+                        keyElement.ValueKind == JsonValueKind.String)
+                    {
+                        var key = keyElement.GetString();
+                        if (!string.IsNullOrWhiteSpace(key))
+                        {
+                            return key;
+                        }
+                    }
+                }
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException)
+            {
+                this._logger.LogDebug(ex, "Failed to read Grok auth file at {Path}", path);
+            }
+        }
+
+        return null;
+    }
+
+    private IEnumerable<string> GetAuthFileCandidates()
+    {
+        if (!string.IsNullOrWhiteSpace(this._authFilePath))
+        {
+            yield return this._authFilePath;
+            yield break;
+        }
+
+        var discoverySpec = StaticDefinition.CreateAuthDiscoverySpec();
+        var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        foreach (var path in ProviderAuthCandidatePathResolver.ResolvePaths(discoverySpec, userProfile))
+        {
+            yield return path;
+        }
+    }
+
+    private static bool TryReadIsoTimestamp(string? raw, out DateTime timestamp)
+    {
+        timestamp = default;
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return false;
+        }
+
+        if (DateTime.TryParse(raw, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var parsed))
+        {
+            timestamp = DateTime.SpecifyKind(parsed, DateTimeKind.Utc);
+            return true;
+        }
+
+        return false;
+    }
+
+    private sealed class GrokBillingResponse
+    {
+        [JsonPropertyName("config")]
+        public GrokBillingConfig? Config { get; set; }
+    }
+
+    private sealed class GrokBillingConfig
+    {
+        [JsonPropertyName("currentPeriod")]
+        public GrokUsagePeriod? CurrentPeriod { get; set; }
+
+        [JsonPropertyName("creditUsagePercent")]
+        public double? CreditUsagePercent { get; set; }
+
+        [JsonPropertyName("onDemandCap")]
+        public GrokCreditValue? OnDemandCap { get; set; }
+
+        [JsonPropertyName("onDemandUsed")]
+        public GrokCreditValue? OnDemandUsed { get; set; }
+
+        [JsonPropertyName("prepaidBalance")]
+        public GrokCreditValue? PrepaidBalance { get; set; }
+
+        [JsonPropertyName("productUsage")]
+        public List<GrokProductUsage>? ProductUsage { get; set; }
+
+        [JsonPropertyName("billingPeriodEnd")]
+        public string? BillingPeriodEnd { get; set; }
+
+        [JsonPropertyName("subscriptionTier")]
+        public string? SubscriptionTier { get; set; }
+    }
+
+    private sealed class GrokUsagePeriod
+    {
+        [JsonPropertyName("type")]
+        public string? Type { get; set; }
+
+        [JsonPropertyName("start")]
+        public string? Start { get; set; }
+
+        [JsonPropertyName("end")]
+        public string? End { get; set; }
+    }
+
+    // The billing API returns credit values as {"val": <number>}; string tolerance mirrors
+    // the defensive parsing used for the Kimi API.
+    [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
+    private sealed class GrokCreditValue
+    {
+        [JsonPropertyName("val")]
+        public long Val { get; set; }
+    }
+
+    private sealed class GrokProductUsage
+    {
+        [JsonPropertyName("product")]
+        public string? Product { get; set; }
+
+        [JsonPropertyName("usagePercent")]
+        public double? UsagePercent { get; set; }
+    }
+}

--- a/AIUsageTracker.Infrastructure/Providers/GrokProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/GrokProvider.cs
@@ -142,10 +142,10 @@ public class GrokProvider : ProviderBase
 
         if (data.Config == null)
         {
-            return new[] { this.CreateUnavailableUsage("No billing data available", authSource: config.AuthSource) };
+            return new[] { this.CreateUnavailableUsage("No billing data available", authSource: effectiveConfig.AuthSource) };
         }
 
-        return this.BuildUsageCards(data.Config, fetchResult.RawContent, fetchResult.HttpStatus, config.AuthSource, providerLabel);
+        return this.BuildUsageCards(data.Config, fetchResult.RawContent, fetchResult.HttpStatus, effectiveConfig.AuthSource, providerLabel);
     }
 
     private IEnumerable<ProviderUsage> BuildUsageCards(

--- a/AIUsageTracker.Infrastructure/Providers/GrokProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/GrokProvider.cs
@@ -20,7 +20,6 @@ namespace AIUsageTracker.Infrastructure.Providers;
 public class GrokProvider : ProviderBase
 {
     private const string BillingEndpoint = "https://cli-chat-proxy.grok.com/v1/billing?format=credits";
-    private const string AuthScopePrefix = "https://auth.x.ai::";
 
     private readonly HttpClient _httpClient;
     private readonly ILogger<GrokProvider> _logger;
@@ -181,6 +180,7 @@ public class GrokProvider : ProviderBase
             var cap = billing.OnDemandCap.Val;
             var used = billing.OnDemandUsed?.Val ?? 0;
             var onDemandPercent = UsageMath.ClampPercent(cap > 0 ? used * 100.0 / cap : 0);
+            var remaining = Math.Max(0, cap - used);
 
             cards.Add(new QuotaProviderUsage
             {
@@ -196,7 +196,7 @@ public class GrokProvider : ProviderBase
                 DisplayAsFraction = true,
                 PlanType = this.Definition.PlanType,
                 IsQuotaBased = this.Definition.IsQuotaBased,
-                Description = $"{(cap - used).ToString(CultureInfo.InvariantCulture)} / {cap.ToString(CultureInfo.InvariantCulture)} on-demand credits remaining",
+                Description = $"{remaining.ToString(CultureInfo.InvariantCulture)} / {cap.ToString(CultureInfo.InvariantCulture)} on-demand credits remaining",
                 RawJson = rawJson,
                 HttpStatus = httpStatus,
             });
@@ -245,23 +245,10 @@ public class GrokProvider : ProviderBase
             {
                 var json = await File.ReadAllTextAsync(path, cancellationToken).ConfigureAwait(false);
                 using var doc = JsonDocument.Parse(json);
-                foreach (var scope in doc.RootElement.EnumerateObject())
+                var authData = ProviderAuthFileSchemaReader.Read(doc.RootElement, StaticDefinition.SessionAuthFileSchemas);
+                if (authData != null)
                 {
-                    if (!scope.Name.StartsWith(AuthScopePrefix, StringComparison.Ordinal) ||
-                        scope.Value.ValueKind != JsonValueKind.Object)
-                    {
-                        continue;
-                    }
-
-                    if (scope.Value.TryGetProperty("key", out var keyElement) &&
-                        keyElement.ValueKind == JsonValueKind.String)
-                    {
-                        var key = keyElement.GetString();
-                        if (!string.IsNullOrWhiteSpace(key))
-                        {
-                            return key;
-                        }
-                    }
+                    return authData.AccessToken;
                 }
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException)

--- a/AIUsageTracker.Infrastructure/Providers/GrokProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/GrokProvider.cs
@@ -19,6 +19,9 @@ namespace AIUsageTracker.Infrastructure.Providers;
 /// </summary>
 public class GrokProvider : ProviderBase
 {
+    private const string GrokProviderId = "grok";
+    private const string WeeklyCardId = "weekly-credits";
+    private const string OnDemandCardId = "on-demand-credits";
     private const string BillingEndpoint = "https://cli-chat-proxy.grok.com/v1/billing?format=credits";
 
     private readonly HttpClient _httpClient;
@@ -33,11 +36,13 @@ public class GrokProvider : ProviderBase
     }
 
     public static ProviderDefinition StaticDefinition { get; } = new(
-        "grok",
+        GrokProviderId,
         "Grok CLI",
         PlanType.Coding,
         isQuotaBased: true)
     {
+        FamilyMode = ProviderFamilyMode.FlatWindowCards,
+        FlatCardShowProviderPrefix = true,
         AdditionalHandledProviderIds = new[] { "grok-cli" },
         SettingsMode = ProviderSettingsMode.SessionAuthStatus,
         SessionStatusLabel = "Grok CLI",
@@ -57,7 +62,18 @@ public class GrokProvider : ProviderBase
         },
         QuotaWindows = new QuotaWindowDefinition[]
         {
-            new(WindowKind.Rolling, "Weekly", PeriodDuration: TimeSpan.FromDays(7)),
+            new(
+                WindowKind.Rolling,
+                "Weekly",
+                ChildProviderId: GrokProviderId + "." + WeeklyCardId,
+                SettingsLabel: "Weekly credits",
+                PeriodDuration: TimeSpan.FromDays(7)),
+            new(
+                WindowKind.None,
+                "On-Demand",
+                ChildProviderId: GrokProviderId + "." + OnDemandCardId,
+                SettingsLabel: "On-Demand credits",
+                DisplayAsFraction: true),
         },
     };
 
@@ -97,8 +113,15 @@ public class GrokProvider : ProviderBase
             {
                 ProviderId = config.ProviderId,
                 ApiKey = token,
-                AuthSource = config.AuthSource ?? "Grok CLI session auth",
+                Limit = config.Limit,
+                BaseUrl = config.BaseUrl,
+                ShowInTray = config.ShowInTray,
+                EnableNotifications = config.EnableNotifications,
+                EnabledSubTrays = config.EnabledSubTrays,
+                AuthSource = string.IsNullOrWhiteSpace(config.AuthSource) ? "Grok CLI session auth" : config.AuthSource,
                 Description = config.Description,
+                Models = config.Models,
+                ShowCachedModelsWhenOffline = config.ShowCachedModelsWhenOffline,
             };
 
         var fetchResult = await this.FetchJsonAsync<GrokBillingResponse>(
@@ -135,7 +158,7 @@ public class GrokProvider : ProviderBase
         var cards = new List<ProviderUsage>();
 
         var resetTime = TryReadIsoTimestamp(billing.CurrentPeriod?.End ?? billing.BillingPeriodEnd, out var parsedReset)
-            ? (DateTime?)parsedReset.ToLocalTime()
+            ? (DateTime?)parsedReset
             : null;
 
         if (billing.CreditUsagePercent.HasValue)
@@ -152,15 +175,15 @@ public class GrokProvider : ProviderBase
 
             if (resetTime.HasValue)
             {
-                description += $" | resets {resetTime.Value.ToString("MMM dd HH:mm", CultureInfo.InvariantCulture)}";
+                description += $" | resets {resetTime.Value.ToLocalTime().ToString("MMM dd HH:mm", CultureInfo.InvariantCulture)}";
             }
 
-            cards.Add(new QuotaProviderUsage
+            cards.Add(new WindowedProviderUsage
             {
                 ProviderId = this.ProviderId,
                 ProviderName = providerLabel,
                 Name = "Weekly",
-                CardId = "weekly-credits",
+                CardId = WeeklyCardId,
                 GroupId = this.ProviderId,
                 IsAvailable = true,
                 UsedPercent = usedPercent,
@@ -183,12 +206,12 @@ public class GrokProvider : ProviderBase
             var onDemandPercent = UsageMath.ClampPercent(cap > 0 ? used * 100.0 / cap : 0);
             var remaining = Math.Max(0, cap - used);
 
-            cards.Add(new QuotaProviderUsage
+            cards.Add(new WindowedProviderUsage
             {
                 ProviderId = this.ProviderId,
                 ProviderName = providerLabel,
                 Name = "On-Demand",
-                CardId = "on-demand-credits",
+                CardId = OnDemandCardId,
                 GroupId = this.ProviderId,
                 IsAvailable = true,
                 UsedPercent = onDemandPercent,
@@ -212,6 +235,7 @@ public class GrokProvider : ProviderBase
                 ProviderName = providerLabel,
                 IsAvailable = true,
                 Description = "Connected (no billing data reported)",
+                AuthSource = authSource ?? string.Empty,
                 RawJson = rawJson,
                 HttpStatus = httpStatus,
             });
@@ -288,7 +312,7 @@ public class GrokProvider : ProviderBase
 
         if (DateTime.TryParse(raw, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var parsed))
         {
-            timestamp = DateTime.SpecifyKind(parsed, DateTimeKind.Utc);
+            timestamp = parsed;
             return true;
         }
 
@@ -324,12 +348,6 @@ public class GrokProvider : ProviderBase
 
     private sealed class GrokUsagePeriod
     {
-        [JsonPropertyName("type")]
-        public string? Type { get; set; }
-
-        [JsonPropertyName("start")]
-        public string? Start { get; set; }
-
         [JsonPropertyName("end")]
         public string? End { get; set; }
     }
@@ -340,7 +358,7 @@ public class GrokProvider : ProviderBase
     private sealed class GrokCreditValue
     {
         [JsonPropertyName("val")]
-        public long Val { get; set; }
+        public double Val { get; set; }
     }
 
     private sealed class GrokProductUsage

--- a/AIUsageTracker.Infrastructure/Providers/GrokProvider.cs
+++ b/AIUsageTracker.Infrastructure/Providers/GrokProvider.cs
@@ -170,6 +170,7 @@ public class GrokProvider : ProviderBase
                 PlanType = this.Definition.PlanType,
                 IsQuotaBased = this.Definition.IsQuotaBased,
                 Description = description,
+                AuthSource = authSource ?? string.Empty,
                 RawJson = rawJson,
                 HttpStatus = httpStatus,
             });
@@ -197,6 +198,7 @@ public class GrokProvider : ProviderBase
                 PlanType = this.Definition.PlanType,
                 IsQuotaBased = this.Definition.IsQuotaBased,
                 Description = $"{remaining.ToString(CultureInfo.InvariantCulture)} / {cap.ToString(CultureInfo.InvariantCulture)} on-demand credits remaining",
+                AuthSource = authSource ?? string.Empty,
                 RawJson = rawJson,
                 HttpStatus = httpStatus,
             });
@@ -313,17 +315,11 @@ public class GrokProvider : ProviderBase
         [JsonPropertyName("onDemandUsed")]
         public GrokCreditValue? OnDemandUsed { get; set; }
 
-        [JsonPropertyName("prepaidBalance")]
-        public GrokCreditValue? PrepaidBalance { get; set; }
-
         [JsonPropertyName("productUsage")]
         public List<GrokProductUsage>? ProductUsage { get; set; }
 
         [JsonPropertyName("billingPeriodEnd")]
         public string? BillingPeriodEnd { get; set; }
-
-        [JsonPropertyName("subscriptionTier")]
-        public string? SubscriptionTier { get; set; }
     }
 
     private sealed class GrokUsagePeriod

--- a/AIUsageTracker.Monitor/Services/GroupedUsageProjectionService.cs
+++ b/AIUsageTracker.Monitor/Services/GroupedUsageProjectionService.cs
@@ -171,6 +171,8 @@ public static class GroupedUsageProjectionService
                     ModelName = GetName(u) ?? string.Empty,
                     UsedPercentage = usedPercentage,
                     RemainingPercentage = remainingPercentage,
+                    RequestsUsed = q?.RequestsUsed ?? 0,
+                    RequestsAvailable = q?.RequestsAvailable ?? 0,
                     NextResetTime = q?.NextResetTime,
                     ResetCreditsAvailable = q?.ResetCreditsAvailable,
                     ResetCreditExpirationsUtc = q?.ResetCreditExpirationsUtc,

--- a/AIUsageTracker.Tests/Infrastructure/Configuration/ProviderSessionTokenResolverTests.cs
+++ b/AIUsageTracker.Tests/Infrastructure/Configuration/ProviderSessionTokenResolverTests.cs
@@ -79,9 +79,9 @@ public class ProviderSessionTokenResolverTests
 
             // Mirrors the Grok CLI auth store: the root property embeds a dynamic OIDC
             // client id and therefore cannot be matched exactly or dot-navigated.
-            var authContent = new Dictionary<string, object>
+            var authContent = new Dictionary<string, object>(StringComparer.Ordinal)
             {
-                ["https://auth.x.ai::b1a00492-073a-47ea-816f-4c329264a828"] = new Dictionary<string, object?>
+                ["https://auth.x.ai::b1a00492-073a-47ea-816f-4c329264a828"] = new Dictionary<string, object?>(StringComparer.Ordinal)
                 {
                     ["key"] = "grok-access-token",
                     ["user_id"] = "user-1",
@@ -121,6 +121,64 @@ public class ProviderSessionTokenResolverTests
             Assert.Equal("grok-access-token", resolved.ApiKey);
             Assert.Equal("Grok CLI auth session", resolved.Description);
             Assert.Contains(authFilePath, resolved.AuthSource, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            TestTempPaths.CleanupPath(testRoot);
+        }
+    }
+
+    [Fact]
+    public async Task TryResolveAsync_WildcardSchemaRoot_SkipsMatchingEntryWithoutTokenAsync()
+    {
+        var testRoot = TestTempPaths.CreateDirectory("provider-session-token-resolver-wildcard-multiple");
+
+        try
+        {
+            var authFilePath = Path.Combine(testRoot, "auth.json");
+            var authContent = new Dictionary<string, object>(StringComparer.Ordinal)
+            {
+                ["https://auth.x.ai::stale-client"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["key"] = string.Empty,
+                    ["user_id"] = "stale-user",
+                },
+                ["https://auth.x.ai::active-client"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["key"] = "active-grok-token",
+                    ["user_id"] = "active-user",
+                },
+            };
+
+            await File.WriteAllTextAsync(authFilePath, JsonSerializer.Serialize(authContent));
+
+            var pathProvider = new Mock<IAppPathProvider>();
+            pathProvider.Setup(provider => provider.GetUserProfileRoot()).Returns(testRoot);
+
+            var definition = new ProviderDefinition(
+                "grok",
+                "Grok CLI",
+                PlanType.Coding,
+                isQuotaBased: true)
+            {
+                AuthIdentityCandidatePathTemplates = new[] { authFilePath },
+                SessionAuthFileSchemas = new[]
+                {
+                    new ProviderAuthFileSchema("https://auth.x.ai::*", "key", "user_id"),
+                },
+            };
+
+            var resolver = new ProviderSessionTokenResolver(
+                definition.CreateAuthDiscoverySpec(),
+                "Grok CLI auth session",
+                "Grok session",
+                NullLogger<TokenDiscoveryService>.Instance,
+                pathProvider.Object);
+
+            var resolved = await resolver.TryResolveAsync();
+
+            Assert.NotNull(resolved);
+            Assert.Equal("active-grok-token", resolved!.ApiKey);
         }
         finally
         {

--- a/AIUsageTracker.Tests/Infrastructure/Configuration/ProviderSessionTokenResolverTests.cs
+++ b/AIUsageTracker.Tests/Infrastructure/Configuration/ProviderSessionTokenResolverTests.cs
@@ -127,4 +127,49 @@ public class ProviderSessionTokenResolverTests
             TestTempPaths.CleanupPath(testRoot);
         }
     }
+
+    [Theory]
+    [InlineData("null")]
+    [InlineData("[]")]
+    public async Task TryResolveAsync_NonObjectAuthRoot_ReturnsNullAsync(string authContent)
+    {
+        var testRoot = TestTempPaths.CreateDirectory("provider-session-token-resolver-non-object");
+
+        try
+        {
+            var authFilePath = Path.Combine(testRoot, "auth.json");
+            await File.WriteAllTextAsync(authFilePath, authContent);
+
+            var pathProvider = new Mock<IAppPathProvider>();
+            pathProvider.Setup(provider => provider.GetUserProfileRoot()).Returns(testRoot);
+
+            var definition = new ProviderDefinition(
+                "grok",
+                "Grok CLI",
+                PlanType.Coding,
+                isQuotaBased: true)
+            {
+                AuthIdentityCandidatePathTemplates = new[] { authFilePath },
+                SessionAuthFileSchemas = new[]
+                {
+                    new ProviderAuthFileSchema("https://auth.x.ai::*", "key", "user_id"),
+                },
+            };
+
+            var resolver = new ProviderSessionTokenResolver(
+                definition.CreateAuthDiscoverySpec(),
+                "Grok CLI auth session",
+                "Grok session",
+                NullLogger<TokenDiscoveryService>.Instance,
+                pathProvider.Object);
+
+            var resolved = await resolver.TryResolveAsync();
+
+            Assert.Null(resolved);
+        }
+        finally
+        {
+            TestTempPaths.CleanupPath(testRoot);
+        }
+    }
 }

--- a/AIUsageTracker.Tests/Infrastructure/Configuration/ProviderSessionTokenResolverTests.cs
+++ b/AIUsageTracker.Tests/Infrastructure/Configuration/ProviderSessionTokenResolverTests.cs
@@ -67,4 +67,64 @@ public class ProviderSessionTokenResolverTests
             TestTempPaths.CleanupPath(testRoot);
         }
     }
+
+    [Fact]
+    public async Task TryResolveAsync_ReadsAccessTokenFromWildcardSchemaRootAsync()
+    {
+        var testRoot = TestTempPaths.CreateDirectory("provider-session-token-resolver-wildcard");
+
+        try
+        {
+            var authFilePath = Path.Combine(testRoot, "auth.json");
+
+            // Mirrors the Grok CLI auth store: the root property embeds a dynamic OIDC
+            // client id and therefore cannot be matched exactly or dot-navigated.
+            var authContent = new Dictionary<string, object>
+            {
+                ["https://auth.x.ai::b1a00492-073a-47ea-816f-4c329264a828"] = new Dictionary<string, object?>
+                {
+                    ["key"] = "grok-access-token",
+                    ["user_id"] = "user-1",
+                    ["auth_mode"] = "oidc",
+                },
+            };
+
+            await File.WriteAllTextAsync(authFilePath, JsonSerializer.Serialize(authContent));
+
+            var pathProvider = new Mock<IAppPathProvider>();
+            pathProvider.Setup(provider => provider.GetUserProfileRoot()).Returns(testRoot);
+
+            var definition = new ProviderDefinition(
+                "grok",
+                "Grok CLI",
+                PlanType.Coding,
+                isQuotaBased: true)
+            {
+                AuthIdentityCandidatePathTemplates = new[] { authFilePath },
+                SessionAuthFileSchemas = new[]
+                {
+                    new ProviderAuthFileSchema("https://auth.x.ai::*", "key", "user_id"),
+                },
+            };
+
+            var resolver = new ProviderSessionTokenResolver(
+                definition.CreateAuthDiscoverySpec(),
+                "Grok CLI auth session",
+                "Grok session",
+                NullLogger<TokenDiscoveryService>.Instance,
+                pathProvider.Object);
+
+            var resolved = await resolver.TryResolveAsync();
+
+            Assert.NotNull(resolved);
+            Assert.Equal("grok", resolved!.ProviderId);
+            Assert.Equal("grok-access-token", resolved.ApiKey);
+            Assert.Equal("Grok CLI auth session", resolved.Description);
+            Assert.Contains(authFilePath, resolved.AuthSource, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            TestTempPaths.CleanupPath(testRoot);
+        }
+    }
 }

--- a/AIUsageTracker.Tests/Infrastructure/ProviderMetadataCatalogTests.cs
+++ b/AIUsageTracker.Tests/Infrastructure/ProviderMetadataCatalogTests.cs
@@ -46,6 +46,7 @@ public class ProviderMetadataCatalogTests
     [InlineData("minimax-coding-plan", "minimax-coding-plan", "Minimax.io Coding Plan")]
     [InlineData("opencode-go", "opencode-go", "OpenCode Go")]
     [InlineData("zai", "zai-coding-plan", "Z.AI")]
+    [InlineData("grok-cli", "grok", "Grok CLI")]
     public void Find_UsesProviderDefinitionsForAliases(string providerId, string expectedDefinitionId, string expectedDisplayName)
     {
         var definition = ProviderMetadataCatalog.Find(providerId);
@@ -504,6 +505,17 @@ public class ProviderMetadataCatalogTests
             var definition = Assert.IsType<ProviderDefinition>(ProviderMetadataCatalog.Find(providerId));
             Assert.Equal(ProviderSettingsMode.StandardApiKey, definition.SettingsMode);
         }
+    }
+
+    [Fact]
+    public void Find_ExposesGrokSessionAuthDiscoveryMetadata()
+    {
+        var definition = ProviderMetadataCatalog.Find("grok");
+
+        Assert.NotNull(definition);
+        Assert.Contains("%USERPROFILE%\\.grok\\auth.json", definition!.AuthIdentityCandidatePathTemplates);
+        Assert.Contains(definition.SessionAuthFileSchemas, schema => string.Equals(schema.RootProperty, "https://auth.x.ai::*", StringComparison.Ordinal) &&
+            string.Equals(schema.AccessTokenProperty, "key", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/AIUsageTracker.Tests/Infrastructure/Providers/GrokProviderTests.cs
+++ b/AIUsageTracker.Tests/Infrastructure/Providers/GrokProviderTests.cs
@@ -116,6 +116,49 @@ public class GrokProviderTests : HttpProviderTestBase<GrokProvider>
     }
 
     [Fact]
+    public async Task GetUsageAsync_NativeSessionToken_DefaultsAuthSourceAsync()
+    {
+        // Arrange
+        var testRoot = TestTempPaths.CreateDirectory("grok-provider-native-auth-source");
+
+        try
+        {
+            var authFilePath = Path.Combine(testRoot, "auth.json");
+            var authContent = new Dictionary<string, object>(StringComparer.Ordinal)
+            {
+                ["https://auth.x.ai::test-client"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["key"] = "native-grok-token",
+                    ["user_id"] = "user-1",
+                },
+            };
+            await File.WriteAllTextAsync(authFilePath, JsonSerializer.Serialize(authContent));
+
+            var provider = new GrokProvider(this.HttpClient, this.Logger.Object, authFilePath);
+            this.Config.AuthSource = string.Empty;
+            this.SetupHttpResponse(BillingEndpoint, new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(JsonSerializer.Serialize(new
+                {
+                    config = new { creditUsagePercent = 10.0 },
+                })),
+            });
+
+            // Act
+            var result = await provider.GetUsageAsync(this.Config);
+
+            // Assert
+            var usage = Assert.IsType<WindowedProviderUsage>(Assert.Single(result));
+            Assert.Equal("Grok CLI session auth", usage.AuthSource);
+        }
+        finally
+        {
+            TestTempPaths.CleanupPath(testRoot);
+        }
+    }
+
+    [Fact]
     public async Task GetUsageAsync_OnDemandCap_AddsOnDemandCardAsync()
     {
         // Arrange

--- a/AIUsageTracker.Tests/Infrastructure/Providers/GrokProviderTests.cs
+++ b/AIUsageTracker.Tests/Infrastructure/Providers/GrokProviderTests.cs
@@ -28,6 +28,48 @@ public class GrokProviderTests : HttpProviderTestBase<GrokProvider>
     }
 
     [Fact]
+    public async Task GetUsageAsync_MissingSession_ReturnsMissingStatusAsync()
+    {
+        // Arrange
+        var config = new ProviderConfig
+        {
+            ProviderId = "grok",
+            AuthSource = "Grok CLI auth session",
+        };
+        var authFilePath = Path.Combine(Path.GetTempPath(), $"missing-grok-auth-{Guid.NewGuid():N}.json");
+        var provider = new GrokProvider(this.HttpClient, this.Logger.Object, authFilePath);
+
+        // Act
+        var result = await provider.GetUsageAsync(config);
+
+        // Assert
+        var usage = Assert.IsType<StatusProviderUsage>(Assert.Single(result));
+        Assert.False(usage.IsAvailable);
+        Assert.Equal(ProviderUsageState.Missing, usage.State);
+        Assert.Equal("Grok CLI session missing - run grok login", usage.Description);
+        Assert.Equal("Grok CLI auth session", usage.AuthSource);
+    }
+
+    [Fact]
+    public void Definition_DeclaresFlatWeeklyAndOnDemandCards()
+    {
+        var definition = GrokProvider.StaticDefinition;
+
+        Assert.Equal(ProviderFamilyMode.FlatWindowCards, definition.FamilyMode);
+        Assert.True(definition.FlatCardShowProviderPrefix);
+
+        var weekly = Assert.Single(definition.QuotaWindows, window =>
+            string.Equals(window.ChildProviderId, "grok.weekly-credits", StringComparison.Ordinal));
+        Assert.Equal(WindowKind.Rolling, weekly.Kind);
+        Assert.Equal(TimeSpan.FromDays(7), weekly.PeriodDuration);
+
+        var onDemand = Assert.Single(definition.QuotaWindows, window =>
+            string.Equals(window.ChildProviderId, "grok.on-demand-credits", StringComparison.Ordinal));
+        Assert.Equal(WindowKind.None, onDemand.Kind);
+        Assert.Null(onDemand.PeriodDuration);
+    }
+
+    [Fact]
     public async Task GetUsageAsync_ValidResponse_MapsWeeklyCreditsCardAsync()
     {
         // Arrange
@@ -59,7 +101,7 @@ public class GrokProviderTests : HttpProviderTestBase<GrokProvider>
         var result = await this._provider.GetUsageAsync(this.Config);
 
         // Assert
-        var usage = result.OfType<QuotaProviderUsage>().Single();
+        var usage = Assert.IsType<WindowedProviderUsage>(Assert.Single(result));
         Assert.Equal("Grok CLI", usage.ProviderName);
         Assert.Equal("Weekly", usage.Name);
         Assert.Equal("weekly-credits", usage.CardId);
@@ -67,6 +109,7 @@ public class GrokProviderTests : HttpProviderTestBase<GrokProvider>
         Assert.Equal(WindowKind.Rolling, usage.WindowKind);
         Assert.Equal(TimeSpan.FromDays(7), usage.PeriodDuration);
         Assert.NotNull(usage.NextResetTime);
+        Assert.Equal(DateTimeKind.Utc, usage.NextResetTime.Value.Kind);
         Assert.True(usage.IsAvailable);
         Assert.Contains("79", usage.Description, StringComparison.Ordinal);
         Assert.Contains("GrokBuild", usage.Description, StringComparison.Ordinal);
@@ -102,7 +145,7 @@ public class GrokProviderTests : HttpProviderTestBase<GrokProvider>
         var result = await this._provider.GetUsageAsync(this.Config);
 
         // Assert
-        var cards = result.OfType<QuotaProviderUsage>().ToList();
+        var cards = result.Select(Assert.IsType<WindowedProviderUsage>).ToList();
         Assert.Equal(2, cards.Count);
 
         var onDemand = cards.Single(card => string.Equals(card.CardId, "on-demand-credits", StringComparison.Ordinal));
@@ -196,6 +239,27 @@ public class GrokProviderTests : HttpProviderTestBase<GrokProvider>
         var usage = result.OfType<StatusProviderUsage>().Single();
         Assert.False(usage.IsAvailable);
         Assert.Contains("No billing data", usage.Description, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetUsageAsync_ConnectedWithoutBillingValues_PreservesAuthSourceAsync()
+    {
+        // Arrange
+        this.Config.AuthSource = "Grok CLI auth session";
+        this.SetupHttpResponse(BillingEndpoint, new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent(JsonSerializer.Serialize(new { config = new { } })),
+        });
+
+        // Act
+        var result = await this._provider.GetUsageAsync(this.Config);
+
+        // Assert
+        var usage = Assert.IsType<StatusProviderUsage>(Assert.Single(result));
+        Assert.True(usage.IsAvailable);
+        Assert.Equal("Connected (no billing data reported)", usage.Description);
+        Assert.Equal("Grok CLI auth session", usage.AuthSource);
     }
 
     [Fact]

--- a/AIUsageTracker.Tests/Infrastructure/Providers/GrokProviderTests.cs
+++ b/AIUsageTracker.Tests/Infrastructure/Providers/GrokProviderTests.cs
@@ -113,6 +113,73 @@ public class GrokProviderTests : HttpProviderTestBase<GrokProvider>
     }
 
     [Fact]
+    public async Task GetUsageAsync_OnDemandUsageExceedsCap_ClampsRemainingCreditsAsync()
+    {
+        // Arrange
+        var responseContent = JsonSerializer.Serialize(new
+        {
+            config = new
+            {
+                creditUsagePercent = 10.0,
+                onDemandCap = new { val = 100 },
+                onDemandUsed = new { val = 125 },
+            },
+        });
+
+        this.SetupHttpResponse(BillingEndpoint, new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent(responseContent),
+        });
+
+        // Act
+        var result = await this._provider.GetUsageAsync(this.Config);
+
+        // Assert
+        var onDemand = result
+            .OfType<QuotaProviderUsage>()
+            .Single(card => string.Equals(card.CardId, "on-demand-credits", StringComparison.Ordinal));
+        Assert.Equal(100.0, onDemand.UsedPercent, 1);
+        Assert.Equal("0 / 100 on-demand credits remaining", onDemand.Description);
+    }
+
+    [Theory]
+    [InlineData("null")]
+    [InlineData("[]")]
+    public async Task GetUsageAsync_NonObjectAuthRoot_FallsBackToConfiguredTokenAsync(string authContent)
+    {
+        // Arrange
+        var testRoot = TestTempPaths.CreateDirectory("grok-provider-non-object-auth");
+
+        try
+        {
+            var authFilePath = Path.Combine(testRoot, "auth.json");
+            await File.WriteAllTextAsync(authFilePath, authContent);
+
+            var provider = new GrokProvider(this.HttpClient, this.Logger.Object, authFilePath);
+            this.SetupHttpResponse(BillingEndpoint, new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(JsonSerializer.Serialize(new
+                {
+                    config = new { creditUsagePercent = 10.0 },
+                })),
+            });
+
+            // Act
+            var result = await provider.GetUsageAsync(this.Config);
+
+            // Assert
+            var usage = result.OfType<QuotaProviderUsage>().Single();
+            Assert.True(usage.IsAvailable);
+        }
+        finally
+        {
+            TestTempPaths.CleanupPath(testRoot);
+        }
+    }
+
+    [Fact]
     public async Task GetUsageAsync_MissingConfig_ReturnsUnavailableAsync()
     {
         // Arrange

--- a/AIUsageTracker.Tests/Infrastructure/Providers/GrokProviderTests.cs
+++ b/AIUsageTracker.Tests/Infrastructure/Providers/GrokProviderTests.cs
@@ -1,0 +1,152 @@
+// <copyright file="GrokProviderTests.cs" company="AIUsageTracker">
+// Copyright (c) AIUsageTracker. All rights reserved.
+// </copyright>
+
+using System.Net;
+using System.Text.Json;
+using AIUsageTracker.Core.Models;
+using AIUsageTracker.Infrastructure.Providers;
+
+namespace AIUsageTracker.Tests.Infrastructure.Providers;
+
+public class GrokProviderTests : HttpProviderTestBase<GrokProvider>
+{
+    private const string BillingEndpoint = "https://cli-chat-proxy.grok.com/v1/billing?format=credits";
+
+    private static readonly string TestToken = Guid.NewGuid().ToString();
+
+    private readonly GrokProvider _provider;
+    private readonly string _authFilePath;
+
+    public GrokProviderTests()
+    {
+        // Point the provider at an auth file that does not exist so tests exercise the
+        // configured token; individual tests may write the file to verify native reads.
+        this._authFilePath = Path.Combine(Path.GetTempPath(), "grok-provider-tests", "auth.json");
+        this._provider = new GrokProvider(this.HttpClient, this.Logger.Object, this._authFilePath);
+        this.Config.ApiKey = TestToken;
+    }
+
+    [Fact]
+    public async Task GetUsageAsync_ValidResponse_MapsWeeklyCreditsCardAsync()
+    {
+        // Arrange
+        var responseContent = JsonSerializer.Serialize(new
+        {
+            config = new
+            {
+                currentPeriod = new
+                {
+                    type = "USAGE_PERIOD_TYPE_WEEKLY",
+                    start = "2026-08-18T20:39:07.120945+00:00",
+                    end = "2026-08-25T20:39:07.120945+00:00",
+                },
+                creditUsagePercent = 21.0,
+                onDemandCap = new { val = 0 },
+                onDemandUsed = new { val = 0 },
+                productUsage = new[] { new { product = "GrokBuild", usagePercent = 21.0 } },
+                prepaidBalance = new { val = 0 },
+            },
+        });
+
+        this.SetupHttpResponse(BillingEndpoint, new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent(responseContent),
+        });
+
+        // Act
+        var result = await this._provider.GetUsageAsync(this.Config);
+
+        // Assert
+        var usage = result.OfType<QuotaProviderUsage>().Single();
+        Assert.Equal("Grok CLI", usage.ProviderName);
+        Assert.Equal("Weekly", usage.Name);
+        Assert.Equal("weekly-credits", usage.CardId);
+        Assert.Equal(21.0, usage.UsedPercent, 1);
+        Assert.Equal(WindowKind.Rolling, usage.WindowKind);
+        Assert.Equal(TimeSpan.FromDays(7), usage.PeriodDuration);
+        Assert.NotNull(usage.NextResetTime);
+        Assert.True(usage.IsAvailable);
+        Assert.Contains("79", usage.Description, StringComparison.Ordinal);
+        Assert.Contains("GrokBuild", usage.Description, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetUsageAsync_OnDemandCap_AddsOnDemandCardAsync()
+    {
+        // Arrange
+        var responseContent = JsonSerializer.Serialize(new
+        {
+            config = new
+            {
+                currentPeriod = new
+                {
+                    type = "USAGE_PERIOD_TYPE_WEEKLY",
+                    start = "2026-08-18T20:39:07.120945+00:00",
+                    end = "2026-08-25T20:39:07.120945+00:00",
+                },
+                creditUsagePercent = 10.0,
+                onDemandCap = new { val = 100 },
+                onDemandUsed = new { val = 25 },
+            },
+        });
+
+        this.SetupHttpResponse(BillingEndpoint, new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent(responseContent),
+        });
+
+        // Act
+        var result = await this._provider.GetUsageAsync(this.Config);
+
+        // Assert
+        var cards = result.OfType<QuotaProviderUsage>().ToList();
+        Assert.Equal(2, cards.Count);
+
+        var onDemand = cards.Single(card => string.Equals(card.CardId, "on-demand-credits", StringComparison.Ordinal));
+        Assert.Equal(25.0, onDemand.UsedPercent, 1);
+        Assert.Equal(25, onDemand.RequestsUsed);
+        Assert.Equal(100, onDemand.RequestsAvailable);
+        Assert.True(onDemand.DisplayAsFraction);
+    }
+
+    [Fact]
+    public async Task GetUsageAsync_MissingConfig_ReturnsUnavailableAsync()
+    {
+        // Arrange
+        this.SetupHttpResponse(BillingEndpoint, new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent(JsonSerializer.Serialize(new { config = (object?)null })),
+        });
+
+        // Act
+        var result = await this._provider.GetUsageAsync(this.Config);
+
+        // Assert
+        var usage = result.OfType<StatusProviderUsage>().Single();
+        Assert.False(usage.IsAvailable);
+        Assert.Contains("No billing data", usage.Description, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetUsageAsync_Unauthorized_ReturnsUnavailableAsync()
+    {
+        // Arrange
+        this.SetupHttpResponse(BillingEndpoint, new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.Unauthorized,
+            Content = new StringContent("{\"error\":\"unauthorized\"}"),
+        });
+
+        // Act
+        var result = await this._provider.GetUsageAsync(this.Config);
+
+        // Assert
+        var usage = result.OfType<StatusProviderUsage>().Single();
+        Assert.False(usage.IsAvailable);
+        Assert.Equal(401, usage.HttpStatus);
+    }
+}

--- a/AIUsageTracker.Tests/Services/GroupedUsageProjectionServiceTests.cs
+++ b/AIUsageTracker.Tests/Services/GroupedUsageProjectionServiceTests.cs
@@ -4,6 +4,7 @@
 
 using AIUsageTracker.Core.Models;
 using AIUsageTracker.Monitor.Services;
+using AIUsageTracker.UI.Slim;
 
 namespace AIUsageTracker.Tests.Services;
 
@@ -306,5 +307,70 @@ public sealed class GroupedUsageProjectionServiceTests
         Assert.Equal("Minimax.io Coding Plan", minimaxCoding.ProviderName);
         Assert.Empty(minimaxIo.Models);
         Assert.Empty(minimaxCoding.Models);
+    }
+
+    [Fact]
+    public void Build_GrokFlatWindowCards_PreservesBothCardsThroughSlimAdapter()
+    {
+        var resetTime = new DateTime(2026, 8, 25, 20, 39, 7, DateTimeKind.Utc);
+        var usages = new ProviderUsage[]
+        {
+            new WindowedProviderUsage
+            {
+                ProviderId = "grok",
+                ProviderName = "Grok CLI",
+                CardId = "weekly-credits",
+                GroupId = "grok",
+                Name = "Weekly",
+                WindowKind = WindowKind.Rolling,
+                IsAvailable = true,
+                IsQuotaBased = true,
+                PlanType = PlanType.Coding,
+                UsedPercent = 21,
+                NextResetTime = resetTime,
+                PeriodDuration = TimeSpan.FromDays(7),
+                Description = "79% weekly credits remaining",
+            },
+            new WindowedProviderUsage
+            {
+                ProviderId = "grok",
+                ProviderName = "Grok CLI",
+                CardId = "on-demand-credits",
+                GroupId = "grok",
+                Name = "On-Demand",
+                WindowKind = WindowKind.None,
+                IsAvailable = true,
+                IsQuotaBased = true,
+                PlanType = PlanType.Coding,
+                UsedPercent = 25,
+                RequestsUsed = 25,
+                RequestsAvailable = 100,
+                DisplayAsFraction = true,
+                Description = "75 / 100 on-demand credits remaining",
+            },
+        };
+
+        var snapshot = GroupedUsageProjectionService.Build(usages);
+
+        var provider = Assert.Single(snapshot.Providers);
+        Assert.Equal(2, provider.Models.Count);
+
+        var cards = GroupedUsageDisplayAdapter.Expand(snapshot);
+        Assert.Equal(2, cards.Count);
+
+        var weekly = Assert.Single(cards, card => string.Equals(card.CardId, "weekly-credits", StringComparison.Ordinal));
+        Assert.Equal("Grok CLI (Weekly)", weekly.ProviderName);
+        Assert.Equal(21, weekly.UsedPercent);
+        Assert.Equal(resetTime, weekly.NextResetTime);
+        Assert.Equal(TimeSpan.FromDays(7), weekly.PeriodDuration);
+        Assert.False(weekly.DisplayAsFraction);
+
+        var onDemand = Assert.Single(cards, card => string.Equals(card.CardId, "on-demand-credits", StringComparison.Ordinal));
+        Assert.Equal("Grok CLI (On-Demand)", onDemand.ProviderName);
+        Assert.Equal(25, onDemand.UsedPercent);
+        Assert.Equal(25, onDemand.RequestsUsed);
+        Assert.Equal(100, onDemand.RequestsAvailable);
+        Assert.True(onDemand.DisplayAsFraction);
+        Assert.Null(onDemand.PeriodDuration);
     }
 }

--- a/AIUsageTracker.Tests/Services/UsageDatabasePipelineTests.cs
+++ b/AIUsageTracker.Tests/Services/UsageDatabasePipelineTests.cs
@@ -181,6 +181,62 @@ public sealed class UsageDatabasePipelineTests : IDisposable
     }
 
     [Fact]
+    public async Task Pipeline_GrokCards_PreserveIdentityThroughDatabaseRoundTripAsync()
+    {
+        var db = await this.CreateDatabaseAsync();
+        var fetchedAt = DateTime.UtcNow.AddMinutes(-1);
+        var usages = new ProviderUsage[]
+        {
+            new WindowedProviderUsage
+            {
+                ProviderId = "grok",
+                ProviderName = "Grok CLI",
+                CardId = "weekly-credits",
+                GroupId = "grok",
+                Name = "Weekly",
+                WindowKind = WindowKind.Rolling,
+                UsedPercent = 21,
+                IsAvailable = true,
+                Description = "79% weekly credits remaining",
+                FetchedAt = fetchedAt,
+            },
+            new WindowedProviderUsage
+            {
+                ProviderId = "grok",
+                ProviderName = "Grok CLI",
+                CardId = "on-demand-credits",
+                GroupId = "grok",
+                Name = "On-Demand",
+                WindowKind = WindowKind.None,
+                RequestsUsed = 25,
+                RequestsAvailable = 100,
+                UsedPercent = 25,
+                IsAvailable = true,
+                Description = "75 / 100 on-demand credits remaining",
+                FetchedAt = fetchedAt,
+            },
+        };
+
+        var processed = this._pipeline.Process(usages, activeProviderIds: ["grok"], isPrivacyMode: false);
+        await db.StoreHistoryAsync(processed.Usages);
+
+        var persisted = await db.GetLatestHistoryAsync(["grok"]);
+        Assert.Equal(2, persisted.Count);
+
+        var weekly = Assert.IsType<WindowedProviderUsage>(
+            Assert.Single(persisted, usage => string.Equals((usage as QuotaProviderUsage)?.CardId, "weekly-credits", StringComparison.Ordinal)));
+        Assert.Equal("grok", weekly.GroupId);
+        Assert.Equal("Weekly", weekly.Name);
+        Assert.Equal(WindowKind.Rolling, weekly.WindowKind);
+
+        var onDemand = Assert.IsType<WindowedProviderUsage>(
+            Assert.Single(persisted, usage => string.Equals((usage as QuotaProviderUsage)?.CardId, "on-demand-credits", StringComparison.Ordinal)));
+        Assert.Equal("grok", onDemand.GroupId);
+        Assert.Equal("On-Demand", onDemand.Name);
+        Assert.Equal(WindowKind.None, onDemand.WindowKind);
+    }
+
+    [Fact]
     public async Task Pipeline_ResetCreditExpirations_ReachTooltipAfterDatabaseRoundTripAsync()
     {
         var db = await this.CreateDatabaseAsync();

--- a/AIUsageTracker.Tests/UI/GroupedUsageDisplayAdapterTests.cs
+++ b/AIUsageTracker.Tests/UI/GroupedUsageDisplayAdapterTests.cs
@@ -841,8 +841,8 @@ public class GroupedUsageDisplayAdapterTests
         Assert.Equal(2, sonnet.UsedPercent, 1);
         Assert.Equal(5, allModels.UsedPercent, 1);
 
-        // PeriodDuration resolved from the provider's Rolling QuotaWindowDefinition (same for all flat cards)
-        Assert.Equal(TimeSpan.FromDays(7), currentSession.PeriodDuration);
+        // Each duration comes from the matching declared quota window.
+        Assert.Equal(TimeSpan.FromHours(5), currentSession.PeriodDuration);
         Assert.Equal(TimeSpan.FromDays(7), sonnet.PeriodDuration);
         Assert.Equal(TimeSpan.FromDays(7), allModels.PeriodDuration);
     }

--- a/AIUsageTracker.UI.Slim/Assets/ProviderLogos/grok.svg
+++ b/AIUsageTracker.UI.Slim/Assets/ProviderLogos/grok.svg
@@ -1,0 +1,4 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="64" height="64" rx="12" fill="#1A1A1A"/>
+<path d="M19 17H28L32 24.5L36 17H45L36.5 31L45 47H36L32 38.5L28 47H19L27.5 31L19 17Z" fill="white"/>
+</svg>

--- a/AIUsageTracker.UI.Slim/FlatWindowCardBuilder.cs
+++ b/AIUsageTracker.UI.Slim/FlatWindowCardBuilder.cs
@@ -12,15 +12,19 @@ internal static class FlatWindowCardBuilder
 {
     internal static IReadOnlyList<QuotaProviderUsage> BuildFlatWindowCards(AgentGroupedProviderUsage provider)
     {
-        ProviderMetadataCatalog.TryGet(provider.ProviderId, out var definition);
-        var showPrefix = definition?.FlatCardShowProviderPrefix == true;
+        var definition = ProviderMetadataCatalog.Find(provider.ProviderId)
+            ?? throw new InvalidOperationException($"Provider definition not found for '{provider.ProviderId}'.");
+        var showPrefix = definition.FlatCardShowProviderPrefix;
         var parentDisplayName = showPrefix ? ProviderMetadataCatalog.GetConfiguredDisplayName(provider.ProviderId) : null;
-        var isQuotaBased = definition?.IsQuotaBased ?? provider.IsQuotaBased;
-        var planType = definition?.PlanType ?? provider.PlanType;
 
         var cards = new List<QuotaProviderUsage>(provider.Models.Count);
         foreach (var model in provider.Models)
         {
+            var windowDefinition = ResolveCardWindow(definition, model.ModelId);
+            var periodDuration = windowDefinition == null
+                ? ResolvePeriodDuration(provider.ProviderId)
+                : windowDefinition.PeriodDuration;
+            var displayAsFraction = windowDefinition?.DisplayAsFraction ?? definition.DisplayAsFraction;
             var modelState = AgentGroupedUsageValueResolver.ResolveModelEffectiveState(model, provider.IsQuotaBased);
             var cardName = showPrefix ? $"{parentDisplayName} ({model.ModelName})" : model.ModelName;
             var description = ResolveCardDescription(provider, modelState.Description);
@@ -29,26 +33,39 @@ internal static class FlatWindowCardBuilder
             {
                 ProviderId = provider.ProviderId,
                 CardId = model.ModelId,
+                GroupId = provider.ProviderId,
+                Name = model.ModelName,
                 ModelName = model.ModelName,
                 ProviderName = cardName,
                 AccountName = provider.AccountName,
                 IsAvailable = provider.IsAvailable,
                 State = provider.State,
-                PlanType = planType,
-                IsQuotaBased = isQuotaBased,
-                IsCurrencyUsage = definition?.IsCurrencyUsage ?? false,
-                RequestsUsed = modelState.UsedPercentage,
+                PlanType = definition.PlanType,
+                IsQuotaBased = definition.IsQuotaBased,
+                IsCurrencyUsage = definition.IsCurrencyUsage,
+                DisplayAsFraction = displayAsFraction,
+                RequestsUsed = displayAsFraction ? model.RequestsUsed : modelState.UsedPercentage,
+                RequestsAvailable = model.RequestsAvailable,
                 UsedPercent = modelState.UsedPercentage,
+                WindowKind = windowDefinition?.Kind ?? WindowKind.None,
                 Description = description,
                 FetchedAt = provider.FetchedAt,
                 NextResetTime = modelState.NextResetTime,
-                PeriodDuration = ResolvePeriodDuration(provider.ProviderId),
+                PeriodDuration = periodDuration,
                 ResetCreditsAvailable = model.ResetCreditsAvailable,
                 ResetCreditExpirationsUtc = model.ResetCreditExpirationsUtc,
             });
         }
 
         return cards;
+    }
+
+    private static QuotaWindowDefinition? ResolveCardWindow(ProviderDefinition definition, string cardId)
+    {
+        var childProviderId = $"{definition.ProviderId}.{cardId}";
+        return definition.QuotaWindows.FirstOrDefault(window =>
+            !string.IsNullOrWhiteSpace(window.ChildProviderId) &&
+            string.Equals(window.ChildProviderId, childProviderId, StringComparison.OrdinalIgnoreCase));
     }
 
     internal static TimeSpan? ResolvePeriodDuration(string providerId)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- **Grok CLI provider** — new `grok` provider surfaces the xAI Grok CLI (SuperGrok) weekly credit usage alongside the existing cards. Session auth is discovered from the Grok CLI's own store (`~/.grok/auth.json`, issuer-scoped root key with a wildcard schema), and usage is read from `https://cli-chat-proxy.grok.com/v1/billing?format=credits`: a rolling Weekly card from `creditUsagePercent` with the billing-period reset time and per-product usage in the description, plus an On-Demand card when the account has an on-demand credit cap. The provider re-reads the auth file before each refresh because the CLI rotates its OIDC access token every few hours; a missing session renders as "Grok CLI session missing - run grok login".
+- **Grok CLI provider** — surfaces xAI SuperGrok weekly credit usage and on-demand credits. Session auth is auto-discovered from `~/.grok/auth.json` using a wildcard issuer-scoped schema; token is re-read on every refresh because the CLI rotates it every few hours. Missing session renders as "Grok CLI session missing - run grok login".
 - **Wildcard root properties in `ProviderAuthFileSchema`** — a schema `RootProperty` ending in `*` (e.g. `https://auth.x.ai::*`) now matches any root property by prefix, enabling issuer-scoped auth stores whose property names embed a dynamic segment (the OIDC client id). Such property names contain dots and are matched whole instead of being dot-navigated.
 
 ## [2.4.6-beta.2] - 2026-07-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Grok CLI provider** — new `grok` provider surfaces the xAI Grok CLI (SuperGrok) weekly credit usage alongside the existing cards. Session auth is discovered from the Grok CLI's own store (`~/.grok/auth.json`, issuer-scoped root key with a wildcard schema), and usage is read from `https://cli-chat-proxy.grok.com/v1/billing?format=credits`: a rolling Weekly card from `creditUsagePercent` with the billing-period reset time and per-product usage in the description, plus an On-Demand card when the account has an on-demand credit cap. The provider re-reads the auth file before each refresh because the CLI rotates its OIDC access token every few hours; a missing session renders as "Grok CLI session missing - run grok login".
+- **Wildcard root properties in `ProviderAuthFileSchema`** — a schema `RootProperty` ending in `*` (e.g. `https://auth.x.ai::*`) now matches any root property by prefix, enabling issuer-scoped auth stores whose property names embed a dynamic segment (the OIDC client id). Such property names contain dots and are matched whole instead of being dot-navigated.
+
 ## [2.4.6-beta.2] - 2026-07-27
 
 ### Added


### PR DESCRIPTION
## Summary

- add Grok CLI as a quota provider using wildcard local auth roots
- model Weekly and On-Demand as definition-driven flat window cards
- preserve Grok card identity and raw quota values through grouped transport and SQLite history
- harden missing-session, token refresh, reset timestamp, and auth-root behavior

## Validation

- `bash scripts/pre-commit-check.sh`
- Release solution build succeeded
- Core tests: 1,438 passed, 2 skipped
- Monitor tests: 143 passed